### PR TITLE
feat : 멤버 role 수정 API 추가

### DIFF
--- a/src/main/java/com/gamzabat/algohub/common/annotation/EnumValidator.java
+++ b/src/main/java/com/gamzabat/algohub/common/annotation/EnumValidator.java
@@ -1,0 +1,28 @@
+package com.gamzabat.algohub.common.annotation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class EnumValidator implements ConstraintValidator<ValidEnum, String> {
+	private Class<? extends Enum<?>> enumClass;
+
+	@Override
+	public void initialize(ValidEnum constraintAnnotation) {
+		this.enumClass = constraintAnnotation.enumClass();
+	}
+
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext constraintValidatorContext) {
+		Object[] enumValues = this.enumClass.getEnumConstants();
+		if (enumValues != null) {
+			for (Object enumValue : enumValues) {
+				if (value.equals(enumValue.toString())) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/common/annotation/ValidEnum.java
+++ b/src/main/java/com/gamzabat/algohub/common/annotation/ValidEnum.java
@@ -1,0 +1,22 @@
+package com.gamzabat.algohub.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = EnumValidator.class)
+public @interface ValidEnum {
+	String message() default "잘못된 enum 값입니다.";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+
+	Class<? extends java.lang.Enum<?>> enumClass();
+}

--- a/src/main/java/com/gamzabat/algohub/common/annotation/ValidEnum.java
+++ b/src/main/java/com/gamzabat/algohub/common/annotation/ValidEnum.java
@@ -8,7 +8,7 @@ import java.lang.annotation.Target;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 
-@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = EnumValidator.class)
 public @interface ValidEnum {

--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -27,6 +28,7 @@ import com.gamzabat.algohub.feature.studygroup.dto.GetGroupResponse;
 import com.gamzabat.algohub.feature.studygroup.dto.GetRankingResponse;
 import com.gamzabat.algohub.feature.studygroup.dto.GetStudyGroupListsResponse;
 import com.gamzabat.algohub.feature.studygroup.dto.GetStudyGroupWithCodeResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.UpdateGroupMemberRoleRequest;
 import com.gamzabat.algohub.feature.studygroup.service.StudyGroupService;
 import com.gamzabat.algohub.feature.user.domain.User;
 
@@ -146,5 +148,16 @@ public class StudyGroupController {
 	public ResponseEntity<String> updateBookmarkGroup(@AuthedUser User user, @RequestParam Long groupId) {
 		String response = studyGroupService.updateBookmarkGroup(user, groupId);
 		return ResponseEntity.ok().body(response);
+	}
+
+	@PatchMapping(value = "/role")
+	@Operation(summary = "스터디 그룹 멤버 역할 수정 API", description = "스터디 그룹 멤버 역할을 ADMIN/PARTICIPANT 로 수정하는 API")
+	public ResponseEntity<String> updateMemberRole(@AuthedUser User user, @Valid @RequestBody
+	UpdateGroupMemberRoleRequest request, Errors errors) {
+		if (errors.hasErrors())
+			throw new RequestException("스터디 그룹 멤버 역할 수정 요청이 올바르지 않습니다.", errors);
+
+		studyGroupService.updateGroupMemberRole(user, request);
+		return ResponseEntity.ok().body("OK");
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/domain/GroupMember.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/domain/GroupMember.java
@@ -42,4 +42,8 @@ public class GroupMember {
 		this.joinDate = joinDate;
 		this.role = role;
 	}
+
+	public void updateRole(RoleOfGroupMember role) {
+		this.role = role;
+	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/dto/UpdateGroupMemberRoleRequest.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/dto/UpdateGroupMemberRoleRequest.java
@@ -1,0 +1,14 @@
+package com.gamzabat.algohub.feature.studygroup.dto;
+
+import com.gamzabat.algohub.common.annotation.ValidEnum;
+import com.gamzabat.algohub.feature.studygroup.etc.RoleOfGroupMember;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateGroupMemberRoleRequest(@NotNull(message = "스터디 그룹 고유 아이디는 필수 입력 입니다.") Long studyGroupId,
+										   @NotNull(message = "스터디 그룹 멤버의 고유 아이디는 필수 입력 입니다.") Long memberId,
+										   @NotBlank(message = "변경할 역할은 필수 입력 입니다.")
+										   @ValidEnum(enumClass = RoleOfGroupMember.class, message = "올바른 enum 값을 입력해주세요. (ADMIN, PARTICIPANT)")
+										   String role) {
+}

--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/service/StudyGroupService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/service/StudyGroupService.java
@@ -34,6 +34,7 @@ import com.gamzabat.algohub.feature.studygroup.dto.GetRankingResponse;
 import com.gamzabat.algohub.feature.studygroup.dto.GetStudyGroupListsResponse;
 import com.gamzabat.algohub.feature.studygroup.dto.GetStudyGroupResponse;
 import com.gamzabat.algohub.feature.studygroup.dto.GetStudyGroupWithCodeResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.UpdateGroupMemberRoleRequest;
 import com.gamzabat.algohub.feature.studygroup.etc.RoleOfGroupMember;
 import com.gamzabat.algohub.feature.studygroup.exception.CannotFoundGroupException;
 import com.gamzabat.algohub.feature.studygroup.exception.CannotFoundProblemException;
@@ -393,5 +394,24 @@ public class StudyGroupService {
 			bookmarkedStudyGroupRepository.delete(bookmarked.get());
 			return "스터디 그룹 즐겨찾기 삭제 성공";
 		}
+	}
+
+	@Transactional
+	public void updateGroupMemberRole(User user, UpdateGroupMemberRoleRequest request) {
+		StudyGroup group = studyGroupRepository.findById(request.studyGroupId())
+			.orElseThrow(() -> new CannotFoundGroupException("존재하지 않는 그룹입니다."));
+
+		if (!group.getOwner().getId().equals(user.getId()))
+			throw new StudyGroupValidationException(HttpStatus.FORBIDDEN.value(), "스터디 그룹의 멤버 역할을 수정할 권한이 없습니다.");
+
+		User targetUser = userRepository.findById(request.memberId())
+			.orElseThrow(() -> new UserValidationException("존재하지 않는 회원입니다."));
+
+		GroupMember member = groupMemberRepository.findByUserAndStudyGroup(targetUser, group)
+			.orElseThrow(
+				() -> new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "해당 스터디 그룹에 참여하지 않은 회원입니다."));
+
+		member.updateRole(RoleOfGroupMember.fromValue(request.role()));
+		log.info("success to update group member role");
 	}
 }

--- a/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
@@ -44,6 +44,7 @@ import com.gamzabat.algohub.feature.studygroup.dto.CreateGroupResponse;
 import com.gamzabat.algohub.feature.studygroup.dto.EditGroupRequest;
 import com.gamzabat.algohub.feature.studygroup.dto.GetStudyGroupListsResponse;
 import com.gamzabat.algohub.feature.studygroup.dto.GetStudyGroupResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.UpdateGroupMemberRoleRequest;
 import com.gamzabat.algohub.feature.studygroup.exception.CannotFoundGroupException;
 import com.gamzabat.algohub.feature.studygroup.exception.GroupMemberValidationException;
 import com.gamzabat.algohub.feature.studygroup.repository.GroupMemberRepository;
@@ -623,5 +624,83 @@ class StudyGroupControllerTest {
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.error").value("참여하지 않은 그룹 입니다."));
 		verify(studyGroupService, times(1)).updateBookmarkGroup(user, groupId);
+	}
+
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 성공")
+	void updateGroupMemberRole() throws Exception {
+		// given
+		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
+		// when, then
+		mockMvc.perform(patch("/api/group/role")
+				.header("Authorization", token)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(content().string("OK"));
+		verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
+	}
+
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 실패 : 존재하지 않는 그룹")
+	void updateGroupMemberRoleFailed_1() throws Exception {
+		// given
+		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
+		doThrow(new CannotFoundSolutionException("존재하지 않는 그룹입니다.")).when(studyGroupService)
+			.updateGroupMemberRole(user, request);
+		// when, then
+		mockMvc.perform(patch("/api/group/role")
+				.header("Authorization", token)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("존재하지 않는 그룹입니다."));
+		verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
+	}
+
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 실패 : 스터디 그룹 멤버 역할 수정 권한 없음")
+	void updateGroupMemberRoleFailed_2() throws Exception {
+		// given
+		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
+		doThrow(new StudyGroupValidationException(HttpStatus.FORBIDDEN.value(), "스터디 그룹 멤버 역할을 수정할 권한이 없습니다.")).when(
+			studyGroupService).updateGroupMemberRole(user, request);
+		// when, then
+		mockMvc.perform(patch("/api/group/role")
+				.header("Authorization", token)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.error").value("스터디 그룹 멤버 역할을 수정할 권한이 없습니다."));
+		verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
+	}
+
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 실패 : 존재하지 않는 회원")
+	void updateGroupMemberRoleFailed_3() throws Exception {
+		// given
+		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
+		doThrow(new UserValidationException("존재하지 않는 회원입니다.")).when(
+			studyGroupService).updateGroupMemberRole(user, request);
+		// when, then
+		mockMvc.perform(patch("/api/group/role")
+				.header("Authorization", token)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("존재하지 않는 회원입니다."));
+		verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
+	}
+
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 실패 : 스터디 그룹에 참여하지 않은 회원")
+	void updateGroupMemberRoleFailed_4() throws Exception {
+		// given
+		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
+		doThrow(new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "해당 스터디 그룹에 참여하지 않은 회원입니다.")).when(
+			studyGroupService).updateGroupMemberRole(user, request);
+		// when, then
+		mockMvc.perform(patch("/api/group/role")
+				.header("Authorization", token)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("해당 스터디 그룹에 참여하지 않은 회원입니다."));
+		verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
 	}
 }

--- a/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
@@ -39,6 +39,8 @@ import com.gamzabat.algohub.feature.studygroup.dto.EditGroupRequest;
 import com.gamzabat.algohub.feature.studygroup.dto.GetRankingResponse;
 import com.gamzabat.algohub.feature.studygroup.dto.GetStudyGroupListsResponse;
 import com.gamzabat.algohub.feature.studygroup.dto.GetStudyGroupResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.UpdateGroupMemberRoleRequest;
+import com.gamzabat.algohub.feature.studygroup.etc.RoleOfGroupMember;
 import com.gamzabat.algohub.feature.studygroup.exception.CannotFoundGroupException;
 import com.gamzabat.algohub.feature.studygroup.exception.GroupMemberValidationException;
 import com.gamzabat.algohub.feature.studygroup.repository.BookmarkedStudyGroupRepository;
@@ -46,6 +48,7 @@ import com.gamzabat.algohub.feature.studygroup.repository.GroupMemberRepository;
 import com.gamzabat.algohub.feature.studygroup.repository.StudyGroupRepository;
 import com.gamzabat.algohub.feature.studygroup.service.StudyGroupService;
 import com.gamzabat.algohub.feature.user.domain.User;
+import com.gamzabat.algohub.feature.user.repository.UserRepository;
 
 @ExtendWith(MockitoExtension.class)
 class StudyGroupServiceTest {
@@ -59,6 +62,8 @@ class StudyGroupServiceTest {
 	private BookmarkedStudyGroupRepository bookmarkedStudyGroupRepository;
 	@Mock
 	private SolutionRepository solutionRepository;
+	@Mock
+	private UserRepository userRepository;
 	@Mock
 	private ImageService imageService;
 	private User user;
@@ -512,5 +517,79 @@ class StudyGroupServiceTest {
 		assertThatThrownBy(() -> studyGroupService.getAllRank(user2, groupId))
 			.isInstanceOf(UserValidationException.class)
 			.hasFieldOrPropertyWithValue("errors", "랭킹을 확인할 권한이 없습니다.");
+	}
+
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 성공")
+	void updateGroupMemberRole() {
+		// given
+		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 2L, "ADMIN");
+		GroupMember member = GroupMember.builder()
+			.studyGroup(group)
+			.user(user2)
+			.role(RoleOfGroupMember.PARTICIPANT)
+			.build();
+		when(groupMemberRepository.findByUserAndStudyGroup(user2, group)).thenReturn(Optional.ofNullable(member));
+		when(studyGroupRepository.findById(groupId)).thenReturn(Optional.ofNullable(group));
+		when(userRepository.findById(anyLong())).thenReturn(Optional.ofNullable(user2));
+		// when
+		studyGroupService.updateGroupMemberRole(user, request);
+		// then
+		assertThat(member.getUser()).isEqualTo(user2);
+		assertThat(member.getStudyGroup()).isEqualTo(group);
+		assertThat(member.getRole()).isEqualTo(RoleOfGroupMember.ADMIN);
+	}
+
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 실패 : 존재하지 않는 그룹")
+	void updateGroupMemberRoleFailed_1() {
+		// given
+		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 2L, "ADMIN");
+		when(studyGroupRepository.findById(groupId)).thenReturn(Optional.empty());
+		// when, then
+		assertThatThrownBy(() -> studyGroupService.updateGroupMemberRole(user, request))
+			.isInstanceOf(CannotFoundGroupException.class)
+			.hasFieldOrPropertyWithValue("errors", "존재하지 않는 그룹입니다.");
+	}
+
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 실패 : 역할 수정 권한 없음")
+	void updateGroupMemberRoleFailed_2() {
+		// given
+		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 2L, "ADMIN");
+		when(studyGroupRepository.findById(groupId)).thenReturn(Optional.of(group));
+		// when, then
+		assertThatThrownBy(() -> studyGroupService.updateGroupMemberRole(user2, request))
+			.isInstanceOf(StudyGroupValidationException.class)
+			.hasFieldOrPropertyWithValue("code", HttpStatus.FORBIDDEN.value())
+			.hasFieldOrPropertyWithValue("error", "스터디 그룹의 멤버 역할을 수정할 권한이 없습니다.");
+	}
+
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 실패 : 존재하지 않는 회원")
+	void updateGroupMemberRoleFailed_3() {
+		// given
+		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 2L, "ADMIN");
+		when(studyGroupRepository.findById(groupId)).thenReturn(Optional.of(group));
+		when(userRepository.findById(anyLong())).thenReturn(Optional.empty());
+		// when, then
+		assertThatThrownBy(() -> studyGroupService.updateGroupMemberRole(user, request))
+			.isInstanceOf(UserValidationException.class)
+			.hasFieldOrPropertyWithValue("errors", "존재하지 않는 회원입니다.");
+	}
+
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 실패 : 참여하지 않은 회원")
+	void updateGroupMemberRoleFailed_4() {
+		// given
+		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 2L, "ADMIN");
+		when(studyGroupRepository.findById(groupId)).thenReturn(Optional.of(group));
+		when(userRepository.findById(anyLong())).thenReturn(Optional.of(user2));
+		when(groupMemberRepository.findByUserAndStudyGroup(user2, group)).thenReturn(Optional.empty());
+		// when, then
+		assertThatThrownBy(() -> studyGroupService.updateGroupMemberRole(user, request))
+			.isInstanceOf(GroupMemberValidationException.class)
+			.hasFieldOrPropertyWithValue("code", HttpStatus.BAD_REQUEST.value())
+			.hasFieldOrPropertyWithValue("error", "해당 스터디 그룹에 참여하지 않은 회원입니다.");
 	}
 }


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
https://github.com/GAMZA-BAT/ALGOHUB-SERVER/issues/91

## 🚀 Description
<!-- 작업 내용 -->
- 방장 권한으로 스터디 그룹 멤버의 role을 ADMIN/PARTICIPANT로 수정하는 API를 추가했습니다.
- 원래는 변경하고자 하는 role을 enum으로 받으려 했는데 그렇게 되면 request body에서 잘못된 enum 값 처리하는 게 너무 복잡하더라고요..
- 그래서 enum 값은 string으로 먼저 받고, @ValidEnum이라는 커스텀 어노테이션으로 유효한 enum 값을 받았는지 확인할 수 있도록 만들었습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->
- @ValidEnum은 커스텀 어노테이션이라 앞으로 무한의 확장성을 고려하여,, 모든 Enum에서 사용할 수 있도록 설계하긴 했습니다.
- 아마 앞으로 다른 분들도 올바른 Enum 값이 들어왔는지 검사할 때 @ValidEnum 사용하시면 될 것 같습니담