### PR TITLE
feat/댓글 수정API 추가

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/comment/controller/CommentController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/comment/controller/CommentController.java
@@ -8,13 +8,7 @@ import com.gamzabat.algohub.feature.comment.dto.ModifyCommentRequest;
 import com.gamzabat.algohub.feature.comment.service.CommentService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.Errors;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.gamzabat.algohub.common.annotation.AuthedUser;
 import com.gamzabat.algohub.feature.user.domain.User;
@@ -55,12 +49,13 @@ public class CommentController {
 		commentService.deleteComment(user,commentId);
 		return ResponseEntity.ok().body("OK");
 	}
-	@PostMapping("/modify")
+	@PutMapping
 	@Operation(summary = "댓글 수정 API")
-	public ResponseEntity<Object> modifyComment(@Valid @RequestBody ModifyCommentRequest request, Errors errors){
+	public ResponseEntity<String> modifyComment(@AuthedUser User user,
+												@Valid @RequestBody ModifyCommentRequest request, Errors errors){
 		if(errors.hasErrors())
 			throw new RequestException("수정 요청이 올바르지 않습니다",errors);
-		commentService.modifyComment(request);
+		commentService.updateComment(user,request);
 		return ResponseEntity.ok().body("OK");
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/comment/controller/CommentController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/comment/controller/CommentController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.gamzabat.algohub.feature.comment.dto.CreateCommentRequest;
 import com.gamzabat.algohub.feature.comment.dto.GetCommentResponse;
+import com.gamzabat.algohub.feature.comment.dto.ModifyCommentRequest;
 import com.gamzabat.algohub.feature.comment.service.CommentService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.Errors;
@@ -52,6 +53,14 @@ public class CommentController {
 	@Operation(summary = "댓글 삭제 API")
 	public ResponseEntity<Object> deleteComment(@AuthedUser User user, @RequestParam Long commentId){
 		commentService.deleteComment(user,commentId);
+		return ResponseEntity.ok().body("OK");
+	}
+	@PostMapping("/modify")
+	@Operation(summary = "댓글 수정 API")
+	public ResponseEntity<Object> modifyComment(@Valid @RequestBody ModifyCommentRequest request, Errors errors){
+		if(errors.hasErrors())
+			throw new RequestException("수정 요청이 올바르지 않습니다",errors);
+		commentService.modifyComment(request);
 		return ResponseEntity.ok().body("OK");
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/comment/domain/Comment.java
+++ b/src/main/java/com/gamzabat/algohub/feature/comment/domain/Comment.java
@@ -39,4 +39,11 @@ public class Comment {
 		this.content = content;
 		this.createdAt = createdAt;
 	}
+
+	public void setContent(String content) {
+		this.content = content;
+	}
+	public void setCreatedAt(LocalDateTime createdAt) {
+		this.createdAt = createdAt;
+	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/comment/domain/Comment.java
+++ b/src/main/java/com/gamzabat/algohub/feature/comment/domain/Comment.java
@@ -14,10 +14,12 @@ import jakarta.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Getter
 @NoArgsConstructor
+@DynamicUpdate
 public class Comment {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,10 +42,9 @@ public class Comment {
 		this.createdAt = createdAt;
 	}
 
-	public void setContent(String content) {
+	public void upadateComment(String content,LocalDateTime createdAt) {
 		this.content = content;
+		this.createdAt = LocalDateTime.now();
 	}
-	public void setCreatedAt(LocalDateTime createdAt) {
-		this.createdAt = createdAt;
-	}
+
 }

--- a/src/main/java/com/gamzabat/algohub/feature/comment/domain/Comment.java
+++ b/src/main/java/com/gamzabat/algohub/feature/comment/domain/Comment.java
@@ -42,7 +42,7 @@ public class Comment {
 		this.createdAt = createdAt;
 	}
 
-	public void upadateComment(String content,LocalDateTime createdAt) {
+	public void upadateComment(String content) {
 		this.content = content;
 		this.createdAt = LocalDateTime.now();
 	}

--- a/src/main/java/com/gamzabat/algohub/feature/comment/dto/ModifyCommentRequest.java
+++ b/src/main/java/com/gamzabat/algohub/feature/comment/dto/ModifyCommentRequest.java
@@ -1,0 +1,10 @@
+package com.gamzabat.algohub.feature.comment.dto;
+
+import com.gamzabat.algohub.feature.user.domain.User;
+
+import java.time.LocalDateTime;
+
+public record ModifyCommentRequest(Long commentId,
+                                   String content
+                                   )  {
+}

--- a/src/main/java/com/gamzabat/algohub/feature/comment/repository/CommentRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/comment/repository/CommentRepository.java
@@ -2,6 +2,7 @@ package com.gamzabat.algohub.feature.comment.repository;
 
 import java.util.List;
 
+import com.gamzabat.algohub.feature.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.gamzabat.algohub.feature.comment.domain.Comment;
@@ -13,4 +14,5 @@ public interface CommentRepository extends JpaRepository<Comment,Long> {
 	List<Comment> findAllBySolution(Solution solution);
 	@Query("SELECT COUNT(c) FROM Comment c WHERE c.solution.id = :solutionId")
 	long countCommentsBySolutionId(@Param("solutionId") Long solutionId);
+	boolean existsByUser(User user);
 }

--- a/src/main/java/com/gamzabat/algohub/feature/comment/repository/CommentRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/comment/repository/CommentRepository.java
@@ -2,7 +2,6 @@ package com.gamzabat.algohub.feature.comment.repository;
 
 import java.util.List;
 
-import com.gamzabat.algohub.feature.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.gamzabat.algohub.feature.comment.domain.Comment;
@@ -14,5 +13,4 @@ public interface CommentRepository extends JpaRepository<Comment,Long> {
 	List<Comment> findAllBySolution(Solution solution);
 	@Query("SELECT COUNT(c) FROM Comment c WHERE c.solution.id = :solutionId")
 	long countCommentsBySolutionId(@Param("solutionId") Long solutionId);
-	boolean existsByUser(User user);
 }

--- a/src/main/java/com/gamzabat/algohub/feature/comment/service/CommentService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/comment/service/CommentService.java
@@ -115,7 +115,7 @@ public class CommentService {
 		if(!comment.getUser().getId().equals(user.getId()))
 			throw new UserValidationException("댓글 작성자가 아닙니다.");
 
-		comment.upadateComment(request.content(),LocalDateTime.now());
+		comment.upadateComment(request.content());
 	}
 
 }

--- a/src/main/java/com/gamzabat/algohub/feature/comment/service/CommentService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/comment/service/CommentService.java
@@ -1,10 +1,13 @@
 package com.gamzabat.algohub.feature.comment.service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.gamzabat.algohub.exception.UserValidationException;
 import com.gamzabat.algohub.feature.comment.domain.Comment;
 import com.gamzabat.algohub.feature.comment.dto.GetCommentResponse;
+import com.gamzabat.algohub.feature.comment.dto.ModifyCommentRequest;
 import com.gamzabat.algohub.feature.comment.exception.CommentValidationException;
 import com.gamzabat.algohub.feature.comment.exception.SolutionValidationException;
 import org.springframework.http.HttpStatus;
@@ -105,4 +108,15 @@ public class CommentService {
 
 		return solution;
 	}
+	@Transactional
+	public void modifyComment(ModifyCommentRequest request) {
+		Comment comment = commentRepository.findById(request.commentId())
+				.orElseThrow(() -> new CommentValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 댓글 입니다."));
+
+		comment.setContent(request.content());
+		comment.setCreatedAt(LocalDateTime.now());
+		commentRepository.save(comment);
+
+	}
+
 }

--- a/src/main/java/com/gamzabat/algohub/feature/comment/service/CommentService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/comment/service/CommentService.java
@@ -1,6 +1,6 @@
 package com.gamzabat.algohub.feature.comment.service;
 
-import java.time.LocalDate;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -109,14 +109,13 @@ public class CommentService {
 		return solution;
 	}
 	@Transactional
-	public void modifyComment(ModifyCommentRequest request) {
+	public void updateComment(User user, ModifyCommentRequest request) {
 		Comment comment = commentRepository.findById(request.commentId())
 				.orElseThrow(() -> new CommentValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 댓글 입니다."));
+		if(!comment.getUser().getId().equals(user.getId()))
+			throw new UserValidationException("댓글 작성자가 아닙니다.");
 
-		comment.setContent(request.content());
-		comment.setCreatedAt(LocalDateTime.now());
-		commentRepository.save(comment);
-
+		comment.upadateComment(request.content(),LocalDateTime.now());
 	}
 
 }

--- a/src/main/java/com/gamzabat/algohub/feature/problem/repository/ProblemRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/problem/repository/ProblemRepository.java
@@ -13,7 +13,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface ProblemRepository extends JpaRepository<Problem, Long> {
 	Page<Problem> findAllByStudyGroup(StudyGroup studyGroup, Pageable pageable);
-	Problem getById(Long id);
 	List<Problem> findAllByNumber(Integer Number);
 	List<Problem> findAllByStudyGroupAndEndDate(StudyGroup studyGroup, LocalDate endDate);
 	@Query("SELECT COUNT(p) FROM Problem p WHERE p.studyGroup.id = :groupId")


### PR DESCRIPTION
## 📌 Related Issue
#24  
## 🚀 Description
댓글 수정 가능 API를 추가했습니다

## 📢 Review Point
원래 댓글 작성한 user 만 수정할 수 있게 검증한번 해보려고 해서 
ModifyCommentReuqest에 User를 받아오려고 했는데 
1. User 정보를 전부 다 가져오는거더라구요..? <- 이게 원래 맞는건가...싶은...
2. 프론트 단에서 User의 Comment 만 수정할 수 있게 거를 수 있는지..? 궁금하구요..
3. Comment 에서 따로 userId를 들고 있는데 이거로 검증을 할 수 있는지....?

## 📚Etc (선택)
1. 궁금한 점 하나 더..! Comment 도메인에 setter를 추가해버렸는데 괜찮은 문제인지