### PR TITLE
fix : 그룹 목록 조회 시 주인이어도 isOwner가 false로 발생하는 버그 수정

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/dto/GetStudyGroupResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/dto/GetStudyGroupResponse.java
@@ -23,7 +23,7 @@ public record GetStudyGroupResponse(Long id,
 			group.getEndDate(),
 			group.getIntroduction(),
 			owner.getNickname(),
-			owner.equals(user),
+			owner.getId().equals(user.getId()),
 			isBookmarked
 		);
 	}

--- a/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
@@ -68,6 +68,7 @@ class StudyGroupServiceTest {
 	@Mock
 	private ImageService imageService;
 	private User user;
+	private User owner;
 	private User user2;
 	private StudyGroup group;
 	private Problem problem1;
@@ -76,6 +77,7 @@ class StudyGroupServiceTest {
 	private Solution solution2;
 	private Solution solution3;
 	private final Long groupId = 10L;
+	private GroupMember ownerGroupmember;
 	private GroupMember groupMember1;
 	private GroupMember groupMember2;
 	@Captor
@@ -87,6 +89,8 @@ class StudyGroupServiceTest {
 	void setUp() throws NoSuchFieldException, IllegalAccessException {
 		user = User.builder().email("email1").password("password").nickname("nickname1")
 			.role(Role.USER).profileImage("image1").build();
+		owner = User.builder().email("email1").password("password").nickname("nickname1")
+			.role(Role.USER).profileImage("image1").build();
 		user2 = User.builder().email("email2").password("password").nickname("nickname2")
 			.role(Role.USER).profileImage("image2").build();
 		group = StudyGroup.builder()
@@ -95,6 +99,11 @@ class StudyGroupServiceTest {
 			.endDate(LocalDate.now().plusDays(1))
 			.groupImage("imageUrl")
 			.groupCode("code")
+			.build();
+		ownerGroupmember = GroupMember.builder()
+			.studyGroup(group)
+			.user(owner)
+			.role(RoleOfGroupMember.OWNER)
 			.build();
 		groupMember1 = GroupMember.builder()
 			.studyGroup(group)
@@ -135,6 +144,7 @@ class StudyGroupServiceTest {
 		Field userField = User.class.getDeclaredField("id");
 		userField.setAccessible(true);
 		userField.set(user, 1L);
+		userField.set(owner, 1L);
 		userField.set(user2, 2L);
 
 		Field groupId = StudyGroup.class.getDeclaredField("id");
@@ -281,7 +291,7 @@ class StudyGroupServiceTest {
 				.build();
 			groups.add(group);
 			when(groupMemberRepository.findByStudyGroupAndRole(group, RoleOfGroupMember.OWNER)).thenReturn(
-				groupMember1);
+				ownerGroupmember);
 		}
 		for (int i = 0; i < 10; i++) {
 			StudyGroup group = StudyGroup.builder()
@@ -291,7 +301,7 @@ class StudyGroupServiceTest {
 				.build();
 			groups.add(group);
 			when(groupMemberRepository.findByStudyGroupAndRole(group, RoleOfGroupMember.OWNER)).thenReturn(
-				groupMember1);
+				ownerGroupmember);
 		}
 		for (int i = 0; i < 10; i++) {
 			StudyGroup group = StudyGroup.builder()
@@ -301,7 +311,7 @@ class StudyGroupServiceTest {
 				.build();
 			groups.add(group);
 			when(groupMemberRepository.findByStudyGroupAndRole(group, RoleOfGroupMember.OWNER)).thenReturn(
-				groupMember1);
+				groupMember2);
 		}
 		List<BookmarkedStudyGroup> bookmarks = new ArrayList<>(10);
 		for (int i = 0; i < 10; i++) {
@@ -330,6 +340,7 @@ class StudyGroupServiceTest {
 			assertThat(done.get(i).startDate()).isEqualTo(LocalDate.now().minusDays(i + 30));
 			assertThat(done.get(i).endDate()).isEqualTo(LocalDate.now().minusDays(30));
 			assertThat(done.get(i).isBookmarked()).isTrue();
+			assertThat(done.get(i).isOwner()).isTrue();
 		}
 		for (int i = 0; i < 10; i++) {
 			assertThat(inProgress.get(i).name()).isEqualTo("name" + i);
@@ -337,13 +348,15 @@ class StudyGroupServiceTest {
 			assertThat(inProgress.get(i).startDate()).isEqualTo(LocalDate.now().minusDays(i));
 			assertThat(inProgress.get(i).endDate()).isEqualTo(LocalDate.now().plusDays(i));
 			assertThat(inProgress.get(i).isBookmarked()).isFalse();
+			assertThat(inProgress.get(i).isOwner()).isTrue();
 		}
 		for (int i = 0; i < 10; i++) {
 			assertThat(queued.get(i).name()).isEqualTo("name" + i);
-			assertThat(queued.get(i).ownerNickname()).isEqualTo("nickname1");
+			assertThat(queued.get(i).ownerNickname()).isEqualTo("nickname2");
 			assertThat(queued.get(i).startDate()).isEqualTo(LocalDate.now().plusDays(30));
 			assertThat(queued.get(i).endDate()).isEqualTo(LocalDate.now().plusDays(i + 30));
 			assertThat(queued.get(i).isBookmarked()).isFalse();
+			assertThat(queued.get(i).isOwner()).isFalse();
 		}
 		for (int i = 0; i < 10; i++) {
 			assertThat(bookmarked.get(i).name()).isEqualTo("name" + i);
@@ -351,6 +364,7 @@ class StudyGroupServiceTest {
 			assertThat(bookmarked.get(i).startDate()).isEqualTo(LocalDate.now().minusDays(i + 30));
 			assertThat(bookmarked.get(i).endDate()).isEqualTo(LocalDate.now().minusDays(30));
 			assertThat(bookmarked.get(i).isBookmarked()).isTrue();
+			assertThat(bookmarked.get(i).isOwner()).isTrue();
 		}
 	}
 


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
https://github.com/GAMZA-BAT/algohub-server/issues/108

## 🚀 Description
<!-- 작업 내용 -->
- 그룹 OWNER인지를 판단하는 코드에서 기존에 객체 참조를 비교하면서 실제 OWNER여도 false를 리턴하는 오류가 있었습니다.
- user의 id와 그룹 OWNER의 id 값을 비교하는 것으로 수정하면서 이제는 정상적으로 OWNER 여부를 리턴합니다.
- 추후에는 `User` 엔티티에서 같은 id를 갖고있으면 동등하다고 판단하도록 `equals()` 메서드를 오버라이딩하는 리팩토링도 좋을 듯 합니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->