### PR TITLE
feat : 닉네임 중복 검사 API 추가

### DIFF
--- a/src/main/java/com/gamzabat/algohub/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/gamzabat/algohub/exception/CustomExceptionHandler.java
@@ -16,6 +16,7 @@ import com.gamzabat.algohub.feature.studygroup.exception.GroupMemberValidationEx
 import com.gamzabat.algohub.feature.studygroup.exception.InvalidRoleException;
 import com.gamzabat.algohub.feature.user.exception.BOJServerErrorException;
 import com.gamzabat.algohub.feature.user.exception.CheckBjNicknameValidationException;
+import com.gamzabat.algohub.feature.user.exception.CheckNicknameValidationException;
 import com.gamzabat.algohub.feature.user.exception.UncorrectedPasswordException;
 
 @ControllerAdvice
@@ -103,4 +104,8 @@ public class CustomExceptionHandler {
 			.body(new ErrorResponse(HttpStatus.SERVICE_UNAVAILABLE.value(), e.getError(), null));
 	}
 
+	@ExceptionHandler(CheckNicknameValidationException.class)
+	protected ResponseEntity<Object> handler(CheckNicknameValidationException e) {
+		return ResponseEntity.status(e.getCode()).body(new ErrorResponse(e.getCode(), e.getError(), null));
+	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
@@ -101,4 +101,11 @@ public class UserController {
 		userService.checkBjNickname(bjNickname);
 		return ResponseEntity.ok().body("OK");
 	}
+
+	@GetMapping("/check-nickname")
+	@Operation(summary = "닉네임 중복 검사 API", description = "회원가입 진행 시, 닉네임 형식 및 중복을 검사하는 API")
+	public ResponseEntity<String> checkNickname(@RequestParam String nickname) {
+		userService.checkNickname(nickname);
+		return ResponseEntity.ok().body("OK");
+	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/exception/CheckNicknameValidationException.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/exception/CheckNicknameValidationException.java
@@ -1,0 +1,14 @@
+package com.gamzabat.algohub.feature.user.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CheckNicknameValidationException extends RuntimeException {
+	private final int code;
+	private final String error;
+
+	public CheckNicknameValidationException(int code, String error) {
+		this.code = code;
+		this.error = error;
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/feature/user/repository/UserRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/repository/UserRepository.java
@@ -18,4 +18,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findById(Long Id);
 
 	boolean existsByBjNickname(String bjNickname);
+
+	boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -169,9 +169,7 @@ public class UserService {
 
 	@Transactional(readOnly = true)
 	public void checkNickname(String nickname) {
-		String regex = "[^a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ]";
-
-		if (nickname.length() < 3 || nickname.length() > 16 || Pattern.compile(regex).matcher(nickname).find())
+		if (isInvalidNicknameForm(nickname))
 			throw new CheckNicknameValidationException(HttpStatus.BAD_REQUEST.value(),
 				"닉네임은 3글자 이상, 16글자 이하이며 특수문자 불가입니다.");
 
@@ -179,5 +177,10 @@ public class UserService {
 			throw new CheckNicknameValidationException(HttpStatus.CONFLICT.value(), "이미 사용 중인 닉네임입니다.");
 
 		log.info("success to check nickname validity");
+	}
+
+	private boolean isInvalidNicknameForm(String nickname) {
+		String regex = "[^a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ]";
+		return nickname.length() < 3 || nickname.length() > 16 || Pattern.compile(regex).matcher(nickname).find();
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.gamzabat.algohub.feature.user.service;
 import static com.gamzabat.algohub.common.ApiConstants.*;
 
 import java.time.Duration;
+import java.util.regex.Pattern;
 
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -36,6 +37,7 @@ import com.gamzabat.algohub.feature.user.dto.UpdateUserRequest;
 import com.gamzabat.algohub.feature.user.dto.UserInfoResponse;
 import com.gamzabat.algohub.feature.user.exception.BOJServerErrorException;
 import com.gamzabat.algohub.feature.user.exception.CheckBjNicknameValidationException;
+import com.gamzabat.algohub.feature.user.exception.CheckNicknameValidationException;
 import com.gamzabat.algohub.feature.user.exception.UncorrectedPasswordException;
 import com.gamzabat.algohub.feature.user.repository.UserRepository;
 
@@ -157,5 +159,19 @@ public class UserService {
 			throw new BOJServerErrorException("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
 		}
 		log.info("success to check baekjoon nickname validity");
+	}
+
+	@Transactional(readOnly = true)
+	public void checkNickname(String nickname) {
+		String regex = "[^a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ]";
+
+		if (nickname.length() < 3 || nickname.length() > 16 || Pattern.compile(regex).matcher(nickname).find())
+			throw new CheckNicknameValidationException(HttpStatus.BAD_REQUEST.value(),
+				"닉네임은 3글자 이상, 16글자 이하이며 특수문자 불가입니다.");
+
+		if (userRepository.existsByNickname(nickname))
+			throw new CheckNicknameValidationException(HttpStatus.CONFLICT.value(), "이미 사용 중인 닉네임입니다.");
+
+		log.info("success to check nickname validity");
 	}
 }

--- a/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -41,6 +42,7 @@ import com.gamzabat.algohub.feature.user.dto.UpdateUserRequest;
 import com.gamzabat.algohub.feature.user.dto.UserInfoResponse;
 import com.gamzabat.algohub.feature.user.exception.BOJServerErrorException;
 import com.gamzabat.algohub.feature.user.exception.CheckBjNicknameValidationException;
+import com.gamzabat.algohub.feature.user.exception.CheckNicknameValidationException;
 import com.gamzabat.algohub.feature.user.exception.UncorrectedPasswordException;
 import com.gamzabat.algohub.feature.user.repository.UserRepository;
 import com.gamzabat.algohub.feature.user.service.UserService;
@@ -392,5 +394,54 @@ class UserControllerTest {
 			.andExpect(status().isServiceUnavailable())
 			.andExpect(jsonPath("$.error").value("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요."));
 		verify(userService, times(1)).checkBjNickname(bjNickname);
+	}
+
+	@Test
+	@DisplayName("닉네임 중복 검사")
+	void checkNickname_1() throws Exception {
+		// given
+		String nickname = "nickname";
+		doNothing().when(userService).checkNickname(nickname);
+		// when, then
+		mockMvc.perform(get("/api/user/check-nickname")
+				.header("Authorization", token)
+				.param("nickname", nickname))
+			.andExpect(status().isOk())
+			.andExpect(content().string("OK"));
+		verify(userService, times(1)).checkNickname(nickname);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"***asdf", "16글자가초과된nickname입니다", "ab"})
+	@DisplayName("닉네임 중복 검사 : 잘못된 형식의 닉네임")
+	void checkNickname_2(String nickname) throws Exception {
+		// given
+		doThrow(
+			new CheckNicknameValidationException(HttpStatus.BAD_REQUEST.value(), "닉네임은 3글자 이상, 16글자 이하이며 특수문자 불가입니다."))
+			.when(userService).checkNickname(nickname);
+		// when, then
+		mockMvc.perform(get("/api/user/check-nickname")
+				.header("Authorization", token)
+				.param("nickname", nickname))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("닉네임은 3글자 이상, 16글자 이하이며 특수문자 불가입니다."));
+		verify(userService, times(1)).checkNickname(nickname);
+	}
+
+	@Test
+	@DisplayName("닉네임 중복 검사 : 이미 사용 중인 닉네임")
+	void checkNickname_3() throws Exception {
+		// given
+		String nickname = "nickname";
+		doThrow(
+			new CheckNicknameValidationException(HttpStatus.CONFLICT.value(), "이미 사용 중인 닉네임입니다."))
+			.when(userService).checkNickname(nickname);
+		// when, then
+		mockMvc.perform(get("/api/user/check-nickname")
+				.header("Authorization", token)
+				.param("nickname", nickname))
+			.andExpect(status().isConflict())
+			.andExpect(jsonPath("$.error").value("이미 사용 중인 닉네임입니다."));
+		verify(userService, times(1)).checkNickname(nickname);
 	}
 }


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
https://github.com/GAMZA-BAT/ALGOHUB-SERVER/issues/88

## 🚀 Description
<!-- 작업 내용 -->
- 닉네임 형태 검증 및 중복을 검사하는 API를 추가했습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->
- Q. 왜 얘는 또 POST가 아닌 GET인가요? 라고 질문을 하신다면
- 이메일 검사때는 실제 회원이 사용중인 이메일이 url 파라미터로 들어가는거기 때문에 보안성을 좀 더 고려하고자 POST로 처리했지만, 닉네임은 민감한 정보도 아니고 제한 사항을 서비스 코드에서 처리하기도 괜찮기 때문에 GET으로 구현했습니다.
- 특수문자는 종류가 너무 많아서 한글, 영어 대소문자, 숫자 외의 모든 문자는 특수문자로 처리했습니다. 