### PR TITLE
refactor : URL 파일 분리 

### DIFF
--- a/src/main/java/com/gamzabat/algohub/common/ApiConstants.java
+++ b/src/main/java/com/gamzabat/algohub/common/ApiConstants.java
@@ -5,5 +5,6 @@ public final class ApiConstants {
 	public static final String BOJ_USER_PROFILE_URL = "https://www.acmicpc.net/user/";
 
 	private ApiConstants() {
+		throw new RuntimeException("Can not instantiate : ApiConstants");
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/common/ApiConstants.java
+++ b/src/main/java/com/gamzabat/algohub/common/ApiConstants.java
@@ -1,0 +1,9 @@
+package com.gamzabat.algohub.common;
+
+public final class ApiConstants {
+	public static final String SOLVED_AC_PROBLEM_API_URL = "https://solved.ac/api/v3/problem/lookup?problemIds=";
+	public static final String BOJ_USER_PROFILE_URL = "https://www.acmicpc.net/user/";
+
+	private ApiConstants() {
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
@@ -1,5 +1,7 @@
 package com.gamzabat.algohub.feature.problem.service;
 
+import static com.gamzabat.algohub.common.ApiConstants.*;
+
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -240,7 +242,7 @@ public class ProblemService {
 	private String getProblemLevel(String problemId) {
 		final RestTemplate restTemplate = new RestTemplate();
 
-		String url = "https://solved.ac/api/v3/problem/lookup?problemIds=" + problemId;
+		String url = SOLVED_AC_PROBLEM_API_URL + problemId;
 
 		try {
 			ResponseEntity<String> responseEntity = restTemplate.getForEntity(url, String.class);
@@ -264,7 +266,7 @@ public class ProblemService {
 
 	private String getProblemTitle(String problemId) {
 		final RestTemplate restTemplate = new RestTemplate();
-		String url = "https://solved.ac/api/v3/problem/lookup?problemIds=" + problemId;
+		String url = SOLVED_AC_PROBLEM_API_URL + problemId;
 
 		try {
 			ResponseEntity<String> responseEntity = restTemplate.getForEntity(url, String.class);

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -1,5 +1,7 @@
 package com.gamzabat.algohub.feature.user.service;
 
+import static com.gamzabat.algohub.common.ApiConstants.*;
+
 import java.time.Duration;
 
 import org.springframework.http.HttpEntity;
@@ -135,7 +137,7 @@ public class UserService {
 
 	@Transactional(readOnly = true)
 	public void checkBjNickname(String bjNickname) {
-		String bjUserUrl = "https://www.acmicpc.net/user/" + bjNickname;
+		String bjUserUrl = BOJ_USER_PROFILE_URL + bjNickname;
 
 		HttpHeaders headers = new HttpHeaders();
 		headers.set("User-Agent",


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
https://github.com/GAMZA-BAT/ALGOHUB-SERVER/issues/79

## 🚀 Description
<!-- 작업 내용 -->
- 하드 코딩을 방지하고자 외부 API를 호출하는 데 사용하는 URL을 ApiConstants 클래스에 모아 정리했습니다.
- 상수 저장 방법 찾아봤는데 개인적으로는 interface로 구현하는 것 보단 final class에 생성자 private 전환하는 게 더 안전한 방법이란 생각이 들어서 그렇게 구현했습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
- 네이밍 진짜 너무 어렵네요 더 좋을 이름 있으면 알려주세요..

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->
- 다른 분들도 나중에 또 다른 외부 API를 호출할 일이 생긴다면 URL 같은 상수들은 ApiConstants에 모아서 관리해주시면 될 것 같습니다.

- 여러분은 상수 인터페이스 방법 1. interface, 2. final class 어떻게 생각하시는지 의견 들어보고 싶네요!
- 개인적으로는 상수 저장에 enum은 왜 이야기가 없을까 하는 궁금증도 생겼습니다