### PR TITLE
fix : Solution content 필드를 varchar(255) -> TEXT로 수정

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/solution/domain/Solution.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/domain/Solution.java
@@ -2,8 +2,10 @@ package com.gamzabat.algohub.feature.solution.domain;
 
 import java.time.LocalDateTime;
 
-import com.gamzabat.algohub.feature.user.domain.User;
 import com.gamzabat.algohub.feature.problem.domain.Problem;
+import com.gamzabat.algohub.feature.user.domain.User;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -32,6 +34,7 @@ public class Solution {
 	private User user;
 
 	private LocalDateTime solvedDateTime;
+	@Column(columnDefinition = "TEXT")
 	private String content;
 	private String result;
 	private Integer memoryUsage;
@@ -41,7 +44,7 @@ public class Solution {
 
 	@Builder
 	public Solution(Problem problem, User user, LocalDateTime solvedDateTime, String content, String result,
-					Integer memoryUsage, Integer executionTime, String language, Integer codeLength) {
+		Integer memoryUsage, Integer executionTime, String language, Integer codeLength) {
 		this.problem = problem;
 		this.user = user;
 		this.solvedDateTime = solvedDateTime;


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
https://github.com/GAMZA-BAT/algohub-server/issues/112

## 🚀 Description
<!-- 작업 내용 -->
- Solution entity의 content 필드를 `TEXT`로 수정했습니다.
- 일반적으로 다른 제한 없이 String으로만 사용하면 `VARCHAR(255)`가 디폴트 입니다.
- `Solution` entity는 코드 내용이 담기는 필드기 때문에 충분히 긴 문자열을 담을 수 있도록 `TEXT`로 수정했습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->