### PR TITLE
feat : 이메일 중복 검사 API 추가

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
@@ -17,6 +17,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.gamzabat.algohub.common.annotation.AuthedUser;
 import com.gamzabat.algohub.exception.RequestException;
 import com.gamzabat.algohub.feature.user.domain.User;
+import com.gamzabat.algohub.feature.user.dto.CheckEmailRequest;
 import com.gamzabat.algohub.feature.user.dto.DeleteUserRequest;
 import com.gamzabat.algohub.feature.user.dto.RegisterRequest;
 import com.gamzabat.algohub.feature.user.dto.SignInRequest;
@@ -99,6 +100,18 @@ public class UserController {
 	@Operation(summary = "백준 닉네임 유효성 검증 API", description = "회원가입 진행 시, 백준 닉네임이 유효한지 검증하는 API")
 	public ResponseEntity<String> checkBjNickname(@RequestParam String bjNickname) {
 		userService.checkBjNickname(bjNickname);
+		return ResponseEntity.ok().body("OK");
+	}
+
+	@PostMapping("/check-email")
+	@Operation(summary = "이메일 중복 검사 API", description = "회원가입 진행 시, 이메일 형태 및 중복을 검사하는 API")
+	public ResponseEntity<String> checkEmailDuplication(
+		@Valid @RequestBody CheckEmailRequest request,
+		Errors errors) {
+		if (errors.hasErrors())
+			throw new RequestException("이메일 중복 검사 요청이 올바르지 않습니다.", errors);
+
+		userService.checkEmail(request.email());
 		return ResponseEntity.ok().body("OK");
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/dto/CheckEmailRequest.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/dto/CheckEmailRequest.java
@@ -1,0 +1,8 @@
+package com.gamzabat.algohub.feature.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record CheckEmailRequest(
+	@NotBlank(message = "이메일은 필수 입력 입니다.") @Email(message = "이메일 형식이 올바르지 않습니다.") String email) {
+}

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -158,4 +158,10 @@ public class UserService {
 		}
 		log.info("success to check baekjoon nickname validity");
 	}
+
+	@Transactional(readOnly = true)
+	public void checkEmail(String email) {
+		if (userRepository.existsByEmail(email))
+			throw new UserValidationException("이미 사용 중인 이메일 입니다.");
+	}
 }

--- a/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
@@ -2,6 +2,7 @@ package com.gamzabat.algohub.feature.user.controller;
 
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -33,6 +34,7 @@ import com.gamzabat.algohub.config.SpringSecurityConfig;
 import com.gamzabat.algohub.exception.UserValidationException;
 import com.gamzabat.algohub.feature.image.service.ImageService;
 import com.gamzabat.algohub.feature.user.domain.User;
+import com.gamzabat.algohub.feature.user.dto.CheckEmailRequest;
 import com.gamzabat.algohub.feature.user.dto.DeleteUserRequest;
 import com.gamzabat.algohub.feature.user.dto.RegisterRequest;
 import com.gamzabat.algohub.feature.user.dto.SignInRequest;
@@ -393,4 +395,53 @@ class UserControllerTest {
 			.andExpect(jsonPath("$.error").value("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요."));
 		verify(userService, times(1)).checkBjNickname(bjNickname);
 	}
+
+	@Test
+	@DisplayName("이메일 유효성 검증 : 사용 가능한 이메일")
+	void checkEmail_1() throws Exception {
+		// given
+		CheckEmailRequest request = new CheckEmailRequest("email@email.com");
+		doNothing().when(userService).checkEmail(anyString());
+		// when, then
+		mockMvc.perform(post("/api/user/check-email")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(content().string("OK"));
+		verify(userService, times(1)).checkEmail(anyString());
+	}
+
+	@Test
+	@DisplayName("이메일 유효성 검증 : 이미 사용 중인 이메일")
+	void checkEmail_2() throws Exception {
+		// given
+		CheckEmailRequest request = new CheckEmailRequest("email@email.com");
+		doThrow(new UserValidationException("이미 사용 중인 이메일 입니다.")).when(userService).checkEmail(anyString());
+		// when, then
+		mockMvc.perform(post("/api/user/check-email")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("이미 사용 중인 이메일 입니다."));
+		verify(userService, times(1)).checkEmail(anyString());
+	}
+
+	@ParameterizedTest
+	@CsvSource(value = {
+		" '', email : 이메일은 필수 입력 입니다.",
+		"email, email : 이메일 형식이 올바르지 않습니다.",
+	})
+	@DisplayName("이메일 유효성 검증 실패 : 잘못된 요청")
+	void checkEmailFailed_1(String email, String exceptionMessage) throws Exception {
+		// given
+		CheckEmailRequest request = new CheckEmailRequest(email);
+		// when, then
+		mockMvc.perform(post("/api/user/check-email")
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value(400))
+			.andExpect(jsonPath("$.error").value("이메일 중복 검사 요청이 올바르지 않습니다."))
+			.andExpect(jsonPath("$.messages", hasItem(exceptionMessage)));
+	}
+
 }

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -313,4 +313,26 @@ class UserServiceTest {
 			.isInstanceOf(BOJServerErrorException.class)
 			.hasFieldOrPropertyWithValue("error", "현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
 	}
+
+	@Test
+	@DisplayName("이메일 유효성 검증")
+	void checkEmail() {
+		// given
+		when(userRepository.existsByEmail(email)).thenReturn(false);
+		// when
+		userService.checkEmail(email);
+		// then
+		verify(userRepository, times(1)).existsByEmail(email);
+	}
+
+	@Test
+	@DisplayName("이메일 유효성 검증 실패 : 이미 가입된 이메일")
+	void checkEmailFailed() {
+		// given
+		when(userRepository.existsByEmail(email)).thenReturn(true);
+		// when, then
+		assertThatThrownBy(() -> userService.checkEmail(email))
+			.isInstanceOf(UserValidationException.class)
+			.hasFieldOrPropertyWithValue("errors", "이미 사용 중인 이메일 입니다.");
+	}
 }


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
https://github.com/GAMZA-BAT/ALGOHUB-SERVER/issues/86

## 🚀 Description
<!-- 작업 내용 -->
- 이메일 형태 및 중복 검사 API를 추가했습니다.
- 이메일 중복 검사 API를 만들 때, REST API로 만든단 가정하에 GET vs POST 방식이 나뉘더라구요
- GET : DB의 데이터가 변경되는 것도 없고 조회만 하는거니까 GET이 맞다
- POST : 이메일 중복 검사 할 때 URL에 email이 파라미터로 들어가는 건 맞지 않다 body로 넣어야 하기에 POST다
- 사실 저는 메서드는 GET이 맞다고 생각했습니다,, 근데 이메일 형태 검사할 때 validation의 @Email을 사용하면 편리하게 확인이 가능하더라구요
- 솔직하게는 @Email로 편하게 검증하고 싶어서 ㅎㅎ POST로 일단 구현했습니다

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
- 여러분은 어떻게 생각하시는지요! 
- REST API는 GET 할 때 불가능한건 아니지만 RequestBody 사용을 권장하지 않는다고 하네요
- 이번 API를 GET + RequestBody로 사용하는걸 어떻게 생각하는지도 궁금합니담

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->
- 다른 서비스들의 REST API 레퍼런스 참고해보니까 GET 메서드를 더 많이 쓰는 것 같긴 합니다