### PR TITLE
feat : 문제 기간 수정 시, 이미 시작 날짜가 지난 문제는 시작 날짜 수정 막는 로직 추가

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
@@ -118,7 +118,7 @@ public class ProblemService {
 				"문제에 대한 권한이 없습니다. : edit // 방장, 부방장일 경우에만 생성이 가능합니다.");
 		}
 
-		if (!problem.getStartDate().isAfter(LocalDate.now()))
+		if (!problem.getStartDate().isAfter(LocalDate.now()) && !request.startDate().isEqual(problem.getStartDate()))
 			throw new ProblemValidationException(HttpStatus.FORBIDDEN.value(), "문제 시작 날짜 수정이 불가합니다. : 이미 진행 중인 문제입니다.");
 
 		problem.editProblemInfo(request.startDate(), request.endDate());

--- a/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
@@ -117,6 +117,10 @@ public class ProblemService {
 			throw new StudyGroupValidationException(HttpStatus.FORBIDDEN.value(),
 				"문제에 대한 권한이 없습니다. : edit // 방장, 부방장일 경우에만 생성이 가능합니다.");
 		}
+
+		if (!problem.getStartDate().isAfter(LocalDate.now()))
+			throw new ProblemValidationException(HttpStatus.FORBIDDEN.value(), "문제 시작 날짜 수정이 불가합니다. : 이미 진행 중인 문제입니다.");
+
 		problem.editProblemInfo(request.startDate(), request.endDate());
 		log.info("success to edit problem deadline");
 	}

--- a/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
@@ -118,11 +118,23 @@ public class ProblemService {
 				"문제에 대한 권한이 없습니다. : edit // 방장, 부방장일 경우에만 생성이 가능합니다.");
 		}
 
-		if (!problem.getStartDate().isAfter(LocalDate.now()) && !request.startDate().isEqual(problem.getStartDate()))
-			throw new ProblemValidationException(HttpStatus.FORBIDDEN.value(), "문제 시작 날짜 수정이 불가합니다. : 이미 진행 중인 문제입니다.");
+		checkProblemPeriodRequest(request, problem);
 
 		problem.editProblemInfo(request.startDate(), request.endDate());
 		log.info("success to edit problem deadline");
+	}
+
+	private void checkProblemPeriodRequest(EditProblemRequest request, Problem problem) {
+		if (!request.startDate().equals(problem.getStartDate()) && request.startDate().isBefore(LocalDate.now()))
+			throw new ProblemValidationException(HttpStatus.BAD_REQUEST.value(), "문제 시작 날짜는 오늘 이전의 날짜로 수정할 수 없습니다.");
+
+		if (!request.endDate().equals(problem.getEndDate()) && request.endDate().isBefore(LocalDate.now()))
+			throw new ProblemValidationException(HttpStatus.BAD_REQUEST.value(), "문제 마감 날짜는 오늘 이전의 날짜로 수정할 수 없습니다.");
+
+		if (!problem.getStartDate().isAfter(LocalDate.now()) && !request.startDate()
+			.isEqual(problem.getStartDate()))
+			throw new ProblemValidationException(HttpStatus.FORBIDDEN.value(),
+				"문제 시작 날짜 수정이 불가합니다. : 이미 진행 중인 문제입니다.");
 	}
 
 	@Transactional(readOnly = true)

--- a/src/test/java/com/gamzabat/algohub/feature/problem/controller/ProblemControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/problem/controller/ProblemControllerTest.java
@@ -266,6 +266,45 @@ class ProblemControllerTest {
 	}
 
 	@Test
+	@DisplayName("문제 진행 기간 수정 실패 : 문제 시작 날짜를 오늘 이전의 날짜로 요청한 경우")
+	void editProblemDeadlineFailed_4() throws Exception {
+		// given
+		EditProblemRequest request = new EditProblemRequest(problemId, LocalDate.now().minusDays(10), LocalDate.now());
+		doThrow(
+			new ProblemValidationException(HttpStatus.BAD_REQUEST.value(), "문제 시작 날짜는 오늘 이전의 날짜로 수정할 수 없습니다.")).when(
+				problemService)
+			.editProblem(any(User.class), any(EditProblemRequest.class));
+		// when, then
+		mockMvc.perform(patch("/api/problem")
+				.header("Authorization", token)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("문제 시작 날짜는 오늘 이전의 날짜로 수정할 수 없습니다."));
+		verify(problemService, times(1)).editProblem(user, request);
+	}
+
+	@Test
+	@DisplayName("문제 진행 기간 수정 실패 : 문제 마감 날짜를 오늘 이전의 날짜로 요청한 경우")
+	void editProblemDeadlineFailed_5() throws Exception {
+		// given
+		EditProblemRequest request = new EditProblemRequest(problemId, LocalDate.now().minusDays(20),
+			LocalDate.now().minusDays(10));
+		doThrow(
+			new ProblemValidationException(HttpStatus.BAD_REQUEST.value(), "문제 마감 날짜는 오늘 이전의 날짜로 수정할 수 없습니다.")).when(
+				problemService)
+			.editProblem(any(User.class), any(EditProblemRequest.class));
+		// when, then
+		mockMvc.perform(patch("/api/problem")
+				.header("Authorization", token)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("문제 마감 날짜는 오늘 이전의 날짜로 수정할 수 없습니다."));
+		verify(problemService, times(1)).editProblem(user, request);
+	}
+
+	@Test
 	@DisplayName("문제 목록 조회 성공")
 	void getProblemList() throws Exception {
 		// given

--- a/src/test/java/com/gamzabat/algohub/feature/problem/controller/ProblemControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/problem/controller/ProblemControllerTest.java
@@ -247,6 +247,25 @@ class ProblemControllerTest {
 	}
 
 	@Test
+	@DisplayName("문제 마감기한 수정 실패 : 이미 진행 중인 문제인데 시작날짜 수정을 요청하는 경우")
+	void editProblemDeadlineFailed_3() throws Exception {
+		// given
+		EditProblemRequest request = new EditProblemRequest(problemId, LocalDate.now(), LocalDate.now().plusDays(10));
+		doThrow(
+			new ProblemValidationException(HttpStatus.FORBIDDEN.value(), "문제 시작 날짜 수정이 불가합니다. : 이미 진행 중인 문제입니다.")).when(
+				problemService)
+			.editProblem(any(User.class), any(EditProblemRequest.class));
+		// when, then
+		mockMvc.perform(patch("/api/problem")
+				.header("Authorization", token)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.error").value("문제 시작 날짜 수정이 불가합니다. : 이미 진행 중인 문제입니다."));
+		verify(problemService, times(1)).editProblem(user, request);
+	}
+
+	@Test
 	@DisplayName("문제 목록 조회 성공")
 	void getProblemList() throws Exception {
 		// given

--- a/src/test/java/com/gamzabat/algohub/feature/problem/controller/ProblemControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/problem/controller/ProblemControllerTest.java
@@ -195,7 +195,7 @@ class ProblemControllerTest {
 	}
 
 	@Test
-	@DisplayName("문제 마감기한 수정 성공")
+	@DisplayName("문제 진행 기간 수정 성공")
 	void editProblemDeadline() throws Exception {
 		// given
 		EditProblemRequest request = new EditProblemRequest(problemId, LocalDate.now(), LocalDate.now().plusDays(10));
@@ -214,7 +214,7 @@ class ProblemControllerTest {
 	@CsvSource(value = {
 		"null,'2024-07-21','2024-08-21',problemId : 문제 고유 아이디는 필수 입력 입니다.",
 	}, nullValues = "null")
-	@DisplayName("문제 마감기한 수정 실패 : 잘못된 요청")
+	@DisplayName("문제 진행 기간 수정 실패 : 잘못된 요청")
 	void editProblemDeadlineFailed_1(Long problemId, LocalDate startDate, LocalDate endDate,
 		String exceptionMessage) throws Exception {
 		// given
@@ -230,7 +230,7 @@ class ProblemControllerTest {
 	}
 
 	@Test
-	@DisplayName("문제 마감기한 수정 실패 : 존재하지 않는 문제")
+	@DisplayName("문제 진행 기간 수정 실패 : 존재하지 않는 문제")
 	void editProblemDeadlineFailed_2() throws Exception {
 		// given
 		EditProblemRequest request = new EditProblemRequest(problemId, LocalDate.now(), LocalDate.now().plusDays(10));
@@ -247,7 +247,7 @@ class ProblemControllerTest {
 	}
 
 	@Test
-	@DisplayName("문제 마감기한 수정 실패 : 이미 진행 중인 문제인데 시작날짜 수정을 요청하는 경우")
+	@DisplayName("문제 진행 기간 수정 실패 : 이미 진행 중인 문제인데 시작날짜 수정을 요청하는 경우")
 	void editProblemDeadlineFailed_3() throws Exception {
 		// given
 		EditProblemRequest request = new EditProblemRequest(problemId, LocalDate.now(), LocalDate.now().plusDays(10));

--- a/src/test/java/com/gamzabat/algohub/service/ProblemServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/ProblemServiceTest.java
@@ -427,6 +427,54 @@ class ProblemServiceTest {
 	}
 
 	@Test
+	@DisplayName("문제 정보 수정 실패 : 문제 시작 날짜를 오늘 이전의 날짜로 요청한 경우")
+	void editProblemFailed_6() {
+		// given
+		Problem problem = Problem.builder()
+			.studyGroup(group)
+			.link("link")
+			.startDate(LocalDate.now())
+			.endDate(LocalDate.now().plusDays(10))
+			.build();
+		EditProblemRequest request = EditProblemRequest.builder()
+			.problemId(20L)
+			.startDate(LocalDate.now().minusDays(3))
+			.endDate(LocalDate.now().plusDays(7))
+			.build();
+		when(problemRepository.findById(20L)).thenReturn(Optional.ofNullable(problem));
+		when(groupRepository.findById(10L)).thenReturn(Optional.ofNullable(group));
+		// when, then
+		assertThatThrownBy(() -> problemService.editProblem(user, request))
+			.isInstanceOf(ProblemValidationException.class)
+			.hasFieldOrPropertyWithValue("code", HttpStatus.BAD_REQUEST.value())
+			.hasFieldOrPropertyWithValue("error", "문제 시작 날짜는 오늘 이전의 날짜로 수정할 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("문제 정보 수정 실패 : 문제 마감 날짜를 오늘 이전의 날짜로 요청한 경우")
+	void editProblemFailed_7() {
+		// given
+		Problem problem = Problem.builder()
+			.studyGroup(group)
+			.link("link")
+			.startDate(LocalDate.now().minusDays(10))
+			.endDate(LocalDate.now())
+			.build();
+		EditProblemRequest request = EditProblemRequest.builder()
+			.problemId(20L)
+			.startDate(LocalDate.now().minusDays(10))
+			.endDate(LocalDate.now().minusDays(2))
+			.build();
+		when(problemRepository.findById(20L)).thenReturn(Optional.ofNullable(problem));
+		when(groupRepository.findById(10L)).thenReturn(Optional.ofNullable(group));
+		// when, then
+		assertThatThrownBy(() -> problemService.editProblem(user, request))
+			.isInstanceOf(ProblemValidationException.class)
+			.hasFieldOrPropertyWithValue("code", HttpStatus.BAD_REQUEST.value())
+			.hasFieldOrPropertyWithValue("error", "문제 마감 날짜는 오늘 이전의 날짜로 수정할 수 없습니다.");
+	}
+
+	@Test
 	@DisplayName("문제 목록 조회 성공")
 	void getProblemList() throws NoSuchFieldException, IllegalAccessException {
 		// given

--- a/src/test/java/com/gamzabat/algohub/service/ProblemServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/ProblemServiceTest.java
@@ -96,8 +96,8 @@ class ProblemServiceTest {
 		problem = Problem.builder()
 			.studyGroup(group)
 			.link("link")
-			.startDate(LocalDate.now().minusDays(7))
-			.endDate(LocalDate.now())
+			.startDate(LocalDate.now().plusDays(3))
+			.endDate(LocalDate.now().plusDays(10))
 			.build();
 
 		Field userField = User.class.getDeclaredField("id");
@@ -400,6 +400,30 @@ class ProblemServiceTest {
 			.isInstanceOf(StudyGroupValidationException.class)
 			.hasFieldOrPropertyWithValue("code", HttpStatus.FORBIDDEN.value())
 			.hasFieldOrPropertyWithValue("error", "문제에 대한 권한이 없습니다. : edit // 방장, 부방장일 경우에만 생성이 가능합니다.");
+	}
+
+	@Test
+	@DisplayName("문제 정보 수정 실패 : 이미 진행 중인 문제인데 시작날짜 수정을 요청하는 경우")
+	void editProblemFailed_5() {
+		// given
+		Problem problem = Problem.builder()
+			.studyGroup(group)
+			.link("link")
+			.startDate(LocalDate.now())
+			.endDate(LocalDate.now().plusDays(10))
+			.build();
+		EditProblemRequest request = EditProblemRequest.builder()
+			.problemId(20L)
+			.startDate(LocalDate.now().plusDays(1))
+			.endDate(LocalDate.now().plusDays(7))
+			.build();
+		when(problemRepository.findById(20L)).thenReturn(Optional.ofNullable(problem));
+		when(groupRepository.findById(10L)).thenReturn(Optional.ofNullable(group));
+		// when, then
+		assertThatThrownBy(() -> problemService.editProblem(user, request))
+			.isInstanceOf(ProblemValidationException.class)
+			.hasFieldOrPropertyWithValue("code", HttpStatus.FORBIDDEN.value())
+			.hasFieldOrPropertyWithValue("error", "문제 시작 날짜 수정이 불가합니다. : 이미 진행 중인 문제입니다.");
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
https://github.com/GAMZA-BAT/ALGOHUB-SERVER/issues/94

## 🚀 Description
<!-- 작업 내용 -->
- 문제 기간을 수정할 때 이미 진행 중인 문제는 시작 날짜 수정이 불가능하도록 로직을 추가했습니다.
- 변동이 없는 날짜도 요청에 기존 날짜를 넣어 요청하는 형식입니다.
- 기존 문제의 시작날짜가 이미 지나서 진행 중인 문제일 경우, 시작날짜를 다른 날로 수정하도록 요청했을 때 예외처리가 되도록 만들었습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
- 지금은 추가되지 않아있는데 혹시 request에서 startDate와 endDate를 올바른 날짜로 전달했는지 검증하는 부분이 추가되어야 할까요?
- startDate, endDate 요청이 오늘보다 이전인 날짜로 수정 불가능하게 막아야 하지 않을까라는 생각이 드는데 어떻게 생각하시는지 궁금합니담
- 추가되어야 한다면 이번 PR에서 추가하겠습니다! 

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->