### PR TITLE
feat : 스터디 그룹 즐겨찾기 추가/취소 API 추가

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupController.java
@@ -140,4 +140,11 @@ public class StudyGroupController {
 		GetGroupResponse response = studyGroupService.getGroup(user, groupId);
 		return ResponseEntity.ok().body(response);
 	}
+
+	@PostMapping(value = "/bookmark")
+	@Operation(summary = "스터디 그룹 즐겨찾기 추가/취소 API", description = "스터디 그룹을 즐겨찾기 추가,취소할 때 사용하는 API")
+	public ResponseEntity<String> updateBookmarkGroup(@AuthedUser User user, @RequestParam Long groupId) {
+		String response = studyGroupService.updateBookmarkGroup(user, groupId);
+		return ResponseEntity.ok().body(response);
+	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/domain/BookmarkedStudyGroup.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/domain/BookmarkedStudyGroup.java
@@ -1,0 +1,37 @@
+package com.gamzabat.algohub.feature.studygroup.domain;
+
+import com.gamzabat.algohub.feature.user.domain.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class BookmarkedStudyGroup {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "study_group_id")
+	private StudyGroup studyGroup;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@Builder
+	public BookmarkedStudyGroup(StudyGroup studyGroup, User user) {
+		this.studyGroup = studyGroup;
+		this.user = user;
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/repository/BookmarkedStudyGroupRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/repository/BookmarkedStudyGroupRepository.java
@@ -1,0 +1,13 @@
+package com.gamzabat.algohub.feature.studygroup.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.gamzabat.algohub.feature.studygroup.domain.BookmarkedStudyGroup;
+import com.gamzabat.algohub.feature.studygroup.domain.StudyGroup;
+import com.gamzabat.algohub.feature.user.domain.User;
+
+public interface BookmarkedStudyGroupRepository extends JpaRepository<BookmarkedStudyGroup, Long> {
+	Optional<BookmarkedStudyGroup> findByUserAndStudyGroup(User user, StudyGroup studyGroup);
+}

--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/service/StudyGroupService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/service/StudyGroupService.java
@@ -5,6 +5,7 @@ import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -20,6 +21,7 @@ import com.gamzabat.algohub.feature.image.service.ImageService;
 import com.gamzabat.algohub.feature.problem.domain.Problem;
 import com.gamzabat.algohub.feature.problem.repository.ProblemRepository;
 import com.gamzabat.algohub.feature.solution.repository.SolutionRepository;
+import com.gamzabat.algohub.feature.studygroup.domain.BookmarkedStudyGroup;
 import com.gamzabat.algohub.feature.studygroup.domain.GroupMember;
 import com.gamzabat.algohub.feature.studygroup.domain.StudyGroup;
 import com.gamzabat.algohub.feature.studygroup.dto.CheckSolvedProblemResponse;
@@ -36,6 +38,7 @@ import com.gamzabat.algohub.feature.studygroup.exception.CannotFoundGroupExcepti
 import com.gamzabat.algohub.feature.studygroup.exception.CannotFoundProblemException;
 import com.gamzabat.algohub.feature.studygroup.exception.CannotFoundUserException;
 import com.gamzabat.algohub.feature.studygroup.exception.GroupMemberValidationException;
+import com.gamzabat.algohub.feature.studygroup.repository.BookmarkedStudyGroupRepository;
 import com.gamzabat.algohub.feature.studygroup.repository.GroupMemberRepository;
 import com.gamzabat.algohub.feature.studygroup.repository.StudyGroupRepository;
 import com.gamzabat.algohub.feature.user.domain.User;
@@ -54,6 +57,8 @@ public class StudyGroupService {
 	private final SolutionRepository solutionRepository;
 	private final ProblemRepository problemRepository;
 	private final UserRepository userRepository;
+	private final StudyGroupRepository studyGroupRepository;
+	private final BookmarkedStudyGroupRepository bookmarkedStudyGroupRepository;
 
 	@Transactional
 	public CreateGroupResponse createGroup(User user, CreateGroupRequest request, MultipartFile profileImage) {
@@ -356,5 +361,27 @@ public class StudyGroupService {
 		BigDecimal percentage = num.multiply(BigDecimal.valueOf(100)).divide(den, 0, RoundingMode.HALF_UP);
 
 		return percentage.toString();
+	}
+
+	@Transactional
+	public String updateBookmarkGroup(User user, Long groupId) {
+		StudyGroup studyGroup = studyGroupRepository.findById(groupId)
+			.orElseThrow(() -> new CannotFoundGroupException("존재하지 않는 그룹 입니다."));
+
+		if (!studyGroup.getOwner().getId().equals(user.getId()) && !groupMemberRepository.existsByUserAndStudyGroup(
+			user, studyGroup))
+			throw new StudyGroupValidationException(HttpStatus.BAD_REQUEST.value(), "참여하지 않은 그룹 입니다.");
+
+		Optional<BookmarkedStudyGroup> bookmarked = bookmarkedStudyGroupRepository.findByUserAndStudyGroup(user,
+			studyGroup);
+
+		if (bookmarked.isEmpty()) {
+			bookmarkedStudyGroupRepository.save(
+				BookmarkedStudyGroup.builder().studyGroup(studyGroup).user(user).build());
+			return "스터디 그룹 즐겨찾기 추가 성공";
+		} else {
+			bookmarkedStudyGroupRepository.delete(bookmarked.get());
+			return "스터디 그룹 즐겨찾기 삭제 성공";
+		}
 	}
 }

--- a/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
@@ -36,6 +36,7 @@ import com.gamzabat.algohub.exception.StudyGroupValidationException;
 import com.gamzabat.algohub.exception.UserValidationException;
 import com.gamzabat.algohub.feature.image.service.ImageService;
 import com.gamzabat.algohub.feature.problem.repository.ProblemRepository;
+import com.gamzabat.algohub.feature.solution.exception.CannotFoundSolutionException;
 import com.gamzabat.algohub.feature.solution.repository.SolutionRepository;
 import com.gamzabat.algohub.feature.studygroup.dto.CheckSolvedProblemResponse;
 import com.gamzabat.algohub.feature.studygroup.dto.CreateGroupRequest;
@@ -555,5 +556,63 @@ class StudyGroupControllerTest {
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.error").value("코드를 조회할 권한이 없습니다."));
 		verify(studyGroupService, times(1)).getGroupCode(any(User.class), anyLong());
+	}
+
+	@Test
+	@DisplayName("스터디 그룹 즐겨찾기 추가 성공")
+	void updateBookmarked_1() throws Exception {
+		// given
+		when(studyGroupService.updateBookmarkGroup(user, groupId)).thenReturn("스터디 그룹 즐겨찾기 추가 성공");
+		// when, then
+		mockMvc.perform(post("/api/group/bookmark")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isOk())
+			.andExpect(content().string("스터디 그룹 즐겨찾기 추가 성공"));
+		verify(studyGroupService, times(1)).updateBookmarkGroup(user, groupId);
+	}
+
+	@Test
+	@DisplayName("스터디 그룹 즐겨찾기 삭제 성공")
+	void updateBookmarked_2() throws Exception {
+		// given
+		when(studyGroupService.updateBookmarkGroup(user, groupId)).thenReturn("스터디 그룹 즐겨찾기 실패 성공");
+		// when, then
+		mockMvc.perform(post("/api/group/bookmark")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isOk())
+			.andExpect(content().string("스터디 그룹 즐겨찾기 실패 성공"));
+		verify(studyGroupService, times(1)).updateBookmarkGroup(user, groupId);
+	}
+
+	@Test
+	@DisplayName("스터디 그룹 즐겨찾기 추가/삭제 실패 : 존재하지 않는 그룹")
+	void updateBookmarkedFailed_1() throws Exception {
+		// given
+		when(studyGroupService.updateBookmarkGroup(user, groupId)).thenThrow(
+			new CannotFoundSolutionException("존재하지 않는 그룹 입니다."));
+		// when, then
+		mockMvc.perform(post("/api/group/bookmark")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("존재하지 않는 그룹 입니다."));
+		verify(studyGroupService, times(1)).updateBookmarkGroup(user, groupId);
+	}
+
+	@Test
+	@DisplayName("스터디 그룹 즐겨찾기 추가/삭제 실패 : 참여하지 않은 그룹")
+	void updateBookmarkedFailed_2() throws Exception {
+		// given
+		when(studyGroupService.updateBookmarkGroup(user, groupId)).thenThrow(
+			new StudyGroupValidationException(HttpStatus.BAD_REQUEST.value(), "참여하지 않은 그룹 입니다."));
+		// when, then
+		mockMvc.perform(post("/api/group/bookmark")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("참여하지 않은 그룹 입니다."));
+		verify(studyGroupService, times(1)).updateBookmarkGroup(user, groupId);
 	}
 }


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
https://github.com/GAMZA-BAT/ALGOHUB-SERVER/issues/46

## 🚀 Description
<!-- 작업 내용 -->
- 스터디 그룹을 즐겨찾기 추가/취소하는 API를 만들었습니다
- 즐겨찾기 On/Off는 두 개의 API로 분리하기엔 단순한 기능이라 생각해, 하나의 API 내에서 처리하고자 했습니다
- 즐겨찾기 추가/취소는 해당 API로 모두 요청한다고 생각하심 됩니담

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->
- API를 하나로 통일했다보니, 즐겨찾기를 추가/취소했을 때 response에서 구분하는 방법으로 body에 String을 넣기로 구현했습니다만 그리 중요한 역할은 아닐겁니다 (아마)
- 단순히 API 테스트 할 때 편리하게 결과를 눈으로 확인할 수 있도록 넣었다고 생각해주심 될 것 같아요!