### PR TITLE
feat : 그룹 회원 목록 조회 API isOwner -> role로 수정

### DIFF
--- a/src/main/java/com/gamzabat/algohub/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/gamzabat/algohub/exception/CustomExceptionHandler.java
@@ -65,7 +65,8 @@ public class CustomExceptionHandler {
 
 	@ExceptionHandler(CannotFoundGroupException.class)
 	protected ResponseEntity<Object> handler(CannotFoundGroupException e) {
-		return ResponseEntity.badRequest().body(new ErrorResponse(HttpStatus.BAD_REQUEST.value(), e.getErrors(), null));
+		return ResponseEntity.status(HttpStatus.NOT_FOUND)
+			.body(new ErrorResponse(HttpStatus.NOT_FOUND.value(), e.getErrors(), null));
 	}
 
 	@ExceptionHandler(NotBojLinkException.class)

--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupController.java
@@ -99,7 +99,7 @@ public class StudyGroupController {
 	@Operation(summary = "그룹 회원 목록 조회")
 	public ResponseEntity<Object> getGroupInfo(@AuthedUser User user, @RequestParam Long groupId) {
 
-		List<GetGroupMemberResponse> members = studyGroupService.groupInfo(user, groupId);
+		List<GetGroupMemberResponse> members = studyGroupService.getGroupMemberList(user, groupId);
 		return ResponseEntity.ok().body(members);
 	}
 

--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/dto/GetGroupMemberResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/dto/GetGroupMemberResponse.java
@@ -2,6 +2,8 @@ package com.gamzabat.algohub.feature.studygroup.dto;
 
 import java.time.LocalDate;
 
+import com.gamzabat.algohub.feature.studygroup.etc.RoleOfGroupMember;
+
 import lombok.Getter;
 
 @Getter
@@ -10,16 +12,16 @@ public class GetGroupMemberResponse {
 	private String nickname;
 	private LocalDate joinDate;
 	private String achivement;
-	private Boolean isOwner;
+	private RoleOfGroupMember role;
 	private String profileImage;
 	private Long memberId;
 
-	public GetGroupMemberResponse(String nickname, LocalDate joinDate, String achivement, Boolean isOwner,
+	public GetGroupMemberResponse(String nickname, LocalDate joinDate, String achivement, RoleOfGroupMember role,
 		String profileImage, Long memberId) {
 		this.nickname = nickname;
 		this.joinDate = joinDate;
 		this.achivement = achivement;
-		this.isOwner = isOwner;
+		this.role = role;
 		this.profileImage = profileImage;
 		this.memberId = memberId;
 	}

--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/service/StudyGroupService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/service/StudyGroupService.java
@@ -224,7 +224,7 @@ public class StudyGroupService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<GetGroupMemberResponse> groupInfo(User user, Long id) {
+	public List<GetGroupMemberResponse> getGroupMemberList(User user, Long id) {
 		StudyGroup group = groupRepository.findById(id)
 			.orElseThrow(() -> new CannotFoundGroupException("그룹을 찾을 수 없습니다."));
 

--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/service/StudyGroupService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/service/StudyGroupService.java
@@ -229,37 +229,36 @@ public class StudyGroupService {
 		StudyGroup group = groupRepository.findById(id)
 			.orElseThrow(() -> new CannotFoundGroupException("그룹을 찾을 수 없습니다."));
 
-		if (groupMemberRepository.existsByUserAndStudyGroup(user, group)) {
-			List<GroupMember> groupMembers = groupMemberRepository.findAllByStudyGroup(group);
+		if (!groupMemberRepository.existsByUserAndStudyGroup(user, group))
+			throw new GroupMemberValidationException(HttpStatus.FORBIDDEN.value(), "그룹 정보를 확인할 권한이 없습니다");
 
-			List<GetGroupMemberResponse> responseList = new ArrayList<>();
+		List<GroupMember> groupMembers = groupMemberRepository.findAllByStudyGroup(group);
 
-			for (GroupMember groupMember : groupMembers) {
-				String nickname = groupMember.getUser().getNickname();
-				LocalDate joinDate = groupMember.getJoinDate();
+		List<GetGroupMemberResponse> responseList = new ArrayList<>();
 
-				Long correctSolution = solutionRepository.countDistinctCorrectSolutionsByUserAndGroup(
-					groupMember.getUser(), id, BOJResultConstants.CORRECT);
-				Long problems = problemRepository.countProblemsByGroupId(id);
-				String achivement;
-				if (correctSolution == 0) {
-					achivement = "0%";
-				} else {
-					achivement = getPercentage(correctSolution, problems) + "%";
-				}
+		for (GroupMember groupMember : groupMembers) {
+			String nickname = groupMember.getUser().getNickname();
+			LocalDate joinDate = groupMember.getJoinDate();
 
-				RoleOfGroupMember role = groupMember.getRole();
-				String profileImage = groupMember.getUser().getProfileImage();
-				Long userId = groupMember.getUser().getId();
-				responseList.add(
-					new GetGroupMemberResponse(nickname, joinDate, achivement, role, profileImage, userId));
+			Long correctSolution = solutionRepository.countDistinctCorrectSolutionsByUserAndGroup(
+				groupMember.getUser(), id, BOJResultConstants.CORRECT);
+			Long problems = problemRepository.countProblemsByGroupId(id);
+			String achivement;
+			if (correctSolution == 0) {
+				achivement = "0%";
+			} else {
+				achivement = getPercentage(correctSolution, problems) + "%";
 			}
-			responseList.sort(Comparator.comparing(GetGroupMemberResponse::getRole));
 
-			return responseList;
-		} else {
-			throw new UserValidationException("그룹 정보를 확인할 권한이 없습니다");
+			RoleOfGroupMember role = groupMember.getRole();
+			String profileImage = groupMember.getUser().getProfileImage();
+			Long userId = groupMember.getUser().getId();
+			responseList.add(
+				new GetGroupMemberResponse(nickname, joinDate, achivement, role, profileImage, userId));
 		}
+		responseList.sort(Comparator.comparing(GetGroupMemberResponse::getRole));
+
+		return responseList;
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/service/StudyGroupService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/service/StudyGroupService.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -247,13 +248,13 @@ public class StudyGroupService {
 					achivement = getPercentage(correctSolution, problems) + "%";
 				}
 
-				Boolean isOwner = getStudyGroupOwner(group).getId().equals(groupMember.getUser().getId());
+				RoleOfGroupMember role = groupMember.getRole();
 				String profileImage = groupMember.getUser().getProfileImage();
 				Long userId = groupMember.getUser().getId();
 				responseList.add(
-					new GetGroupMemberResponse(nickname, joinDate, achivement, isOwner, profileImage, userId));
+					new GetGroupMemberResponse(nickname, joinDate, achivement, role, profileImage, userId));
 			}
-			responseList.sort((a, b) -> Boolean.compare(!a.getIsOwner(), !b.getIsOwner()));
+			responseList.sort(Comparator.comparing(GetGroupMemberResponse::getRole));
 
 			return responseList;
 		} else {

--- a/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
@@ -502,12 +502,12 @@ class StudyGroupControllerTest {
 	void getGroupInfoFailed_2() throws Exception {
 		// given
 		when(studyGroupService.getGroupMemberList(user, groupId)).thenThrow(
-			new UserValidationException("그룹 내용을 확인할 권한이 없습니다"));
+			new GroupMemberValidationException(HttpStatus.FORBIDDEN.value(), "그룹 내용을 확인할 권한이 없습니다"));
 		// when, then
 		mockMvc.perform(get("/api/group/member-list")
 				.header("Authorization", token)
 				.param("groupId", String.valueOf(groupId)))
-			.andExpect(status().isBadRequest())
+			.andExpect(status().isForbidden())
 			.andExpect(jsonPath("$.error").value("그룹 내용을 확인할 권한이 없습니다"));
 
 		verify(studyGroupService, times(1)).getGroupMemberList(any(User.class), anyLong());

--- a/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
@@ -46,6 +46,7 @@ import com.gamzabat.algohub.feature.studygroup.dto.GetGroupMemberResponse;
 import com.gamzabat.algohub.feature.studygroup.dto.GetStudyGroupListsResponse;
 import com.gamzabat.algohub.feature.studygroup.dto.GetStudyGroupResponse;
 import com.gamzabat.algohub.feature.studygroup.dto.UpdateGroupMemberRoleRequest;
+import com.gamzabat.algohub.feature.studygroup.etc.RoleOfGroupMember;
 import com.gamzabat.algohub.feature.studygroup.exception.CannotFoundGroupException;
 import com.gamzabat.algohub.feature.studygroup.exception.GroupMemberValidationException;
 import com.gamzabat.algohub.feature.studygroup.repository.GroupMemberRepository;
@@ -466,7 +467,7 @@ class StudyGroupControllerTest {
 		List<GetGroupMemberResponse> response = new ArrayList<>(30);
 		for (int i = 0; i < 30; i++) {
 			response.add(new GetGroupMemberResponse(
-				"name" + i, LocalDate.now(), "70%", false, "profileImage" + i, (long)i
+				"name" + i, LocalDate.now(), "70%", RoleOfGroupMember.ADMIN, "profileImage" + i, (long)i
 			));
 		}
 		when(studyGroupService.getGroupMemberList(user, groupId)).thenReturn(response);

--- a/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
@@ -469,7 +469,7 @@ class StudyGroupControllerTest {
 				"name" + i, LocalDate.now(), "70%", false, "profileImage" + i, (long)i
 			));
 		}
-		when(studyGroupService.groupInfo(user, groupId)).thenReturn(response);
+		when(studyGroupService.getGroupMemberList(user, groupId)).thenReturn(response);
 		// when, then
 		mockMvc.perform(get("/api/group/member-list")
 				.header("Authorization", token)
@@ -477,14 +477,15 @@ class StudyGroupControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(content().json(objectMapper.writeValueAsString(response)));
 
-		verify(studyGroupService, times(1)).groupInfo(any(User.class), anyLong());
+		verify(studyGroupService, times(1)).getGroupMemberList(any(User.class), anyLong());
 	}
 
 	@Test
 	@DisplayName("그룹 회원 목록 조회 실패 : 존재하지 않는 그룹")
 	void getGroupInfoFailed_1() throws Exception {
 		// given
-		when(studyGroupService.groupInfo(user, groupId)).thenThrow(new CannotFoundGroupException("그룹을 찾을 수 없습니다."));
+		when(studyGroupService.getGroupMemberList(user, groupId)).thenThrow(
+			new CannotFoundGroupException("그룹을 찾을 수 없습니다."));
 		// when, then
 		mockMvc.perform(get("/api/group/member-list")
 				.header("Authorization", token)
@@ -492,14 +493,15 @@ class StudyGroupControllerTest {
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.error").value("그룹을 찾을 수 없습니다."));
 
-		verify(studyGroupService, times(1)).groupInfo(any(User.class), anyLong());
+		verify(studyGroupService, times(1)).getGroupMemberList(any(User.class), anyLong());
 	}
 
 	@Test
 	@DisplayName("그룹 회원 목록 조회 실패 : 권한 없음")
 	void getGroupInfoFailed_2() throws Exception {
 		// given
-		when(studyGroupService.groupInfo(user, groupId)).thenThrow(new UserValidationException("그룹 내용을 확인할 권한이 없습니다"));
+		when(studyGroupService.getGroupMemberList(user, groupId)).thenThrow(
+			new UserValidationException("그룹 내용을 확인할 권한이 없습니다"));
 		// when, then
 		mockMvc.perform(get("/api/group/member-list")
 				.header("Authorization", token)
@@ -507,7 +509,7 @@ class StudyGroupControllerTest {
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.error").value("그룹 내용을 확인할 권한이 없습니다"));
 
-		verify(studyGroupService, times(1)).groupInfo(any(User.class), anyLong());
+		verify(studyGroupService, times(1)).getGroupMemberList(any(User.class), anyLong());
 	}
 
 	@Test

--- a/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
@@ -491,7 +491,7 @@ class StudyGroupControllerTest {
 		mockMvc.perform(get("/api/group/member-list")
 				.header("Authorization", token)
 				.param("groupId", String.valueOf(groupId)))
-			.andExpect(status().isBadRequest())
+			.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.error").value("그룹을 찾을 수 없습니다."));
 
 		verify(studyGroupService, times(1)).getGroupMemberList(any(User.class), anyLong());
@@ -541,7 +541,7 @@ class StudyGroupControllerTest {
 		mockMvc.perform(get("/api/group/problem-solving")
 				.header("Authorization", token)
 				.param("problemId", String.valueOf(problemId)))
-			.andExpect(status().isBadRequest())
+			.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.error").value("문제를 찾을 수 없습니다."));
 		verify(studyGroupService, times(1)).getCheckingSolvedProblem(any(User.class), anyLong());
 	}
@@ -584,7 +584,7 @@ class StudyGroupControllerTest {
 		mockMvc.perform(get("/api/group/group-code")
 				.header("Authorization", token)
 				.param("groupId", String.valueOf(groupId)))
-			.andExpect(status().isBadRequest())
+			.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.error").value("그룹을 찾지 못했습니다."));
 		verify(studyGroupService, times(1)).getGroupCode(any(User.class), anyLong());
 	}


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
https://github.com/GAMZA-BAT/algohub-server/issues/102

## 🚀 Description
<!-- 작업 내용 -->
- 그룹 회원 목록을 조회하는 API response인 `GetGroupMemberResponse`에서 방장 여부만 나타내던 `isOwner`를 `role`로 수정했습니다.
- response를 정렬할 땐 `role`이 `OWNER`, `ADMIN`, `PARTICIPANT` 순으로 정렬되도록 수정했습니다.
- 기존에 그룹 회원 목록을 조회하는 Service 테스트 코드가 없길래 그것도 추가했습니다. 

- 이 외에도 좀 자잘한 리팩토링을 했습니다.
&nbsp; - 그룹 회원 목록 조회 API의 메서드 명을 더 명확히 하고자 `groupInfo`에서 `getGroupMemberList`로 수정했습니다.
&nbsp; - 가독성 좋은 코드를 위해 참여하지 않은 그룹에 대한 예외 처리를 early return 하도록 수정했습니다.
&nbsp; - `CannotFoundGroupException`의 에러 핸들링 시, status code를 400(BAD_REQUEST)보단 404(NOT_FOUND)가 적절할 것 같아 수정했습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->