### PR TITLE
fix : 스터디 그룹 목록 조회 시, InProgress 필터링 오류 수정 

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/service/StudyGroupService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/service/StudyGroupService.java
@@ -148,10 +148,8 @@ public class StudyGroupService {
 
 		List<GetStudyGroupResponse> inProgress = groups.stream()
 			.filter(
-				group -> group.getStartDate() != null && (group.getStartDate().isBefore(today) || group.getStartDate()
-					.isEqual(today))
-					&& (group.getEndDate() != null && (group.getEndDate().isAfter(today) || group.getEndDate()
-					.isEqual(today))))
+				group -> !(group.getStartDate() == null || group.getStartDate().isAfter(today))
+					&& !(group.getEndDate() == null || group.getEndDate().isBefore(today)))
 			.map(group -> GetStudyGroupResponse.toDTO(group, user))
 			.collect(Collectors.toList());
 

--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/service/StudyGroupService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/service/StudyGroupService.java
@@ -147,8 +147,11 @@ public class StudyGroupService {
 			.collect(Collectors.toList());
 
 		List<GetStudyGroupResponse> inProgress = groups.stream()
-			.filter(group -> group.getStartDate() != null && group.getStartDate().isBefore(today) &&
-				(group.getEndDate() == null || group.getEndDate().isAfter(today)))
+			.filter(
+				group -> group.getStartDate() != null && (group.getStartDate().isBefore(today) || group.getStartDate()
+					.isEqual(today))
+					&& (group.getEndDate() != null && (group.getEndDate().isAfter(today) || group.getEndDate()
+					.isEqual(today))))
 			.map(group -> GetStudyGroupResponse.toDTO(group, user))
 			.collect(Collectors.toList());
 

--- a/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
@@ -222,8 +222,8 @@ class StudyGroupServiceTest {
 			groups.add(StudyGroup.builder()
 				.name("name" + i)
 				.owner(user)
-				.startDate(LocalDate.now().minusDays(i + 1))
-				.endDate(LocalDate.now().plusDays(i + 1))
+				.startDate(LocalDate.now().minusDays(i))
+				.endDate(LocalDate.now().plusDays(i))
 				.build());
 		}
 		for (int i = 0; i < 10; i++) {
@@ -263,8 +263,8 @@ class StudyGroupServiceTest {
 		for (int i = 0; i < 10; i++) {
 			assertThat(inProgress.get(i).name()).isEqualTo("name" + i);
 			assertThat(inProgress.get(i).ownerNickname()).isEqualTo("nickname");
-			assertThat(inProgress.get(i).startDate()).isEqualTo(LocalDate.now().minusDays(i + 1));
-			assertThat(inProgress.get(i).endDate()).isEqualTo(LocalDate.now().plusDays(i + 1));
+			assertThat(inProgress.get(i).startDate()).isEqualTo(LocalDate.now().minusDays(i));
+			assertThat(inProgress.get(i).endDate()).isEqualTo(LocalDate.now().plusDays(i));
 		}
 		for (int i = 0; i < 10; i++) {
 			assertThat(queued.get(i).name()).isEqualTo("name" + i);
@@ -275,8 +275,8 @@ class StudyGroupServiceTest {
 		for (int i = 0; i < 10; i++) {
 			assertThat(bookmarked.get(i).name()).isEqualTo("name" + i);
 			assertThat(bookmarked.get(i).ownerNickname()).isEqualTo("nickname");
-			assertThat(bookmarked.get(i).startDate()).isEqualTo(LocalDate.now().minusDays(i + 1));
-			assertThat(bookmarked.get(i).endDate()).isEqualTo(LocalDate.now().plusDays(i + 1));
+			assertThat(bookmarked.get(i).startDate()).isEqualTo(LocalDate.now().minusDays(i));
+			assertThat(bookmarked.get(i).endDate()).isEqualTo(LocalDate.now().plusDays(i));
 		}
 	}
 


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
https://github.com/GAMZA-BAT/ALGOHUB-SERVER/issues/60

## 🚀 Description
<!-- 작업 내용 -->
- 그룹 목록 조회 API에서 InProgress 로직에 오늘 날짜도 포함되도록 수정했습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->
- 질문입니다! 테스트 코드 작성할 때 이 사례처럼 InProgress에 startDate,endDate가 당일인 스터디 그룹을 추가 안했어서 API를 직접 실행해보며 버그를 찾았는데요
- 그럼 테스트 코드도 당일을 startDate, endDate로 갖는 스터디 그룹을 추가해서 작성을 해야 할까요? 아님 굳이인가요? 의견 필요합니다 
- 저는 그래도 작성하는게 좋을거라 생각하는데(사실 아직 안씀) 어떻게들 생각하시는지 궁금하네요
- 의견들 보고 필요하겠다 싶으면 테스트 코드 수정해서 다시 커밋하겠습니다