### PR TITLE
[#7] feat : 그룹 생성 API response를 초대코드로 수정

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupController.java
@@ -2,7 +2,6 @@ package com.gamzabat.algohub.feature.studygroup.controller;
 
 import java.util.List;
 
-import com.gamzabat.algohub.feature.studygroup.domain.StudyGroup;
 import com.gamzabat.algohub.feature.studygroup.dto.*;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -37,12 +36,12 @@ public class StudyGroupController {
 
 	@PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Operation(summary = "그룹 생성 API")
-	public ResponseEntity<Object> createGroup(@AuthedUser User user,
+	public ResponseEntity<CreateGroupResponse> createGroup(@AuthedUser User user,
 		@Valid @RequestPart CreateGroupRequest request, Errors errors, @RequestPart(required = false) MultipartFile profileImage){
 		if (errors.hasErrors())
 			throw new RequestException("그룹 생성 요청이 올바르지 않습니다.",errors);
-		studyGroupService.createGroup(user, request, profileImage);
-		return ResponseEntity.ok().body("OK");
+		CreateGroupResponse inviteCode = studyGroupService.createGroup(user, request, profileImage);
+		return ResponseEntity.ok().body(inviteCode);
 	}
 
 	@PostMapping(value = "/{code}/join")

--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/dto/CreateGroupResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/dto/CreateGroupResponse.java
@@ -1,0 +1,4 @@
+package com.gamzabat.algohub.feature.studygroup.dto;
+
+public record CreateGroupResponse(String inviteCode) {
+}

--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/service/StudyGroupService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/service/StudyGroupService.java
@@ -34,8 +34,6 @@ import com.gamzabat.algohub.feature.studygroup.repository.StudyGroupRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import javax.swing.*;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -48,8 +46,9 @@ public class StudyGroupService {
 	private final UserRepository userRepository;
 
 	@Transactional
-	public void createGroup(User user, CreateGroupRequest request, MultipartFile profileImage) {
+	public CreateGroupResponse createGroup(User user, CreateGroupRequest request, MultipartFile profileImage) {
 		String imageUrl = imageService.saveImage(profileImage);
+		String inviteCode = NanoIdUtils.randomNanoId();
 		groupRepository.save(StudyGroup.builder()
 				.name(request.name())
 				.startDate(request.startDate())
@@ -57,9 +56,10 @@ public class StudyGroupService {
 				.introduction(request.introduction())
 				.groupImage(imageUrl)
 				.owner(user)
-				.groupCode(NanoIdUtils.randomNanoId())
+				.groupCode(inviteCode)
 				.build());
 		log.info("success to save study group");
+		return new CreateGroupResponse(inviteCode);
 	}
 
 	@Transactional


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
https://github.com/GAMZA-BAT/ALGOHUB-SERVER/issues/7

## 🚀 Description
<!-- 작업 내용 -->
- 그룹 생성 시 만들어지는 그룹 별 고유 코드를 response body에 담았습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
- 지금처럼 body에 단일 element를 담아도 DTO를 만드는게 나을지, 아님 Map<String, String>으로 담는게 나을지 좋은 의견 있으심 공유 부탁드림다

## 📚Etc 
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->