### PR TITLE
feat : 백준 닉네임 유효성 검증 API 추가

### DIFF
--- a/src/main/java/com/gamzabat/algohub/config/RestTemplateConfig.java
+++ b/src/main/java/com/gamzabat/algohub/config/RestTemplateConfig.java
@@ -1,0 +1,19 @@
+package com.gamzabat.algohub.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+	@Bean
+	public RestTemplate restTemplate() {
+		RestTemplate restTemplate = new RestTemplate();
+		SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+		requestFactory.setConnectTimeout(5000);
+		requestFactory.setReadTimeout(5000);
+		restTemplate.setRequestFactory(requestFactory);
+		return restTemplate;
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/gamzabat/algohub/exception/CustomExceptionHandler.java
@@ -12,6 +12,8 @@ import com.gamzabat.algohub.feature.solution.exception.CannotFoundSolutionExcept
 import com.gamzabat.algohub.feature.studygroup.exception.CannotFoundGroupException;
 import com.gamzabat.algohub.feature.studygroup.exception.GroupMemberValidationException;
 import com.gamzabat.algohub.feature.studygroup.exception.InvalidRoleException;
+import com.gamzabat.algohub.feature.user.exception.BOJServerErrorException;
+import com.gamzabat.algohub.feature.user.exception.CheckBjNicknameValidationException;
 import com.gamzabat.algohub.feature.user.exception.UncorrectedPasswordException;
 
 @ControllerAdvice
@@ -75,5 +77,16 @@ public class CustomExceptionHandler {
 	@ExceptionHandler(InvalidRoleException.class)
 	protected ResponseEntity<Object> handler(InvalidRoleException e) {
 		return ResponseEntity.badRequest().body(new ErrorResponse(HttpStatus.BAD_REQUEST.value(), e.getError(), null));
+	}
+
+	@ExceptionHandler(CheckBjNicknameValidationException.class)
+	protected ResponseEntity<Object> handler(CheckBjNicknameValidationException e) {
+		return ResponseEntity.status(e.getCode()).body(new ErrorResponse(e.getCode(), e.getError(), null));
+	}
+
+	@ExceptionHandler(BOJServerErrorException.class)
+	protected ResponseEntity<Object> handler(BOJServerErrorException e) {
+		return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+			.body(new ErrorResponse(HttpStatus.SERVICE_UNAVAILABLE.value(), e.getError(), null));
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -33,7 +34,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/user")
-@Tag(name = "회원 컨트롤러", description = "회원 관련된 API 명세서")
+@Tag(name = "회원 API", description = "회원 관련된 API 명세서")
 public class UserController {
 	private final UserService userService;
 
@@ -93,8 +94,11 @@ public class UserController {
 		userService.logout(request);
 		return ResponseEntity.ok().body("OK");
 	}
-}
 
-// 파일이 변경됐어요~!~!
-// pr
-// issue
+	@GetMapping("/check-baekjoon-nickname")
+	@Operation(summary = "백준 닉네임 유효성 검증 API", description = "회원가입 진행 시, 백준 닉네임이 유효한지 검증하는 API")
+	public ResponseEntity<String> checkBjNickname(@RequestParam String bjNickname) {
+		userService.checkBjNickname(bjNickname);
+		return ResponseEntity.ok().body("OK");
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/feature/user/domain/User.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/domain/User.java
@@ -7,7 +7,6 @@ import org.hibernate.annotations.SQLRestriction;
 
 import com.gamzabat.algohub.enums.Role;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -34,7 +33,6 @@ public class User {
 	private String bjNickname;
 	private String profileImage;
 
-	@Column(name = "deleted_at")
 	private LocalDateTime deletedAt;
 
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/com/gamzabat/algohub/feature/user/exception/BOJServerErrorException.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/exception/BOJServerErrorException.java
@@ -1,0 +1,12 @@
+package com.gamzabat.algohub.feature.user.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BOJServerErrorException extends RuntimeException {
+	private final String error;
+
+	public BOJServerErrorException(String error) {
+		this.error = error;
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/feature/user/exception/CheckBjNicknameValidationException.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/exception/CheckBjNicknameValidationException.java
@@ -1,0 +1,14 @@
+package com.gamzabat.algohub.feature.user.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CheckBjNicknameValidationException extends RuntimeException {
+	private final int code;
+	private final String error;
+
+	public CheckBjNicknameValidationException(int code, String error) {
+		this.code = code;
+		this.error = error;
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/feature/user/repository/UserRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/repository/UserRepository.java
@@ -17,4 +17,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 	Optional<User> findById(Long Id);
 
+	boolean existsByBjNickname(String bjNickname);
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -151,7 +151,7 @@ public class UserService {
 			if (e.getStatusCode() == HttpStatus.NOT_FOUND)
 				throw new CheckBjNicknameValidationException(HttpStatus.NOT_FOUND.value(), "백준 닉네임이 유효하지 않습니다.");
 		} catch (HttpServerErrorException e) {
-			log.info("BOJ server error occurred : " + e.getMessage());
+			log.error("BOJ server error occurred : " + e.getMessage());
 			throw new BOJServerErrorException("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
 		}
 		log.info("success to check baekjoon nickname validity");

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -144,8 +144,9 @@ public class UserService {
 
 		try {
 			restTemplate.exchange(bjUserUrl, HttpMethod.GET, entity, String.class);
-			if (userRepository.existsByBjNickname(bjNickname))
-				throw new CheckBjNicknameValidationException(HttpStatus.CONFLICT.value(), "이미 가입된 백준 닉네임 입니다.");
+			// TODO : 백준 본인 인증 관련 사항 확정 후 로직 수정
+			// if (userRepository.existsByBjNickname(bjNickname))
+			// 	throw new CheckBjNicknameValidationException(HttpStatus.CONFLICT.value(), "이미 가입된 백준 닉네임 입니다.");
 		} catch (HttpClientErrorException e) {
 			if (e.getStatusCode() == HttpStatus.NOT_FOUND)
 				throw new CheckBjNicknameValidationException(HttpStatus.NOT_FOUND.value(), "백준 닉네임이 유효하지 않습니다.");

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -2,6 +2,9 @@ package com.gamzabat.algohub.feature.user.service;
 
 import java.time.Duration;
 
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -10,6 +13,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.gamzabat.algohub.common.jwt.TokenProvider;
@@ -26,6 +32,8 @@ import com.gamzabat.algohub.feature.user.dto.SignInRequest;
 import com.gamzabat.algohub.feature.user.dto.SignInResponse;
 import com.gamzabat.algohub.feature.user.dto.UpdateUserRequest;
 import com.gamzabat.algohub.feature.user.dto.UserInfoResponse;
+import com.gamzabat.algohub.feature.user.exception.BOJServerErrorException;
+import com.gamzabat.algohub.feature.user.exception.CheckBjNicknameValidationException;
 import com.gamzabat.algohub.feature.user.exception.UncorrectedPasswordException;
 import com.gamzabat.algohub.feature.user.repository.UserRepository;
 
@@ -43,6 +51,7 @@ public class UserService {
 	private final TokenProvider tokenProvider;
 	private final AuthenticationManagerBuilder authManager;
 	private final RedisService redisService;
+	private final RestTemplate restTemplate;
 
 	@Transactional
 	public void register(RegisterRequest request, MultipartFile profileImage) {
@@ -122,5 +131,28 @@ public class UserService {
 		long tokenExpiration = tokenProvider.getTokenExpiration();
 		redisService.setValues(accessToken, "logout", Duration.ofMillis(tokenExpiration));
 		log.info("success to logout");
+	}
+
+	@Transactional(readOnly = true)
+	public void checkBjNickname(String bjNickname) {
+		String bjUserUrl = "https://www.acmicpc.net/user/" + bjNickname;
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.set("User-Agent",
+			"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36");
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+
+		try {
+			restTemplate.exchange(bjUserUrl, HttpMethod.GET, entity, String.class);
+			if (userRepository.existsByBjNickname(bjNickname))
+				throw new CheckBjNicknameValidationException(HttpStatus.CONFLICT.value(), "이미 가입된 백준 닉네임 입니다.");
+		} catch (HttpClientErrorException e) {
+			if (e.getStatusCode() == HttpStatus.NOT_FOUND)
+				throw new CheckBjNicknameValidationException(HttpStatus.NOT_FOUND.value(), "백준 닉네임이 유효하지 않습니다.");
+		} catch (HttpServerErrorException e) {
+			log.info("BOJ server error occurred : " + e.getMessage());
+			throw new BOJServerErrorException("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+		}
+		log.info("success to check baekjoon nickname validity");
 	}
 }

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -37,11 +37,11 @@ class UserServiceTest {
 		String bjNickname = "bjNickname";
 		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
 			.thenReturn(new ResponseEntity<>(HttpStatus.OK));
-		when(userRepository.existsByBjNickname(bjNickname)).thenReturn(false);
+		// when(userRepository.existsByBjNickname(bjNickname)).thenReturn(false);
 		// when
 		userService.checkBjNickname(bjNickname);
 		// then
-		verify(userRepository, times(1)).existsByBjNickname(bjNickname);
+		// verify(userRepository, times(1)).existsByBjNickname(bjNickname);
 	}
 
 	@Test
@@ -58,20 +58,20 @@ class UserServiceTest {
 			.hasFieldOrPropertyWithValue("error", "백준 닉네임이 유효하지 않습니다.");
 	}
 
-	@Test
-	@DisplayName("백준 닉네임 유효성 검증 : 이미 가입된 백준 닉네임")
-	void checkBjNickname_3() {
-		// given
-		String bjNickname = "bjNickname";
-		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
-			.thenReturn(new ResponseEntity<>(HttpStatus.OK));
-		when(userRepository.existsByBjNickname(bjNickname)).thenReturn(true);
-		// when, then
-		assertThatThrownBy(() -> userService.checkBjNickname(bjNickname))
-			.isInstanceOf(CheckBjNicknameValidationException.class)
-			.hasFieldOrPropertyWithValue("code", HttpStatus.CONFLICT.value())
-			.hasFieldOrPropertyWithValue("error", "이미 가입된 백준 닉네임 입니다.");
-	}
+	// @Test
+	// @DisplayName("백준 닉네임 유효성 검증 : 이미 가입된 백준 닉네임")
+	// void checkBjNickname_3() {
+	// 	// given
+	// 	String bjNickname = "bjNickname";
+	// 	when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+	// 		.thenReturn(new ResponseEntity<>(HttpStatus.OK));
+	// 	when(userRepository.existsByBjNickname(bjNickname)).thenReturn(true);
+	// 	// when, then
+	// 	assertThatThrownBy(() -> userService.checkBjNickname(bjNickname))
+	// 		.isInstanceOf(CheckBjNicknameValidationException.class)
+	// 		.hasFieldOrPropertyWithValue("code", HttpStatus.CONFLICT.value())
+	// 		.hasFieldOrPropertyWithValue("error", "이미 가입된 백준 닉네임 입니다.");
+	// }
 
 	@Test
 	@DisplayName("백준 닉네임 유효성 검증 실패 : 백준 서버 오류 발생")

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -1,0 +1,88 @@
+package com.gamzabat.algohub.feature.user.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import com.gamzabat.algohub.feature.user.exception.BOJServerErrorException;
+import com.gamzabat.algohub.feature.user.exception.CheckBjNicknameValidationException;
+import com.gamzabat.algohub.feature.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+	@InjectMocks
+	private UserService userService;
+	@Mock
+	private UserRepository userRepository;
+	@Mock
+	private RestTemplate restTemplate;
+
+	@Test
+	@DisplayName("백준 닉네임 유효성 검증 : 사용 가능한 백준 닉네임")
+	void checkBjNickname_1() {
+		// given
+		String bjNickname = "bjNickname";
+		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+			.thenReturn(new ResponseEntity<>(HttpStatus.OK));
+		when(userRepository.existsByBjNickname(bjNickname)).thenReturn(false);
+		// when
+		userService.checkBjNickname(bjNickname);
+		// then
+		verify(userRepository, times(1)).existsByBjNickname(bjNickname);
+	}
+
+	@Test
+	@DisplayName("백준 닉네임 유효성 검증 : 유효하지 않은 백준 닉네임")
+	void checkBjNickname_2() {
+		// given
+		String bjNickname = "bjNickname";
+		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+			.thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+		// when, then
+		assertThatThrownBy(() -> userService.checkBjNickname(bjNickname))
+			.isInstanceOf(CheckBjNicknameValidationException.class)
+			.hasFieldOrPropertyWithValue("code", HttpStatus.NOT_FOUND.value())
+			.hasFieldOrPropertyWithValue("error", "백준 닉네임이 유효하지 않습니다.");
+	}
+
+	@Test
+	@DisplayName("백준 닉네임 유효성 검증 : 이미 가입된 백준 닉네임")
+	void checkBjNickname_3() {
+		// given
+		String bjNickname = "bjNickname";
+		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+			.thenReturn(new ResponseEntity<>(HttpStatus.OK));
+		when(userRepository.existsByBjNickname(bjNickname)).thenReturn(true);
+		// when, then
+		assertThatThrownBy(() -> userService.checkBjNickname(bjNickname))
+			.isInstanceOf(CheckBjNicknameValidationException.class)
+			.hasFieldOrPropertyWithValue("code", HttpStatus.CONFLICT.value())
+			.hasFieldOrPropertyWithValue("error", "이미 가입된 백준 닉네임 입니다.");
+	}
+
+	@Test
+	@DisplayName("백준 닉네임 유효성 검증 실패 : 백준 서버 오류 발생")
+	void checkBjNickname_4() {
+		// given
+		String bjNickname = "bjNickname";
+		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+			.thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
+		// when, then
+		assertThatThrownBy(() -> userService.checkBjNickname(bjNickname))
+			.isInstanceOf(BOJServerErrorException.class)
+			.hasFieldOrPropertyWithValue("error", "현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+	}
+}


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
https://github.com/GAMZA-BAT/ALGOHUB-SERVER/issues/71

## 🚀 Description
<!-- 작업 내용 -->
- 백준 닉네임 유효성을 검증하는 API를 추가했습니다.
- 나눈 케이스는 아래와 같습니다.
   1. 사용 가능한 백준 닉네임
   2. ~~이미 가입 된 백준 닉네임~~
   3. 유효하지 않은 백준 닉네임
   4. 백준 서버의 에러 발생
   
## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
- 다 try-catch로 일일이 잡아낸지라 좀 더러워 보이긴 합니다.. 최선인지 모르겠네요 더 좋은 로직 있으면 알려주세요
- RestTemplate으로 발생하는 HttpClientErrorException에서 404(NOT_FOUND) 외에 발생하는 다른 예외는 처리를 해야할지 궁금합니다. 만약 처리를 해야한다면 어떤 메세지로 어떻게 처리를 해야할지도 잘 모르겠어요

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->
- '2. 이미 가입된 백준 닉네임' 의 경우, 백준 본인 인증 절차가 아직 확립되지 않아 PR에서 제외합니다