### PR TITLE
feat : 날짜 포매터 전역 적용 

### DIFF
--- a/src/main/java/com/gamzabat/algohub/common/DateFormatUtil.java
+++ b/src/main/java/com/gamzabat/algohub/common/DateFormatUtil.java
@@ -1,0 +1,11 @@
+package com.gamzabat.algohub.common;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public final class DateFormatUtil {
+	public static String formatDate(LocalDate date) {
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+		return date.format(formatter);
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/common/DateFormatUtil.java
+++ b/src/main/java/com/gamzabat/algohub/common/DateFormatUtil.java
@@ -1,11 +1,17 @@
 package com.gamzabat.algohub.common;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 public final class DateFormatUtil {
 	public static String formatDate(LocalDate date) {
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
 		return date.format(formatter);
+	}
+
+	public static String formatDateTime(LocalDateTime dateTime) {
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm:ss");
+		return dateTime.format(formatter);
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/board/dto/GetBoardResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/board/dto/GetBoardResponse.java
@@ -1,7 +1,6 @@
 package com.gamzabat.algohub.feature.board.dto;
 
-import java.time.LocalDateTime;
-
+import com.gamzabat.algohub.common.DateFormatUtil;
 import com.gamzabat.algohub.feature.board.domain.Board;
 
 import lombok.Builder;
@@ -11,7 +10,7 @@ public record GetBoardResponse(String author,
 							   Long boardId,
 							   String boardContent,
 							   String boardTitle,
-							   LocalDateTime createAt) {
+							   String createAt) {
 
 	public static GetBoardResponse toDTO(Board board) {
 		return GetBoardResponse.builder()
@@ -19,7 +18,7 @@ public record GetBoardResponse(String author,
 			.boardId(board.getId())
 			.boardTitle(board.getTitle())
 			.boardContent(board.getContent())
-			.createAt(board.getCreatedAt())
+			.createAt(DateFormatUtil.formatDate(board.getCreatedAt().toLocalDate()))
 			.build();
 
 	}

--- a/src/main/java/com/gamzabat/algohub/feature/board/service/BoardService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/board/service/BoardService.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.gamzabat.algohub.common.DateFormatUtil;
 import com.gamzabat.algohub.common.annotation.AuthedUser;
 import com.gamzabat.algohub.exception.StudyGroupValidationException;
 import com.gamzabat.algohub.exception.UserValidationException;
@@ -71,7 +72,7 @@ public class BoardService {
 			.boardId(board.getId())
 			.boardTitle(board.getTitle())
 			.boardContent(board.getContent())
-			.createAt(board.getCreatedAt())
+			.createAt(DateFormatUtil.formatDate(board.getCreatedAt().toLocalDate()))
 			.build();
 	}
 

--- a/src/main/java/com/gamzabat/algohub/feature/comment/dto/GetCommentResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/comment/dto/GetCommentResponse.java
@@ -1,7 +1,6 @@
 package com.gamzabat.algohub.feature.comment.dto;
 
-import java.time.LocalDateTime;
-
+import com.gamzabat.algohub.common.DateFormatUtil;
 import com.gamzabat.algohub.feature.comment.domain.Comment;
 
 import lombok.Builder;
@@ -11,14 +10,14 @@ public record GetCommentResponse(Long commentId,
 								 String writerNickname,
 								 String writerProfileImage,
 								 String content,
-								 LocalDateTime createdAt) {
+								 String createdAt) {
 	public static GetCommentResponse toDTO(Comment comment) {
 		return GetCommentResponse.builder()
 			.commentId(comment.getId())
 			.writerNickname(comment.getUser().getNickname())
 			.writerProfileImage(comment.getUser().getProfileImage())
 			.content(comment.getContent())
-			.createdAt(comment.getCreatedAt())
+			.createdAt(DateFormatUtil.formatDate(comment.getCreatedAt().toLocalDate()))
 			.build();
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/notification/dto/GetNotificationResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notification/dto/GetNotificationResponse.java
@@ -1,7 +1,6 @@
 package com.gamzabat.algohub.feature.notification.dto;
 
-import java.time.LocalDateTime;
-
+import com.gamzabat.algohub.common.DateFormatUtil;
 import com.gamzabat.algohub.feature.notification.domain.Notification;
 
 public record GetNotificationResponse(Long id,
@@ -9,7 +8,7 @@ public record GetNotificationResponse(Long id,
 									  String groupImage,
 									  String message,
 									  String subContent,
-									  LocalDateTime createdAt,
+									  String createdAt,
 									  boolean isRead) {
 	public static GetNotificationResponse toDTO(Notification notification) {
 		return new GetNotificationResponse(
@@ -18,7 +17,7 @@ public record GetNotificationResponse(Long id,
 			notification.getStudyGroup().getGroupImage(),
 			notification.getMessage(),
 			notification.getSubContent(),
-			notification.getCreatedAt(),
+			DateFormatUtil.formatDate(notification.getCreatedAt().toLocalDate()),
 			notification.isRead()
 		);
 	}

--- a/src/main/java/com/gamzabat/algohub/feature/problem/dto/GetProblemResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/problem/dto/GetProblemResponse.java
@@ -2,6 +2,8 @@ package com.gamzabat.algohub.feature.problem.dto;
 
 import java.time.LocalDate;
 
+import com.gamzabat.algohub.common.DateFormatUtil;
+
 import lombok.Getter;
 
 @Getter
@@ -9,8 +11,8 @@ public class GetProblemResponse {
 	private String title;
 	private Long problemId;
 	private String link;
-	private LocalDate startDate;
-	private LocalDate endDate;
+	private String startDate;
+	private String endDate;
 	private Integer level;
 	private boolean solved;
 	private Integer submitMemberCount;
@@ -24,8 +26,8 @@ public class GetProblemResponse {
 		this.title = title;
 		this.problemId = problemId;
 		this.link = link;
-		this.startDate = startDate;
-		this.endDate = endDate;
+		this.startDate = DateFormatUtil.formatDate(startDate);
+		this.endDate = DateFormatUtil.formatDate(endDate);
 		this.level = level;
 		this.solved = solved;
 		this.submitMemberCount = submissionCount;
@@ -34,21 +36,3 @@ public class GetProblemResponse {
 		this.inProgress = inProgress;
 	}
 }
-/*public record GetProblemResponse(Long problemId,
-								 String link,
-								 String title,
-								 LocalDate deadline,
-								 Integer level,
-								 Integer submissionCount,
-								 Integer memberCount,
-								 Integer accurancy) {
-	public static GetProblemResponse toDTO(Problem problem){
-		return GetProblemResponse.builder()
-			.problemId(problem.getId())
-			.link(problem.getLink())
-			.title(problem.getTitle())
-			.deadline(problem.getDeadline())
-			.level(problem.getLevel())
-			.build();
-	}
-}*/

--- a/src/main/java/com/gamzabat/algohub/feature/solution/dto/GetSolutionResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/dto/GetSolutionResponse.java
@@ -1,7 +1,6 @@
 package com.gamzabat.algohub.feature.solution.dto;
 
-import java.time.format.DateTimeFormatter;
-
+import com.gamzabat.algohub.common.DateFormatUtil;
 import com.gamzabat.algohub.feature.solution.domain.Solution;
 
 import lombok.Builder;
@@ -19,14 +18,11 @@ public record GetSolutionResponse(Long solutionId,
 								  Integer codeLength,
 								  Long commentCount) {
 	public static GetSolutionResponse toDTO(Solution solution, Long commentCount) {
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-		String solvedDateTime = solution.getSolvedDateTime().format(formatter);
-
 		return GetSolutionResponse.builder()
 			.solutionId(solution.getId())
 			.nickname(solution.getUser().getNickname())
 			.profileImage(solution.getUser().getProfileImage())
-			.solvedDateTime(solvedDateTime)
+			.solvedDateTime(DateFormatUtil.formatDate(solution.getSolvedDateTime().toLocalDate()))
 			.content(solution.getContent())
 			.result(solution.getResult())
 			.memoryUsage(solution.getMemoryUsage())

--- a/src/main/java/com/gamzabat/algohub/feature/solution/dto/GetSolutionResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/dto/GetSolutionResponse.java
@@ -22,7 +22,7 @@ public record GetSolutionResponse(Long solutionId,
 			.solutionId(solution.getId())
 			.nickname(solution.getUser().getNickname())
 			.profileImage(solution.getUser().getProfileImage())
-			.solvedDateTime(DateFormatUtil.formatDate(solution.getSolvedDateTime().toLocalDate()))
+			.solvedDateTime(DateFormatUtil.formatDateTime(solution.getSolvedDateTime()))
 			.content(solution.getContent())
 			.result(solution.getResult())
 			.memoryUsage(solution.getMemoryUsage())

--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/dto/GetGroupMemberResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/dto/GetGroupMemberResponse.java
@@ -2,6 +2,7 @@ package com.gamzabat.algohub.feature.studygroup.dto;
 
 import java.time.LocalDate;
 
+import com.gamzabat.algohub.common.DateFormatUtil;
 import com.gamzabat.algohub.feature.studygroup.etc.RoleOfGroupMember;
 
 import lombok.Getter;
@@ -10,7 +11,7 @@ import lombok.Getter;
 public class GetGroupMemberResponse {
 
 	private String nickname;
-	private LocalDate joinDate;
+	private String joinDate;
 	private String achivement;
 	private RoleOfGroupMember role;
 	private String profileImage;
@@ -19,7 +20,7 @@ public class GetGroupMemberResponse {
 	public GetGroupMemberResponse(String nickname, LocalDate joinDate, String achivement, RoleOfGroupMember role,
 		String profileImage, Long memberId) {
 		this.nickname = nickname;
-		this.joinDate = joinDate;
+		this.joinDate = DateFormatUtil.formatDate(joinDate);
 		this.achivement = achivement;
 		this.role = role;
 		this.profileImage = profileImage;

--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/dto/GetGroupResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/dto/GetGroupResponse.java
@@ -2,14 +2,16 @@ package com.gamzabat.algohub.feature.studygroup.dto;
 
 import java.time.LocalDate;
 
+import com.gamzabat.algohub.common.DateFormatUtil;
+
 import lombok.Getter;
 
 @Getter
 public class GetGroupResponse {
 	private Long id;
 	private String name;
-	private LocalDate startDate;
-	private LocalDate endDate;
+	private String startDate;
+	private String endDate;
 	private String introduction;
 	private String groupImage;
 	private Boolean isOwner;
@@ -19,8 +21,8 @@ public class GetGroupResponse {
 		String groupImage, Boolean isOwner, String ownerNickname) {
 		this.id = id;
 		this.name = name;
-		this.startDate = startDate;
-		this.endDate = endDate;
+		this.startDate = DateFormatUtil.formatDate(startDate);
+		this.endDate = DateFormatUtil.formatDate(endDate);
 		this.introduction = introduction;
 		this.groupImage = groupImage;
 		this.isOwner = isOwner;

--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/dto/GetStudyGroupResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/dto/GetStudyGroupResponse.java
@@ -1,15 +1,14 @@
 package com.gamzabat.algohub.feature.studygroup.dto;
 
-import java.time.LocalDate;
-
+import com.gamzabat.algohub.common.DateFormatUtil;
 import com.gamzabat.algohub.feature.studygroup.domain.StudyGroup;
 import com.gamzabat.algohub.feature.user.domain.User;
 
 public record GetStudyGroupResponse(Long id,
 									String name,
 									String groupImage,
-									LocalDate startDate,
-									LocalDate endDate,
+									String startDate,
+									String endDate,
 									String introduction,
 									String ownerNickname,
 									boolean isOwner,
@@ -19,8 +18,8 @@ public record GetStudyGroupResponse(Long id,
 			group.getId(),
 			group.getName(),
 			group.getGroupImage(),
-			group.getStartDate(),
-			group.getEndDate(),
+			DateFormatUtil.formatDate(group.getStartDate()),
+			DateFormatUtil.formatDate(group.getEndDate()),
 			group.getIntroduction(),
 			owner.getNickname(),
 			owner.getId().equals(user.getId()),

--- a/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
@@ -1,23 +1,18 @@
 package com.gamzabat.algohub.feature.studygroup.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.gamzabat.algohub.common.jwt.TokenProvider;
-import com.gamzabat.algohub.config.SpringSecurityConfig;
-import com.gamzabat.algohub.exception.StudyGroupValidationException;
-import com.gamzabat.algohub.exception.UserValidationException;
-import com.gamzabat.algohub.feature.image.service.ImageService;
-import com.gamzabat.algohub.feature.problem.repository.ProblemRepository;
-import com.gamzabat.algohub.feature.solution.exception.CannotFoundSolutionException;
-import com.gamzabat.algohub.feature.solution.repository.SolutionRepository;
-import com.gamzabat.algohub.feature.studygroup.dto.*;
-import com.gamzabat.algohub.feature.studygroup.etc.RoleOfGroupMember;
-import com.gamzabat.algohub.feature.studygroup.exception.CannotFoundGroupException;
-import com.gamzabat.algohub.feature.studygroup.exception.GroupMemberValidationException;
-import com.gamzabat.algohub.feature.studygroup.repository.GroupMemberRepository;
-import com.gamzabat.algohub.feature.studygroup.repository.StudyGroupRepository;
-import com.gamzabat.algohub.feature.studygroup.service.StudyGroupService;
-import com.gamzabat.algohub.feature.user.domain.User;
-import com.gamzabat.algohub.feature.user.repository.UserRepository;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,725 +29,742 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
-import static org.hamcrest.Matchers.hasItems;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gamzabat.algohub.common.DateFormatUtil;
+import com.gamzabat.algohub.common.jwt.TokenProvider;
+import com.gamzabat.algohub.config.SpringSecurityConfig;
+import com.gamzabat.algohub.exception.StudyGroupValidationException;
+import com.gamzabat.algohub.exception.UserValidationException;
+import com.gamzabat.algohub.feature.image.service.ImageService;
+import com.gamzabat.algohub.feature.problem.repository.ProblemRepository;
+import com.gamzabat.algohub.feature.solution.exception.CannotFoundSolutionException;
+import com.gamzabat.algohub.feature.solution.repository.SolutionRepository;
+import com.gamzabat.algohub.feature.studygroup.dto.CheckSolvedProblemResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.CreateGroupRequest;
+import com.gamzabat.algohub.feature.studygroup.dto.CreateGroupResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.EditGroupRequest;
+import com.gamzabat.algohub.feature.studygroup.dto.GetGroupMemberResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.GetStudyGroupListsResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.GetStudyGroupResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.UpdateGroupMemberRoleRequest;
+import com.gamzabat.algohub.feature.studygroup.etc.RoleOfGroupMember;
+import com.gamzabat.algohub.feature.studygroup.exception.CannotFoundGroupException;
+import com.gamzabat.algohub.feature.studygroup.exception.GroupMemberValidationException;
+import com.gamzabat.algohub.feature.studygroup.repository.GroupMemberRepository;
+import com.gamzabat.algohub.feature.studygroup.repository.StudyGroupRepository;
+import com.gamzabat.algohub.feature.studygroup.service.StudyGroupService;
+import com.gamzabat.algohub.feature.user.domain.User;
+import com.gamzabat.algohub.feature.user.repository.UserRepository;
 
 @WebMvcTest(StudyGroupController.class)
 @WithMockUser
 @Import(SpringSecurityConfig.class)
 class StudyGroupControllerTest {
-    private final Long userId = 0L;
-    private final String token = "token";
-    private final Long groupId = 1L;
-    private final String code = "invitationCode";
-    private final Long problemId = 10L;
-    @Autowired
-    private MockMvc mockMvc;
-    @Autowired
-    private ObjectMapper objectMapper;
-    @MockBean
-    private StudyGroupService studyGroupService;
-    @MockBean
-    private StudyGroupRepository studyGroupRepository;
-    @MockBean
-    private GroupMemberRepository groupMemberRepository;
-    @MockBean
-    private ImageService imageService;
-    @MockBean
-    private SolutionRepository solutionRepository;
-    @MockBean
-    private ProblemRepository problemRepository;
-    @MockBean
-    private TokenProvider tokenProvider;
-    @MockBean
-    private UserRepository userRepository;
-    private User user;
+	private final Long userId = 0L;
+	private final String token = "token";
+	private final Long groupId = 1L;
+	private final String code = "invitationCode";
+	private final Long problemId = 10L;
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@MockBean
+	private StudyGroupService studyGroupService;
+	@MockBean
+	private StudyGroupRepository studyGroupRepository;
+	@MockBean
+	private GroupMemberRepository groupMemberRepository;
+	@MockBean
+	private ImageService imageService;
+	@MockBean
+	private SolutionRepository solutionRepository;
+	@MockBean
+	private ProblemRepository problemRepository;
+	@MockBean
+	private TokenProvider tokenProvider;
+	@MockBean
+	private UserRepository userRepository;
+	private User user;
 
-    @BeforeEach
-    void setUp() {
-        user = User.builder().email("email").password("password").build();
-        when(tokenProvider.getUserEmail(token)).thenReturn("email");
-        when(userRepository.findByEmail("email")).thenReturn(Optional.ofNullable(user));
-    }
+	@BeforeEach
+	void setUp() {
+		user = User.builder().email("email").password("password").build();
+		when(tokenProvider.getUserEmail(token)).thenReturn("email");
+		when(userRepository.findByEmail("email")).thenReturn(Optional.ofNullable(user));
+	}
 
-    @Test
-    @DisplayName("그룹 생성 성공")
-    void createGroup() throws Exception {
-        // given
-        CreateGroupRequest request = new CreateGroupRequest("name", LocalDate.now(), LocalDate.now().plusDays(30),
-                "introduction");
-        CreateGroupResponse response = new CreateGroupResponse("inviteCode");
-        MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
-                objectMapper.writeValueAsString(request).getBytes());
-        MockMultipartFile profileImage = new MockMultipartFile("profileImage", "profile.jpg", "image/jpeg",
-                "image".getBytes());
-        when(studyGroupService.createGroup(any(User.class), any(CreateGroupRequest.class),
-                any(MultipartFile.class))).thenReturn(response);
-        // when, then
-        mockMvc.perform(multipart("/api/group")
-                        .file(requestPart)
-                        .file(profileImage)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .header("Authorization", token)
-                        .with(request1 -> {
-                            request1.setMethod("POST");
-                            return request1;
-                        }))
-                .andExpect(status().isOk())
-                .andExpect(content().json(objectMapper.writeValueAsString(response)));
+	@Test
+	@DisplayName("그룹 생성 성공")
+	void createGroup() throws Exception {
+		// given
+		CreateGroupRequest request = new CreateGroupRequest("name", LocalDate.now(), LocalDate.now().plusDays(30),
+			"introduction");
+		CreateGroupResponse response = new CreateGroupResponse("inviteCode");
+		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
+			objectMapper.writeValueAsString(request).getBytes());
+		MockMultipartFile profileImage = new MockMultipartFile("profileImage", "profile.jpg", "image/jpeg",
+			"image".getBytes());
+		when(studyGroupService.createGroup(any(User.class), any(CreateGroupRequest.class),
+			any(MultipartFile.class))).thenReturn(response);
+		// when, then
+		mockMvc.perform(multipart("/api/group")
+				.file(requestPart)
+				.file(profileImage)
+				.contentType(MediaType.MULTIPART_FORM_DATA)
+				.header("Authorization", token)
+				.with(request1 -> {
+					request1.setMethod("POST");
+					return request1;
+				}))
+			.andExpect(status().isOk())
+			.andExpect(content().json(objectMapper.writeValueAsString(response)));
 
-        verify(studyGroupService, times(1)).createGroup(user, request, profileImage);
-    }
+		verify(studyGroupService, times(1)).createGroup(user, request, profileImage);
+	}
 
-    @ParameterizedTest
-    @CsvSource(value = {
-            "'', '2024-07-01', '2024-07-29','', name : 스터디 이름은 1글자 이상 15글자 이하로 작성해야 합니다.",
-            "name, null, '2024-07-29','', startDate : 스터디 시작 날짜는 필수 입력 입니다.",
-            "name, '2024-07-01',null,'', endDate : 스터디 종료 날짜는 필수 입력 입니다."
-    }, nullValues = "null")
-    @DisplayName("그룹 생성 실패 : 잘못된 요청")
-    void createGroupFailed_1(String name, LocalDate startDate, LocalDate endDate, String introduction,
-                             String exceptionMessage) throws Exception {
-        // given
-        CreateGroupRequest request = new CreateGroupRequest(name, startDate, endDate, introduction);
-        MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
-                objectMapper.writeValueAsString(request).getBytes());
-        MockMultipartFile profileImage = new MockMultipartFile("profileImage", "profile.jpg", "image/jpeg",
-                "image".getBytes());
-        // when, then
-        mockMvc.perform(multipart("/api/group")
-                        .file(requestPart)
-                        .file(profileImage)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .header("Authorization", token)
-                        .with(request1 -> {
-                            request1.setMethod("POST");
-                            return request1;
-                        }))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("그룹 생성 요청이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.messages", hasItems(exceptionMessage)));
-    }
+	@ParameterizedTest
+	@CsvSource(value = {
+		"'', '2024-07-01', '2024-07-29','', name : 스터디 이름은 1글자 이상 15글자 이하로 작성해야 합니다.",
+		"name, null, '2024-07-29','', startDate : 스터디 시작 날짜는 필수 입력 입니다.",
+		"name, '2024-07-01',null,'', endDate : 스터디 종료 날짜는 필수 입력 입니다."
+	}, nullValues = "null")
+	@DisplayName("그룹 생성 실패 : 잘못된 요청")
+	void createGroupFailed_1(String name, LocalDate startDate, LocalDate endDate, String introduction,
+		String exceptionMessage) throws Exception {
+		// given
+		CreateGroupRequest request = new CreateGroupRequest(name, startDate, endDate, introduction);
+		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
+			objectMapper.writeValueAsString(request).getBytes());
+		MockMultipartFile profileImage = new MockMultipartFile("profileImage", "profile.jpg", "image/jpeg",
+			"image".getBytes());
+		// when, then
+		mockMvc.perform(multipart("/api/group")
+				.file(requestPart)
+				.file(profileImage)
+				.contentType(MediaType.MULTIPART_FORM_DATA)
+				.header("Authorization", token)
+				.with(request1 -> {
+					request1.setMethod("POST");
+					return request1;
+				}))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("그룹 생성 요청이 올바르지 않습니다."))
+			.andExpect(jsonPath("$.messages", hasItems(exceptionMessage)));
+	}
 
-    @Test
-    @DisplayName("그룹 코드를 사용해 그룹 참여 성공")
-    void joinGroupWithCode() throws Exception {
-        // given
-        doNothing().when(studyGroupService).joinGroupWithCode(any(User.class), anyString());
-        // when, then
-        mockMvc.perform(post("/api/group/{code}/join", code)
-                        .header("Authorization", token)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().string("OK"));
+	@Test
+	@DisplayName("그룹 코드를 사용해 그룹 참여 성공")
+	void joinGroupWithCode() throws Exception {
+		// given
+		doNothing().when(studyGroupService).joinGroupWithCode(any(User.class), anyString());
+		// when, then
+		mockMvc.perform(post("/api/group/{code}/join", code)
+				.header("Authorization", token)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().string("OK"));
 
-        verify(studyGroupService, times(1)).joinGroupWithCode(user, code);
-    }
+		verify(studyGroupService, times(1)).joinGroupWithCode(user, code);
+	}
 
-    @Test
-    @DisplayName("그룹 코드를 사용해 그룹 참여 실패 : 존재하지 않는 그룹")
-    void joinGroupWithCodeFailed_1() throws Exception {
-        // given
-        doThrow(new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다.")).when(
-                studyGroupService).joinGroupWithCode(any(User.class), anyString());
-        // when, then
-        mockMvc.perform(post("/api/group/{code}/join", code)
-                        .header("Authorization", token)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.error").value("존재하지 않는 그룹 입니다."));
+	@Test
+	@DisplayName("그룹 코드를 사용해 그룹 참여 실패 : 존재하지 않는 그룹")
+	void joinGroupWithCodeFailed_1() throws Exception {
+		// given
+		doThrow(new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다.")).when(
+			studyGroupService).joinGroupWithCode(any(User.class), anyString());
+		// when, then
+		mockMvc.perform(post("/api/group/{code}/join", code)
+				.header("Authorization", token)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.error").value("존재하지 않는 그룹 입니다."));
 
-        verify(studyGroupService, times(1)).joinGroupWithCode(user, code);
-    }
+		verify(studyGroupService, times(1)).joinGroupWithCode(user, code);
+	}
 
-    @Test
-    @DisplayName("그룹 코드를 사용해 그룹 참여 실패 : 이미 참여한 그룹")
-    void joinGroupWithCodeFailed_2() throws Exception {
-        // given
-        doThrow(new StudyGroupValidationException(HttpStatus.BAD_REQUEST.value(), "이미 참여한 그룹 입니다.")).when(
-                studyGroupService).joinGroupWithCode(any(User.class), anyString());
-        // when, then
-        mockMvc.perform(post("/api/group/{code}/join", code)
-                        .header("Authorization", token)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("이미 참여한 그룹 입니다."));
+	@Test
+	@DisplayName("그룹 코드를 사용해 그룹 참여 실패 : 이미 참여한 그룹")
+	void joinGroupWithCodeFailed_2() throws Exception {
+		// given
+		doThrow(new StudyGroupValidationException(HttpStatus.BAD_REQUEST.value(), "이미 참여한 그룹 입니다.")).when(
+			studyGroupService).joinGroupWithCode(any(User.class), anyString());
+		// when, then
+		mockMvc.perform(post("/api/group/{code}/join", code)
+				.header("Authorization", token)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("이미 참여한 그룹 입니다."));
 
-        verify(studyGroupService, times(1)).joinGroupWithCode(user, code);
-    }
+		verify(studyGroupService, times(1)).joinGroupWithCode(user, code);
+	}
 
-    @Test
-    @DisplayName("그룹 목록 조회 성공")
-    void getStudyGroupList() throws Exception {
-        // given
-        List<GetStudyGroupResponse> bookmarked = new ArrayList<>();
-        List<GetStudyGroupResponse> done = new ArrayList<>();
-        List<GetStudyGroupResponse> inProgress = new ArrayList<>();
-        List<GetStudyGroupResponse> queued = new ArrayList<>();
+	@Test
+	@DisplayName("그룹 목록 조회 성공")
+	void getStudyGroupList() throws Exception {
+		// given
+		List<GetStudyGroupResponse> bookmarked = new ArrayList<>();
+		List<GetStudyGroupResponse> done = new ArrayList<>();
+		List<GetStudyGroupResponse> inProgress = new ArrayList<>();
+		List<GetStudyGroupResponse> queued = new ArrayList<>();
 
-        for (int i = 0; i < 10; i++) {
-            bookmarked.add(new GetStudyGroupResponse(
-                    (long) i, "name" + i, "groupImage" + 1,
-                    LocalDate.now(), LocalDate.now().plusDays(i),
-                    "introduction" + 1, "nickname", true, true
-            ));
-        }
+		for (int i = 0; i < 10; i++) {
+			bookmarked.add(new GetStudyGroupResponse(
+				(long)i, "name" + i, "groupImage" + 1,
+				DateFormatUtil.formatDate(LocalDate.now()), DateFormatUtil.formatDate(LocalDate.now().plusDays(i)),
+				"introduction" + 1, "nickname", true, true
+			));
+		}
 
-        for (int i = 0; i < 10; i++) {
-            done.add(new GetStudyGroupResponse(
-                    (long) i, "name" + i, "groupImage" + 1,
-                    LocalDate.now(), LocalDate.now().plusDays(i),
-                    "introduction" + 1, "nickname", true, true
-            ));
-        }
-        for (int i = 0; i < 10; i++) {
-            inProgress.add(new GetStudyGroupResponse(
-                    (long) i, "name" + i, "groupImage" + 1,
-                    LocalDate.now(), LocalDate.now().plusDays(i),
-                    "introduction" + 1, "nickname", true, true
-            ));
-        }
-        for (int i = 0; i < 10; i++) {
-            queued.add(new GetStudyGroupResponse(
-                    (long) i, "name" + i, "groupImage" + 1,
-                    LocalDate.now(), LocalDate.now().plusDays(i),
-                    "introduction" + 1, "nickname", true, true
-            ));
-        }
-        GetStudyGroupListsResponse response = new GetStudyGroupListsResponse(bookmarked, done, inProgress, queued);
-        when(studyGroupService.getStudyGroupList(user)).thenReturn(response);
-        // when, then
-        mockMvc.perform(get("/api/group/list")
-                        .header("Authorization", token)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().json(objectMapper.writeValueAsString(response)));
+		for (int i = 0; i < 10; i++) {
+			done.add(new GetStudyGroupResponse(
+				(long)i, "name" + i, "groupImage" + 1,
+				DateFormatUtil.formatDate(LocalDate.now()), DateFormatUtil.formatDate(LocalDate.now().plusDays(i)),
+				"introduction" + 1, "nickname", true, true
+			));
+		}
+		for (int i = 0; i < 10; i++) {
+			inProgress.add(new GetStudyGroupResponse(
+				(long)i, "name" + i, "groupImage" + 1,
+				DateFormatUtil.formatDate(LocalDate.now()), DateFormatUtil.formatDate(LocalDate.now().plusDays(i)),
+				"introduction" + 1, "nickname", true, true
+			));
+		}
+		for (int i = 0; i < 10; i++) {
+			queued.add(new GetStudyGroupResponse(
+				(long)i, "name" + i, "groupImage" + 1,
+				DateFormatUtil.formatDate(LocalDate.now()), DateFormatUtil.formatDate(LocalDate.now().plusDays(i)),
+				"introduction" + 1, "nickname", true, true
+			));
+		}
+		GetStudyGroupListsResponse response = new GetStudyGroupListsResponse(bookmarked, done, inProgress, queued);
+		when(studyGroupService.getStudyGroupList(user)).thenReturn(response);
+		// when, then
+		mockMvc.perform(get("/api/group/list")
+				.header("Authorization", token)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().json(objectMapper.writeValueAsString(response)));
 
-        verify(studyGroupService, times(1)).getStudyGroupList(any(User.class));
-    }
+		verify(studyGroupService, times(1)).getStudyGroupList(any(User.class));
+	}
 
-    @Test
-    @DisplayName("그룹 탈퇴 성공")
-    void leaveGroup() throws Exception {
-        // given
-        doNothing().when(studyGroupService).deleteGroup(user, groupId);
-        // when, then
-        mockMvc.perform(delete("/api/group/leave")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().string("OK"));
+	@Test
+	@DisplayName("그룹 탈퇴 성공")
+	void leaveGroup() throws Exception {
+		// given
+		doNothing().when(studyGroupService).deleteGroup(user, groupId);
+		// when, then
+		mockMvc.perform(delete("/api/group/leave")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().string("OK"));
 
-        verify(studyGroupService, times(1)).deleteGroup(any(User.class), anyLong());
-    }
+		verify(studyGroupService, times(1)).deleteGroup(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("그룹 탈퇴 실패 : 존재하지 않는 그룹")
-    void leaveGroupFailed_1() throws Exception {
-        // given
-        doThrow(new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다.")).when(
-                studyGroupService).deleteGroup(user, groupId);
-        // when, then
-        mockMvc.perform(delete("/api/group/leave")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.error").value("존재하지 않는 그룹 입니다."));
+	@Test
+	@DisplayName("그룹 탈퇴 실패 : 존재하지 않는 그룹")
+	void leaveGroupFailed_1() throws Exception {
+		// given
+		doThrow(new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다.")).when(
+			studyGroupService).deleteGroup(user, groupId);
+		// when, then
+		mockMvc.perform(delete("/api/group/leave")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.error").value("존재하지 않는 그룹 입니다."));
 
-        verify(studyGroupService, times(1)).deleteGroup(any(User.class), anyLong());
-    }
+		verify(studyGroupService, times(1)).deleteGroup(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("그룹 탈퇴 실패 : 이미 참여 안한 그룹")
-    void leaveGroupFailed_2() throws Exception {
-        // given
-        doThrow(new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "이미 참여하지 않은 그룹 입니다.")).when(
-                studyGroupService).deleteGroup(user, groupId);
-        // when, then
-        mockMvc.perform(delete("/api/group/leave")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("이미 참여하지 않은 그룹 입니다."));
+	@Test
+	@DisplayName("그룹 탈퇴 실패 : 이미 참여 안한 그룹")
+	void leaveGroupFailed_2() throws Exception {
+		// given
+		doThrow(new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "이미 참여하지 않은 그룹 입니다.")).when(
+			studyGroupService).deleteGroup(user, groupId);
+		// when, then
+		mockMvc.perform(delete("/api/group/leave")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("이미 참여하지 않은 그룹 입니다."));
 
-        verify(studyGroupService, times(1)).deleteGroup(any(User.class), anyLong());
-    }
+		verify(studyGroupService, times(1)).deleteGroup(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("그룹 멤버 삭제 성공")
-    void deleteUser() throws Exception {
-        // given
-        doNothing().when(studyGroupService).deleteMember(any(User.class), anyLong(), anyLong());
-        // when, then
-        mockMvc.perform(delete("/api/group/delete")
-                        .header("Authorization", token)
-                        .param("userId", String.valueOf(userId))
-                        .param("groupId", String.valueOf(groupId))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().string("OK"));
-        verify(studyGroupService, times(1)).deleteMember(user, userId, groupId);
-    }
+	@Test
+	@DisplayName("그룹 멤버 삭제 성공")
+	void deleteUser() throws Exception {
+		// given
+		doNothing().when(studyGroupService).deleteMember(any(User.class), anyLong(), anyLong());
+		// when, then
+		mockMvc.perform(delete("/api/group/delete")
+				.header("Authorization", token)
+				.param("userId", String.valueOf(userId))
+				.param("groupId", String.valueOf(groupId))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().string("OK"));
+		verify(studyGroupService, times(1)).deleteMember(user, userId, groupId);
+	}
 
-    @Test
-    @DisplayName("그룹 탈퇴 실패 : 참여하지 않은 그룹")
-    void deleteMemberFailed_1() throws Exception {
-        // given
-        doThrow(new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(),
-                "멤버 삭제 권한이 없습니다. : 참여하지 않은 그룹 입니다.")).when(
-                studyGroupService).deleteGroup(user, groupId);
-        // when, then
-        mockMvc.perform(delete("/api/group/leave")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("멤버 삭제 권한이 없습니다. : 참여하지 않은 그룹 입니다."));
-    }
+	@Test
+	@DisplayName("그룹 탈퇴 실패 : 참여하지 않은 그룹")
+	void deleteMemberFailed_1() throws Exception {
+		// given
+		doThrow(new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(),
+			"멤버 삭제 권한이 없습니다. : 참여하지 않은 그룹 입니다.")).when(
+			studyGroupService).deleteGroup(user, groupId);
+		// when, then
+		mockMvc.perform(delete("/api/group/leave")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("멤버 삭제 권한이 없습니다. : 참여하지 않은 그룹 입니다."));
+	}
 
-    @Test
-    @DisplayName("그룹 탈퇴 실패 : 권한 없음")
-    void deleteMemberFailed_2() throws Exception {
-        // given
-        doThrow(new UserValidationException("멤버를 삭제 할 권한이 없습니다.")).when(
-                studyGroupService).deleteGroup(user, groupId);
-        // when, then
-        mockMvc.perform(delete("/api/group/leave")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("멤버를 삭제 할 권한이 없습니다."));
-    }
+	@Test
+	@DisplayName("그룹 탈퇴 실패 : 권한 없음")
+	void deleteMemberFailed_2() throws Exception {
+		// given
+		doThrow(new UserValidationException("멤버를 삭제 할 권한이 없습니다.")).when(
+			studyGroupService).deleteGroup(user, groupId);
+		// when, then
+		mockMvc.perform(delete("/api/group/leave")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("멤버를 삭제 할 권한이 없습니다."));
+	}
 
-    @Test
-    @DisplayName("그룹 정보 수정 성공")
-    void editGroup() throws Exception {
-        // given
-        EditGroupRequest request = new EditGroupRequest(groupId, "name", LocalDate.now(), LocalDate.now().plusDays(30),
-                "editedIntroduction");
-        MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
-                objectMapper.writeValueAsBytes(request));
-        MockMultipartFile groupImage = new MockMultipartFile("groupImage", "group.jpg", "image/jpeg",
-                "image".getBytes());
-        doNothing().when(studyGroupService)
-                .editGroup(any(User.class), any(EditGroupRequest.class), any(MultipartFile.class));
-        // when, then
-        mockMvc.perform(multipart("/api/group")
-                        .file(requestPart)
-                        .file(groupImage) // 파라미터 이름이랑 똑같이 해줘야 함
-                        .header("Authorization", token)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .with(request1 -> {
-                            request1.setMethod("PATCH");
-                            return request1;
-                        }))
-                .andExpect(status().isOk())
-                .andExpect(content().string("OK"));
+	@Test
+	@DisplayName("그룹 정보 수정 성공")
+	void editGroup() throws Exception {
+		// given
+		EditGroupRequest request = new EditGroupRequest(groupId, "name", LocalDate.now(), LocalDate.now().plusDays(30),
+			"editedIntroduction");
+		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
+			objectMapper.writeValueAsBytes(request));
+		MockMultipartFile groupImage = new MockMultipartFile("groupImage", "group.jpg", "image/jpeg",
+			"image".getBytes());
+		doNothing().when(studyGroupService)
+			.editGroup(any(User.class), any(EditGroupRequest.class), any(MultipartFile.class));
+		// when, then
+		mockMvc.perform(multipart("/api/group")
+				.file(requestPart)
+				.file(groupImage) // 파라미터 이름이랑 똑같이 해줘야 함
+				.header("Authorization", token)
+				.contentType(MediaType.MULTIPART_FORM_DATA)
+				.with(request1 -> {
+					request1.setMethod("PATCH");
+					return request1;
+				}))
+			.andExpect(status().isOk())
+			.andExpect(content().string("OK"));
 
-        verify(studyGroupService, times(1)).editGroup(any(User.class), any(EditGroupRequest.class),
-                any(MultipartFile.class));
-    }
+		verify(studyGroupService, times(1)).editGroup(any(User.class), any(EditGroupRequest.class),
+			any(MultipartFile.class));
+	}
 
-    @Test
-    @DisplayName("그룹 정보 수정 실패 : 잘못된 요청__잘못된 id")
-    void editGroupFailed_1() throws Exception {
-        // given
-        EditGroupRequest request = new EditGroupRequest(null, "name", LocalDate.now(), LocalDate.now().plusDays(30),
-                "editedIntroduction");
-        MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
-                objectMapper.writeValueAsBytes(request));
-        MockMultipartFile groupImage = new MockMultipartFile("groupImage", "group.jpg", "image/jpeg",
-                "image".getBytes());
-        // when, then
-        mockMvc.perform(multipart("/api/group")
-                        .file(requestPart)
-                        .file(groupImage)
-                        .header("Authorization", token)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .with(request1 -> {
-                            request1.setMethod("PATCH");
-                            return request1;
-                        }))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("그룹 정보 수정 요청이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.messages", hasItems("id : 그룹 고유 아이디는 필수 입력 입니다.")));
-    }
+	@Test
+	@DisplayName("그룹 정보 수정 실패 : 잘못된 요청__잘못된 id")
+	void editGroupFailed_1() throws Exception {
+		// given
+		EditGroupRequest request = new EditGroupRequest(null, "name", LocalDate.now(), LocalDate.now().plusDays(30),
+			"editedIntroduction");
+		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
+			objectMapper.writeValueAsBytes(request));
+		MockMultipartFile groupImage = new MockMultipartFile("groupImage", "group.jpg", "image/jpeg",
+			"image".getBytes());
+		// when, then
+		mockMvc.perform(multipart("/api/group")
+				.file(requestPart)
+				.file(groupImage)
+				.header("Authorization", token)
+				.contentType(MediaType.MULTIPART_FORM_DATA)
+				.with(request1 -> {
+					request1.setMethod("PATCH");
+					return request1;
+				}))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("그룹 정보 수정 요청이 올바르지 않습니다."))
+			.andExpect(jsonPath("$.messages", hasItems("id : 그룹 고유 아이디는 필수 입력 입니다.")));
+	}
 
-    @Test
-    @DisplayName("그룹 정보 수정 실패 : 잘못된 요청__스터디 이름이 15글자 초과")
-    void editGroupFailed_nameTooLong() throws Exception {
-        // given
-        EditGroupRequest request = new EditGroupRequest(1L, "이름이너무긴스터디이름이네요하하", LocalDate.now(), LocalDate.now().plusDays(30),
-                "editedIntroduction"); // 16글자
-        MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
-                objectMapper.writeValueAsBytes(request));
-        MockMultipartFile groupImage = new MockMultipartFile("groupImage", "group.jpg", "image/jpeg",
-                "image".getBytes());
+	@Test
+	@DisplayName("그룹 정보 수정 실패 : 잘못된 요청__스터디 이름이 15글자 초과")
+	void editGroupFailed_nameTooLong() throws Exception {
+		// given
+		EditGroupRequest request = new EditGroupRequest(1L, "이름이너무긴스터디이름이네요하하", LocalDate.now(),
+			LocalDate.now().plusDays(30),
+			"editedIntroduction"); // 16글자
+		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
+			objectMapper.writeValueAsBytes(request));
+		MockMultipartFile groupImage = new MockMultipartFile("groupImage", "group.jpg", "image/jpeg",
+			"image".getBytes());
 
-        // when, then
-        mockMvc.perform(multipart("/api/group")
-                        .file(requestPart)
-                        .file(groupImage)
-                        .header("Authorization", token)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .with(request1 -> {
-                            request1.setMethod("PATCH");
-                            return request1;
-                        }))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("그룹 정보 수정 요청이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.messages", hasItems("name : 스터디 이름은 1글자 이상 15글자 이하로 작성해야 합니다.")));
-    }
+		// when, then
+		mockMvc.perform(multipart("/api/group")
+				.file(requestPart)
+				.file(groupImage)
+				.header("Authorization", token)
+				.contentType(MediaType.MULTIPART_FORM_DATA)
+				.with(request1 -> {
+					request1.setMethod("PATCH");
+					return request1;
+				}))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("그룹 정보 수정 요청이 올바르지 않습니다."))
+			.andExpect(jsonPath("$.messages", hasItems("name : 스터디 이름은 1글자 이상 15글자 이하로 작성해야 합니다.")));
+	}
 
-    @Test
-    @DisplayName("그룹 정보 수정 실패 : 존재하지 않는 그룹")
-    void editGroupFailed_2() throws Exception {
-        // given
-        EditGroupRequest request = new EditGroupRequest(groupId, "name", LocalDate.now(), LocalDate.now().plusDays(30),
-                "editedIntroduction");
-        MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
-                objectMapper.writeValueAsBytes(request));
-        MockMultipartFile groupImage = new MockMultipartFile("groupImage", "group.jpg", "image/jpeg",
-                "image".getBytes());
-        doThrow(new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다.")).when(
-                        studyGroupService)
-                .editGroup(any(User.class), any(EditGroupRequest.class), any(MultipartFile.class));
-        // when, then
-        mockMvc.perform(multipart("/api/group")
-                        .file(requestPart)
-                        .file(groupImage)
-                        .header("Authorization", token)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .with(request1 -> {
-                            request1.setMethod("PATCH");
-                            return request1;
-                        }))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.error").value("존재하지 않는 그룹 입니다."));
+	@Test
+	@DisplayName("그룹 정보 수정 실패 : 존재하지 않는 그룹")
+	void editGroupFailed_2() throws Exception {
+		// given
+		EditGroupRequest request = new EditGroupRequest(groupId, "name", LocalDate.now(), LocalDate.now().plusDays(30),
+			"editedIntroduction");
+		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
+			objectMapper.writeValueAsBytes(request));
+		MockMultipartFile groupImage = new MockMultipartFile("groupImage", "group.jpg", "image/jpeg",
+			"image".getBytes());
+		doThrow(new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다.")).when(
+				studyGroupService)
+			.editGroup(any(User.class), any(EditGroupRequest.class), any(MultipartFile.class));
+		// when, then
+		mockMvc.perform(multipart("/api/group")
+				.file(requestPart)
+				.file(groupImage)
+				.header("Authorization", token)
+				.contentType(MediaType.MULTIPART_FORM_DATA)
+				.with(request1 -> {
+					request1.setMethod("PATCH");
+					return request1;
+				}))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.error").value("존재하지 않는 그룹 입니다."));
 
-        verify(studyGroupService, times(1)).editGroup(any(User.class), any(EditGroupRequest.class),
-                any(MultipartFile.class));
-    }
+		verify(studyGroupService, times(1)).editGroup(any(User.class), any(EditGroupRequest.class),
+			any(MultipartFile.class));
+	}
 
-    @Test
-    @DisplayName("그룹 정보 수정 실패 : 권한 없음")
-    void editGroupFailed_3() throws Exception {
-        // given
-        EditGroupRequest request = new EditGroupRequest(groupId, "name", LocalDate.now(), LocalDate.now().plusDays(30),
-                "editedIntroduction");
-        MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
-                objectMapper.writeValueAsBytes(request));
-        MockMultipartFile groupImage = new MockMultipartFile("groupImage", "group.jpg", "image/jpeg",
-                "image".getBytes());
-        doThrow(new StudyGroupValidationException(HttpStatus.FORBIDDEN.value(), "그룹 정보 수정에 대한 권한이 없습니다.")).when(
-                        studyGroupService)
-                .editGroup(any(User.class), any(EditGroupRequest.class), any(MultipartFile.class));
-        // when, then
-        mockMvc.perform(multipart("/api/group")
-                        .file(requestPart)
-                        .file(groupImage)
-                        .header("Authorization", token)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .with(request1 -> {
-                            request1.setMethod("PATCH");
-                            return request1;
-                        }))
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.error").value("그룹 정보 수정에 대한 권한이 없습니다."));
+	@Test
+	@DisplayName("그룹 정보 수정 실패 : 권한 없음")
+	void editGroupFailed_3() throws Exception {
+		// given
+		EditGroupRequest request = new EditGroupRequest(groupId, "name", LocalDate.now(), LocalDate.now().plusDays(30),
+			"editedIntroduction");
+		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
+			objectMapper.writeValueAsBytes(request));
+		MockMultipartFile groupImage = new MockMultipartFile("groupImage", "group.jpg", "image/jpeg",
+			"image".getBytes());
+		doThrow(new StudyGroupValidationException(HttpStatus.FORBIDDEN.value(), "그룹 정보 수정에 대한 권한이 없습니다.")).when(
+				studyGroupService)
+			.editGroup(any(User.class), any(EditGroupRequest.class), any(MultipartFile.class));
+		// when, then
+		mockMvc.perform(multipart("/api/group")
+				.file(requestPart)
+				.file(groupImage)
+				.header("Authorization", token)
+				.contentType(MediaType.MULTIPART_FORM_DATA)
+				.with(request1 -> {
+					request1.setMethod("PATCH");
+					return request1;
+				}))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.error").value("그룹 정보 수정에 대한 권한이 없습니다."));
 
-        verify(studyGroupService, times(1)).editGroup(any(User.class), any(EditGroupRequest.class),
-                any(MultipartFile.class));
-    }
+		verify(studyGroupService, times(1)).editGroup(any(User.class), any(EditGroupRequest.class),
+			any(MultipartFile.class));
+	}
 
-    @Test
-    @DisplayName("그룹 회원 목록 조회 성공")
-    void getGroupInfo() throws Exception {
-        // given
-        List<GetGroupMemberResponse> response = new ArrayList<>(30);
-        for (int i = 0; i < 30; i++) {
-            response.add(new GetGroupMemberResponse(
-                    "name" + i, LocalDate.now(), "70%", RoleOfGroupMember.ADMIN, "profileImage" + i, (long) i
-            ));
-        }
-        when(studyGroupService.getGroupMemberList(user, groupId)).thenReturn(response);
-        // when, then
-        mockMvc.perform(get("/api/group/member-list")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId)))
-                .andExpect(status().isOk())
-                .andExpect(content().json(objectMapper.writeValueAsString(response)));
+	@Test
+	@DisplayName("그룹 회원 목록 조회 성공")
+	void getGroupInfo() throws Exception {
+		// given
+		List<GetGroupMemberResponse> response = new ArrayList<>(30);
+		for (int i = 0; i < 30; i++) {
+			response.add(new GetGroupMemberResponse(
+				"name" + i, LocalDate.now(), "70%", RoleOfGroupMember.ADMIN, "profileImage" + i, (long)i
+			));
+		}
+		when(studyGroupService.getGroupMemberList(user, groupId)).thenReturn(response);
+		// when, then
+		mockMvc.perform(get("/api/group/member-list")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isOk())
+			.andExpect(content().json(objectMapper.writeValueAsString(response)));
 
-        verify(studyGroupService, times(1)).getGroupMemberList(any(User.class), anyLong());
-    }
+		verify(studyGroupService, times(1)).getGroupMemberList(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("그룹 회원 목록 조회 실패 : 존재하지 않는 그룹")
-    void getGroupInfoFailed_1() throws Exception {
-        // given
-        when(studyGroupService.getGroupMemberList(user, groupId)).thenThrow(
-                new CannotFoundGroupException("그룹을 찾을 수 없습니다."));
-        // when, then
-        mockMvc.perform(get("/api/group/member-list")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId)))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.error").value("그룹을 찾을 수 없습니다."));
+	@Test
+	@DisplayName("그룹 회원 목록 조회 실패 : 존재하지 않는 그룹")
+	void getGroupInfoFailed_1() throws Exception {
+		// given
+		when(studyGroupService.getGroupMemberList(user, groupId)).thenThrow(
+			new CannotFoundGroupException("그룹을 찾을 수 없습니다."));
+		// when, then
+		mockMvc.perform(get("/api/group/member-list")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.error").value("그룹을 찾을 수 없습니다."));
 
-        verify(studyGroupService, times(1)).getGroupMemberList(any(User.class), anyLong());
-    }
+		verify(studyGroupService, times(1)).getGroupMemberList(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("그룹 회원 목록 조회 실패 : 권한 없음")
-    void getGroupInfoFailed_2() throws Exception {
-        // given
-        when(studyGroupService.getGroupMemberList(user, groupId)).thenThrow(
-                new GroupMemberValidationException(HttpStatus.FORBIDDEN.value(), "그룹 내용을 확인할 권한이 없습니다"));
-        // when, then
-        mockMvc.perform(get("/api/group/member-list")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId)))
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.error").value("그룹 내용을 확인할 권한이 없습니다"));
+	@Test
+	@DisplayName("그룹 회원 목록 조회 실패 : 권한 없음")
+	void getGroupInfoFailed_2() throws Exception {
+		// given
+		when(studyGroupService.getGroupMemberList(user, groupId)).thenThrow(
+			new GroupMemberValidationException(HttpStatus.FORBIDDEN.value(), "그룹 내용을 확인할 권한이 없습니다"));
+		// when, then
+		mockMvc.perform(get("/api/group/member-list")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.error").value("그룹 내용을 확인할 권한이 없습니다"));
 
-        verify(studyGroupService, times(1)).getGroupMemberList(any(User.class), anyLong());
-    }
+		verify(studyGroupService, times(1)).getGroupMemberList(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("문제 별 회원 풀이 여부 조회 성공")
-    void getCheckingSolvedProblem() throws Exception {
-        // given
-        List<CheckSolvedProblemResponse> response = new ArrayList<>(30);
-        for (int i = 0; i < 30; i++) {
-            response.add(new CheckSolvedProblemResponse((long) i, "nickname" + i, "profileImage" + i, true));
-        }
-        when(studyGroupService.getCheckingSolvedProblem(any(User.class), anyLong())).thenReturn(response);
-        // when, then
-        mockMvc.perform(get("/api/group/problem-solving")
-                        .header("Authorization", token)
-                        .param("problemId", String.valueOf(problemId)))
-                .andExpect(status().isOk())
-                .andExpect(content().json(objectMapper.writeValueAsString(response)));
-        verify(studyGroupService, times(1)).getCheckingSolvedProblem(any(User.class), anyLong());
-    }
+	@Test
+	@DisplayName("문제 별 회원 풀이 여부 조회 성공")
+	void getCheckingSolvedProblem() throws Exception {
+		// given
+		List<CheckSolvedProblemResponse> response = new ArrayList<>(30);
+		for (int i = 0; i < 30; i++) {
+			response.add(new CheckSolvedProblemResponse((long)i, "nickname" + i, "profileImage" + i, true));
+		}
+		when(studyGroupService.getCheckingSolvedProblem(any(User.class), anyLong())).thenReturn(response);
+		// when, then
+		mockMvc.perform(get("/api/group/problem-solving")
+				.header("Authorization", token)
+				.param("problemId", String.valueOf(problemId)))
+			.andExpect(status().isOk())
+			.andExpect(content().json(objectMapper.writeValueAsString(response)));
+		verify(studyGroupService, times(1)).getCheckingSolvedProblem(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("문제 별 회원 풀이 여부 조회 실패 : 존재하지 않는 문제")
-    void getCheckingSolvedProblemFailed_1() throws Exception {
-        // given
-        when(studyGroupService.getCheckingSolvedProblem(any(User.class), anyLong())).thenThrow(
-                new CannotFoundGroupException("문제를 찾을 수 없습니다."));
-        // when, then
-        mockMvc.perform(get("/api/group/problem-solving")
-                        .header("Authorization", token)
-                        .param("problemId", String.valueOf(problemId)))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.error").value("문제를 찾을 수 없습니다."));
-        verify(studyGroupService, times(1)).getCheckingSolvedProblem(any(User.class), anyLong());
-    }
+	@Test
+	@DisplayName("문제 별 회원 풀이 여부 조회 실패 : 존재하지 않는 문제")
+	void getCheckingSolvedProblemFailed_1() throws Exception {
+		// given
+		when(studyGroupService.getCheckingSolvedProblem(any(User.class), anyLong())).thenThrow(
+			new CannotFoundGroupException("문제를 찾을 수 없습니다."));
+		// when, then
+		mockMvc.perform(get("/api/group/problem-solving")
+				.header("Authorization", token)
+				.param("problemId", String.valueOf(problemId)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.error").value("문제를 찾을 수 없습니다."));
+		verify(studyGroupService, times(1)).getCheckingSolvedProblem(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("문제 별 회원 풀이 여부 조회 실패 : 권한 없음")
-    void getCheckingSolvedProblemFailed_2() throws Exception {
-        // given
-        when(studyGroupService.getCheckingSolvedProblem(any(User.class), anyLong())).thenThrow(
-                new UserValidationException("풀이 여부 목록을 확인할 권한이 없습니다."));
-        // when, then
-        mockMvc.perform(get("/api/group/problem-solving")
-                        .header("Authorization", token)
-                        .param("problemId", String.valueOf(problemId)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("풀이 여부 목록을 확인할 권한이 없습니다."));
-        verify(studyGroupService, times(1)).getCheckingSolvedProblem(any(User.class), anyLong());
-    }
+	@Test
+	@DisplayName("문제 별 회원 풀이 여부 조회 실패 : 권한 없음")
+	void getCheckingSolvedProblemFailed_2() throws Exception {
+		// given
+		when(studyGroupService.getCheckingSolvedProblem(any(User.class), anyLong())).thenThrow(
+			new UserValidationException("풀이 여부 목록을 확인할 권한이 없습니다."));
+		// when, then
+		mockMvc.perform(get("/api/group/problem-solving")
+				.header("Authorization", token)
+				.param("problemId", String.valueOf(problemId)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("풀이 여부 목록을 확인할 권한이 없습니다."));
+		verify(studyGroupService, times(1)).getCheckingSolvedProblem(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("그룹 초대 코드 조회 성공")
-    void getGroupCode() throws Exception {
-        // given
-        when(studyGroupService.getGroupCode(user, groupId)).thenReturn(code);
-        // when, then
-        mockMvc.perform(get("/api/group/group-code")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId)))
-                .andExpect(status().isOk())
-                .andExpect(content().string(code));
-        verify(studyGroupService, times(1)).getGroupCode(any(User.class), anyLong());
-    }
+	@Test
+	@DisplayName("그룹 초대 코드 조회 성공")
+	void getGroupCode() throws Exception {
+		// given
+		when(studyGroupService.getGroupCode(user, groupId)).thenReturn(code);
+		// when, then
+		mockMvc.perform(get("/api/group/group-code")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isOk())
+			.andExpect(content().string(code));
+		verify(studyGroupService, times(1)).getGroupCode(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("그룹 초대 코드 조회 실패 : 존재하지 않는 그룹")
-    void getGroupCodeFailed_1() throws Exception {
-        // given
-        when(studyGroupService.getGroupCode(user, groupId)).thenThrow(new CannotFoundGroupException("그룹을 찾지 못했습니다."));
-        // when, then
-        mockMvc.perform(get("/api/group/group-code")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId)))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.error").value("그룹을 찾지 못했습니다."));
-        verify(studyGroupService, times(1)).getGroupCode(any(User.class), anyLong());
-    }
+	@Test
+	@DisplayName("그룹 초대 코드 조회 실패 : 존재하지 않는 그룹")
+	void getGroupCodeFailed_1() throws Exception {
+		// given
+		when(studyGroupService.getGroupCode(user, groupId)).thenThrow(new CannotFoundGroupException("그룹을 찾지 못했습니다."));
+		// when, then
+		mockMvc.perform(get("/api/group/group-code")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.error").value("그룹을 찾지 못했습니다."));
+		verify(studyGroupService, times(1)).getGroupCode(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("그룹 초대 코드 조회 실패 : 권한 없음")
-    void getGroupCodeFailed_2() throws Exception {
-        // given
-        when(studyGroupService.getGroupCode(user, groupId)).thenThrow(
-                new UserValidationException("초대 코드를 조회할 권한이 없습니다."));
-        // when, then
-        mockMvc.perform(get("/api/group/group-code")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("초대 코드를 조회할 권한이 없습니다."));
-        verify(studyGroupService, times(1)).getGroupCode(any(User.class), anyLong());
-    }
+	@Test
+	@DisplayName("그룹 초대 코드 조회 실패 : 권한 없음")
+	void getGroupCodeFailed_2() throws Exception {
+		// given
+		when(studyGroupService.getGroupCode(user, groupId)).thenThrow(
+			new UserValidationException("초대 코드를 조회할 권한이 없습니다."));
+		// when, then
+		mockMvc.perform(get("/api/group/group-code")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("초대 코드를 조회할 권한이 없습니다."));
+		verify(studyGroupService, times(1)).getGroupCode(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("스터디 그룹 즐겨찾기 추가 성공")
-    void updateBookmarked_1() throws Exception {
-        // given
-        when(studyGroupService.updateBookmarkGroup(user, groupId)).thenReturn("스터디 그룹 즐겨찾기 추가 성공");
-        // when, then
-        mockMvc.perform(post("/api/group/bookmark")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId)))
-                .andExpect(status().isOk())
-                .andExpect(content().string("스터디 그룹 즐겨찾기 추가 성공"));
-        verify(studyGroupService, times(1)).updateBookmarkGroup(user, groupId);
-    }
+	@Test
+	@DisplayName("스터디 그룹 즐겨찾기 추가 성공")
+	void updateBookmarked_1() throws Exception {
+		// given
+		when(studyGroupService.updateBookmarkGroup(user, groupId)).thenReturn("스터디 그룹 즐겨찾기 추가 성공");
+		// when, then
+		mockMvc.perform(post("/api/group/bookmark")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isOk())
+			.andExpect(content().string("스터디 그룹 즐겨찾기 추가 성공"));
+		verify(studyGroupService, times(1)).updateBookmarkGroup(user, groupId);
+	}
 
-    @Test
-    @DisplayName("스터디 그룹 즐겨찾기 삭제 성공")
-    void updateBookmarked_2() throws Exception {
-        // given
-        when(studyGroupService.updateBookmarkGroup(user, groupId)).thenReturn("스터디 그룹 즐겨찾기 실패 성공");
-        // when, then
-        mockMvc.perform(post("/api/group/bookmark")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId)))
-                .andExpect(status().isOk())
-                .andExpect(content().string("스터디 그룹 즐겨찾기 실패 성공"));
-        verify(studyGroupService, times(1)).updateBookmarkGroup(user, groupId);
-    }
+	@Test
+	@DisplayName("스터디 그룹 즐겨찾기 삭제 성공")
+	void updateBookmarked_2() throws Exception {
+		// given
+		when(studyGroupService.updateBookmarkGroup(user, groupId)).thenReturn("스터디 그룹 즐겨찾기 실패 성공");
+		// when, then
+		mockMvc.perform(post("/api/group/bookmark")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isOk())
+			.andExpect(content().string("스터디 그룹 즐겨찾기 실패 성공"));
+		verify(studyGroupService, times(1)).updateBookmarkGroup(user, groupId);
+	}
 
-    @Test
-    @DisplayName("스터디 그룹 즐겨찾기 추가/삭제 실패 : 존재하지 않는 그룹")
-    void updateBookmarkedFailed_1() throws Exception {
-        // given
-        when(studyGroupService.updateBookmarkGroup(user, groupId)).thenThrow(
-                new CannotFoundSolutionException("존재하지 않는 그룹 입니다."));
-        // when, then
-        mockMvc.perform(post("/api/group/bookmark")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("존재하지 않는 그룹 입니다."));
-        verify(studyGroupService, times(1)).updateBookmarkGroup(user, groupId);
-    }
+	@Test
+	@DisplayName("스터디 그룹 즐겨찾기 추가/삭제 실패 : 존재하지 않는 그룹")
+	void updateBookmarkedFailed_1() throws Exception {
+		// given
+		when(studyGroupService.updateBookmarkGroup(user, groupId)).thenThrow(
+			new CannotFoundSolutionException("존재하지 않는 그룹 입니다."));
+		// when, then
+		mockMvc.perform(post("/api/group/bookmark")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("존재하지 않는 그룹 입니다."));
+		verify(studyGroupService, times(1)).updateBookmarkGroup(user, groupId);
+	}
 
-    @Test
-    @DisplayName("스터디 그룹 즐겨찾기 추가/삭제 실패 : 참여하지 않은 그룹")
-    void updateBookmarkedFailed_2() throws Exception {
-        // given
-        when(studyGroupService.updateBookmarkGroup(user, groupId)).thenThrow(
-                new StudyGroupValidationException(HttpStatus.BAD_REQUEST.value(), "참여하지 않은 그룹 입니다."));
-        // when, then
-        mockMvc.perform(post("/api/group/bookmark")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("참여하지 않은 그룹 입니다."));
-        verify(studyGroupService, times(1)).updateBookmarkGroup(user, groupId);
-    }
+	@Test
+	@DisplayName("스터디 그룹 즐겨찾기 추가/삭제 실패 : 참여하지 않은 그룹")
+	void updateBookmarkedFailed_2() throws Exception {
+		// given
+		when(studyGroupService.updateBookmarkGroup(user, groupId)).thenThrow(
+			new StudyGroupValidationException(HttpStatus.BAD_REQUEST.value(), "참여하지 않은 그룹 입니다."));
+		// when, then
+		mockMvc.perform(post("/api/group/bookmark")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("참여하지 않은 그룹 입니다."));
+		verify(studyGroupService, times(1)).updateBookmarkGroup(user, groupId);
+	}
 
-    @Test
-    @DisplayName("스터디 그룹 멤버 역할 수정 성공")
-    void updateGroupMemberRole() throws Exception {
-        // given
-        UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
-        // when, then
-        mockMvc.perform(patch("/api/group/role")
-                        .header("Authorization", token)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(content().string("OK"));
-        verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
-    }
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 성공")
+	void updateGroupMemberRole() throws Exception {
+		// given
+		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
+		// when, then
+		mockMvc.perform(patch("/api/group/role")
+				.header("Authorization", token)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(content().string("OK"));
+		verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
+	}
 
-    @Test
-    @DisplayName("스터디 그룹 멤버 역할 수정 실패 : 존재하지 않는 그룹")
-    void updateGroupMemberRoleFailed_1() throws Exception {
-        // given
-        UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
-        doThrow(new CannotFoundSolutionException("존재하지 않는 그룹입니다.")).when(studyGroupService)
-                .updateGroupMemberRole(user, request);
-        // when, then
-        mockMvc.perform(patch("/api/group/role")
-                        .header("Authorization", token)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("존재하지 않는 그룹입니다."));
-        verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
-    }
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 실패 : 존재하지 않는 그룹")
+	void updateGroupMemberRoleFailed_1() throws Exception {
+		// given
+		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
+		doThrow(new CannotFoundSolutionException("존재하지 않는 그룹입니다.")).when(studyGroupService)
+			.updateGroupMemberRole(user, request);
+		// when, then
+		mockMvc.perform(patch("/api/group/role")
+				.header("Authorization", token)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("존재하지 않는 그룹입니다."));
+		verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
+	}
 
-    @Test
-    @DisplayName("스터디 그룹 멤버 역할 수정 실패 : 스터디 그룹 멤버 역할 수정 권한 없음")
-    void updateGroupMemberRoleFailed_2() throws Exception {
-        // given
-        UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
-        doThrow(new StudyGroupValidationException(HttpStatus.FORBIDDEN.value(), "스터디 그룹 멤버 역할을 수정할 권한이 없습니다.")).when(
-                studyGroupService).updateGroupMemberRole(user, request);
-        // when, then
-        mockMvc.perform(patch("/api/group/role")
-                        .header("Authorization", token)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.error").value("스터디 그룹 멤버 역할을 수정할 권한이 없습니다."));
-        verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
-    }
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 실패 : 스터디 그룹 멤버 역할 수정 권한 없음")
+	void updateGroupMemberRoleFailed_2() throws Exception {
+		// given
+		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
+		doThrow(new StudyGroupValidationException(HttpStatus.FORBIDDEN.value(), "스터디 그룹 멤버 역할을 수정할 권한이 없습니다.")).when(
+			studyGroupService).updateGroupMemberRole(user, request);
+		// when, then
+		mockMvc.perform(patch("/api/group/role")
+				.header("Authorization", token)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.error").value("스터디 그룹 멤버 역할을 수정할 권한이 없습니다."));
+		verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
+	}
 
-    @Test
-    @DisplayName("스터디 그룹 멤버 역할 수정 실패 : 존재하지 않는 회원")
-    void updateGroupMemberRoleFailed_3() throws Exception {
-        // given
-        UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
-        doThrow(new UserValidationException("존재하지 않는 회원입니다.")).when(
-                studyGroupService).updateGroupMemberRole(user, request);
-        // when, then
-        mockMvc.perform(patch("/api/group/role")
-                        .header("Authorization", token)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("존재하지 않는 회원입니다."));
-        verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
-    }
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 실패 : 존재하지 않는 회원")
+	void updateGroupMemberRoleFailed_3() throws Exception {
+		// given
+		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
+		doThrow(new UserValidationException("존재하지 않는 회원입니다.")).when(
+			studyGroupService).updateGroupMemberRole(user, request);
+		// when, then
+		mockMvc.perform(patch("/api/group/role")
+				.header("Authorization", token)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("존재하지 않는 회원입니다."));
+		verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
+	}
 
-    @Test
-    @DisplayName("스터디 그룹 멤버 역할 수정 실패 : 스터디 그룹에 참여하지 않은 회원")
-    void updateGroupMemberRoleFailed_4() throws Exception {
-        // given
-        UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
-        doThrow(new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "해당 스터디 그룹에 참여하지 않은 회원입니다.")).when(
-                studyGroupService).updateGroupMemberRole(user, request);
-        // when, then
-        mockMvc.perform(patch("/api/group/role")
-                        .header("Authorization", token)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("해당 스터디 그룹에 참여하지 않은 회원입니다."));
-        verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
-    }
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 실패 : 스터디 그룹에 참여하지 않은 회원")
+	void updateGroupMemberRoleFailed_4() throws Exception {
+		// given
+		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
+		doThrow(new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "해당 스터디 그룹에 참여하지 않은 회원입니다.")).when(
+			studyGroupService).updateGroupMemberRole(user, request);
+		// when, then
+		mockMvc.perform(patch("/api/group/role")
+				.header("Authorization", token)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("해당 스터디 그룹에 참여하지 않은 회원입니다."));
+		verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
+	}
 }

--- a/src/test/java/com/gamzabat/algohub/service/BoardServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/BoardServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Field;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -20,6 +21,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
+import com.gamzabat.algohub.common.DateFormatUtil;
 import com.gamzabat.algohub.enums.Role;
 import com.gamzabat.algohub.exception.StudyGroupValidationException;
 import com.gamzabat.algohub.exception.UserValidationException;
@@ -67,7 +69,13 @@ public class BoardServiceTest {
 		studyGroup = StudyGroup.builder().build();
 		groupMember2 = GroupMember.builder().user(user2).studyGroup(studyGroup).role(ADMIN).build();
 		groupMember3 = GroupMember.builder().user(user3).studyGroup(studyGroup).role(PARTICIPANT).build();
-		board = Board.builder().studyGroup(studyGroup).title("title").content("content").author(user).build();
+		board = Board.builder()
+			.studyGroup(studyGroup)
+			.createdAt(LocalDateTime.now())
+			.title("title")
+			.content("content")
+			.author(user)
+			.build();
 
 		Field userField = User.class.getDeclaredField("id");
 		userField.setAccessible(true);
@@ -166,6 +174,7 @@ public class BoardServiceTest {
 		assertThat(response.author()).isEqualTo("nickname1");
 		assertThat(response.boardContent()).isEqualTo("content");
 		assertThat(response.boardTitle()).isEqualTo("title");
+		assertThat(response.createAt()).isEqualTo(DateFormatUtil.formatDate(LocalDateTime.now().toLocalDate()));
 		assertThat(response.boardId()).isEqualTo(1000L);
 	}
 
@@ -202,10 +211,22 @@ public class BoardServiceTest {
 		List<Board> boardList = new ArrayList<>(10);
 		for (int i = 0; i < 10; i++)
 			boardList.add(
-				board.builder().author(user).content("content" + i).title("title" + i).studyGroup(studyGroup).build());
+				board.builder()
+					.author(user)
+					.content("content" + i)
+					.title("title" + i)
+					.createdAt(LocalDateTime.now())
+					.studyGroup(studyGroup)
+					.build());
 		for (int i = 10; i < 20; i++)
 			boardList.add(
-				board.builder().author(user2).content("content" + i).title("title" + i).studyGroup(studyGroup).build());
+				board.builder()
+					.author(user2)
+					.content("content" + i)
+					.title("title" + i)
+					.createdAt(LocalDateTime.now())
+					.studyGroup(studyGroup)
+					.build());
 		when(studyGroupRepository.findById(30L)).thenReturn(Optional.ofNullable(studyGroup));
 		when(groupMemberRepository.existsByUserAndStudyGroup(user, studyGroup)).thenReturn(true);
 		when(boardRepository.findAllByStudyGroup(studyGroup)).thenReturn(boardList);

--- a/src/test/java/com/gamzabat/algohub/service/CommentServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/CommentServiceTest.java
@@ -212,7 +212,12 @@ class CommentServiceTest {
 		// given
 		List<Comment> list = new ArrayList<>(30);
 		for (int i = 0; i < 30; i++)
-			list.add(Comment.builder().solution(solution).user(user).content("content" + i).build());
+			list.add(Comment.builder()
+				.solution(solution)
+				.createdAt(LocalDateTime.now())
+				.user(user)
+				.content("content" + i)
+				.build());
 		when(solutionRepository.findById(10L)).thenReturn(Optional.ofNullable(solution));
 		when(problemRepository.findById(20L)).thenReturn(Optional.ofNullable(problem));
 		when(studyGroupRepository.findById(30L)).thenReturn(Optional.ofNullable(studyGroup));

--- a/src/test/java/com/gamzabat/algohub/service/ProblemServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/ProblemServiceTest.java
@@ -26,6 +26,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
+import com.gamzabat.algohub.common.DateFormatUtil;
 import com.gamzabat.algohub.enums.Role;
 import com.gamzabat.algohub.exception.ProblemValidationException;
 import com.gamzabat.algohub.exception.StudyGroupValidationException;
@@ -517,13 +518,15 @@ class ProblemServiceTest {
 			assertThat(inProgress.get(i).getProblemId()).isEqualTo(i);
 			assertThat(inProgress.get(i).getLink()).isEqualTo("https://www.acmicpc.net/problem/" + i);
 			assertThat(inProgress.get(i).getTitle()).isEqualTo("title" + i);
-			assertThat(inProgress.get(i).getEndDate()).isEqualTo(LocalDate.now().plusDays(i + 1));
+			assertThat(inProgress.get(i).getEndDate()).isEqualTo(
+				DateFormatUtil.formatDate(LocalDate.now().plusDays(i + 1)));
 		}
 		for (int i = 10; i < 20; i++) {
 			assertThat(expired.get(i - 10).getProblemId()).isEqualTo(i);
 			assertThat(expired.get(i - 10).getLink()).isEqualTo("https://www.acmicpc.net/problem/" + i);
 			assertThat(expired.get(i - 10).getTitle()).isEqualTo("title" + i);
-			assertThat(expired.get(i - 10).getEndDate()).isEqualTo(LocalDate.now().minusDays(i));
+			assertThat(expired.get(i - 10).getEndDate()).isEqualTo(
+				DateFormatUtil.formatDate(LocalDate.now().minusDays(i)));
 		}
 	}
 
@@ -636,8 +639,9 @@ class ProblemServiceTest {
 			assertThat(result.get(i).getProblemId()).isEqualTo(i);
 			assertThat(result.get(i).getLink()).isEqualTo("https://www.acmicpc.net/problem/" + i);
 			assertThat(result.get(i).getTitle()).isEqualTo("title" + i);
-			assertThat(result.get(i).getStartDate()).isEqualTo(LocalDate.now().plusDays(1));
-			assertThat(result.get(i).getEndDate()).isEqualTo(LocalDate.now().plusDays(i + 1));
+			assertThat(result.get(i).getStartDate()).isEqualTo(DateFormatUtil.formatDate(LocalDate.now().plusDays(1)));
+			assertThat(result.get(i).getEndDate()).isEqualTo(
+				DateFormatUtil.formatDate(LocalDate.now().plusDays(i + 1)));
 		}
 	}
 
@@ -675,8 +679,9 @@ class ProblemServiceTest {
 			assertThat(result.get(i).getProblemId()).isEqualTo(i);
 			assertThat(result.get(i).getLink()).isEqualTo("https://www.acmicpc.net/problem/" + i);
 			assertThat(result.get(i).getTitle()).isEqualTo("title" + i);
-			assertThat(result.get(i).getStartDate()).isEqualTo(LocalDate.now().plusDays(1));
-			assertThat(result.get(i).getEndDate()).isEqualTo(LocalDate.now().plusDays(i + 1));
+			assertThat(result.get(i).getStartDate()).isEqualTo(DateFormatUtil.formatDate(LocalDate.now().plusDays(1)));
+			assertThat(result.get(i).getEndDate()).isEqualTo(
+				DateFormatUtil.formatDate(LocalDate.now().plusDays(i + 1)));
 		}
 	}
 

--- a/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 
+import com.gamzabat.algohub.common.DateFormatUtil;
 import com.gamzabat.algohub.enums.Role;
 import com.gamzabat.algohub.exception.ProblemValidationException;
 import com.gamzabat.algohub.exception.StudyGroupValidationException;
@@ -127,7 +128,7 @@ class SolutionServiceTest {
 			assertThat(compileErrorResult.getContent().get(i).nickname()).isEqualTo("nickname1");
 			assertThat(compileErrorResult.getContent().get(i).language()).isEqualTo("Java 11");
 			assertThat(compileErrorResult.getContent().get(i).solvedDateTime()).isEqualTo(
-				fixedDateTime.format(formatter));
+				DateFormatUtil.formatDate(fixedDateTime.toLocalDate()));
 		}
 		for (int i = 5; i < 10; i++) {
 			assertThat(compileErrorResult.getContent().get(i).content()).isEqualTo("content" + i);
@@ -137,7 +138,7 @@ class SolutionServiceTest {
 			assertThat(compileErrorResult.getContent().get(i).nickname()).isEqualTo("nickname2");
 			assertThat(compileErrorResult.getContent().get(i).language()).isEqualTo("C++17");
 			assertThat(compileErrorResult.getContent().get(i).solvedDateTime()).isEqualTo(
-				fixedDateTime.format(formatter));
+				DateFormatUtil.formatDate(fixedDateTime.toLocalDate()));
 		}
 		// 2) 맞았습니다!! 풀이 목록 조회
 		assertThat(correctResult.getContent().size()).isEqualTo(10);
@@ -150,7 +151,7 @@ class SolutionServiceTest {
 			assertThat(correctResult.getContent().get(i).nickname()).isEqualTo("nickname1");
 			assertThat(correctResult.getContent().get(i).language()).isEqualTo("Java 11");
 			assertThat(correctResult.getContent().get(i).solvedDateTime()).isEqualTo(
-				fixedDateTime.format(formatter));
+				DateFormatUtil.formatDate(fixedDateTime.toLocalDate()));
 		}
 		for (int i = 5; i < 10; i++) {
 			assertThat(correctResult.getContent().get(i).content()).isEqualTo("content" + (i + 10));
@@ -160,7 +161,7 @@ class SolutionServiceTest {
 			assertThat(correctResult.getContent().get(i).nickname()).isEqualTo("nickname2");
 			assertThat(correctResult.getContent().get(i).language()).isEqualTo("PyPy3");
 			assertThat(correctResult.getContent().get(i).solvedDateTime()).isEqualTo(
-				fixedDateTime.format(formatter));
+				DateFormatUtil.formatDate(fixedDateTime.toLocalDate()));
 		}
 	}
 
@@ -196,7 +197,7 @@ class SolutionServiceTest {
 			assertThat(result.getContent().get(i).nickname()).isEqualTo("nickname1");
 			assertThat(result.getContent().get(i).language()).isEqualTo("Java 11");
 			assertThat(result.getContent().get(i).solvedDateTime()).isEqualTo(
-				fixedDateTime.format(formatter));
+				DateFormatUtil.formatDate(fixedDateTime.toLocalDate()));
 		}
 	}
 
@@ -271,7 +272,7 @@ class SolutionServiceTest {
 		assertThat(response.language()).isEqualTo("Java");
 		assertThat(response.codeLength()).isEqualTo(10);
 		assertThat(response.commentCount()).isEqualTo(0);
-		assertThat(response.solvedDateTime()).isEqualTo(LocalDateTime.now().format(formatter));
+		assertThat(response.solvedDateTime()).isEqualTo(DateFormatUtil.formatDate(LocalDateTime.now().toLocalDate()));
 	}
 
 	@Test
@@ -303,7 +304,7 @@ class SolutionServiceTest {
 		assertThat(response.language()).isEqualTo("Java");
 		assertThat(response.codeLength()).isEqualTo(10);
 		assertThat(response.commentCount()).isEqualTo(0);
-		assertThat(response.solvedDateTime()).isEqualTo(LocalDateTime.now().format(formatter));
+		assertThat(response.solvedDateTime()).isEqualTo(DateFormatUtil.formatDate(LocalDateTime.now().toLocalDate()));
 	}
 
 	@Test

--- a/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
@@ -128,7 +128,7 @@ class SolutionServiceTest {
 			assertThat(compileErrorResult.getContent().get(i).nickname()).isEqualTo("nickname1");
 			assertThat(compileErrorResult.getContent().get(i).language()).isEqualTo("Java 11");
 			assertThat(compileErrorResult.getContent().get(i).solvedDateTime()).isEqualTo(
-				DateFormatUtil.formatDate(fixedDateTime.toLocalDate()));
+				DateFormatUtil.formatDateTime(fixedDateTime));
 		}
 		for (int i = 5; i < 10; i++) {
 			assertThat(compileErrorResult.getContent().get(i).content()).isEqualTo("content" + i);
@@ -138,7 +138,7 @@ class SolutionServiceTest {
 			assertThat(compileErrorResult.getContent().get(i).nickname()).isEqualTo("nickname2");
 			assertThat(compileErrorResult.getContent().get(i).language()).isEqualTo("C++17");
 			assertThat(compileErrorResult.getContent().get(i).solvedDateTime()).isEqualTo(
-				DateFormatUtil.formatDate(fixedDateTime.toLocalDate()));
+				DateFormatUtil.formatDateTime(fixedDateTime));
 		}
 		// 2) 맞았습니다!! 풀이 목록 조회
 		assertThat(correctResult.getContent().size()).isEqualTo(10);
@@ -151,7 +151,7 @@ class SolutionServiceTest {
 			assertThat(correctResult.getContent().get(i).nickname()).isEqualTo("nickname1");
 			assertThat(correctResult.getContent().get(i).language()).isEqualTo("Java 11");
 			assertThat(correctResult.getContent().get(i).solvedDateTime()).isEqualTo(
-				DateFormatUtil.formatDate(fixedDateTime.toLocalDate()));
+				DateFormatUtil.formatDateTime(fixedDateTime));
 		}
 		for (int i = 5; i < 10; i++) {
 			assertThat(correctResult.getContent().get(i).content()).isEqualTo("content" + (i + 10));
@@ -161,7 +161,7 @@ class SolutionServiceTest {
 			assertThat(correctResult.getContent().get(i).nickname()).isEqualTo("nickname2");
 			assertThat(correctResult.getContent().get(i).language()).isEqualTo("PyPy3");
 			assertThat(correctResult.getContent().get(i).solvedDateTime()).isEqualTo(
-				DateFormatUtil.formatDate(fixedDateTime.toLocalDate()));
+				DateFormatUtil.formatDateTime(fixedDateTime));
 		}
 	}
 
@@ -197,7 +197,7 @@ class SolutionServiceTest {
 			assertThat(result.getContent().get(i).nickname()).isEqualTo("nickname1");
 			assertThat(result.getContent().get(i).language()).isEqualTo("Java 11");
 			assertThat(result.getContent().get(i).solvedDateTime()).isEqualTo(
-				DateFormatUtil.formatDate(fixedDateTime.toLocalDate()));
+				DateFormatUtil.formatDateTime(fixedDateTime));
 		}
 	}
 
@@ -272,7 +272,7 @@ class SolutionServiceTest {
 		assertThat(response.language()).isEqualTo("Java");
 		assertThat(response.codeLength()).isEqualTo(10);
 		assertThat(response.commentCount()).isEqualTo(0);
-		assertThat(response.solvedDateTime()).isEqualTo(DateFormatUtil.formatDate(LocalDateTime.now().toLocalDate()));
+		assertThat(response.solvedDateTime()).isEqualTo(DateFormatUtil.formatDateTime(LocalDateTime.now()));
 	}
 
 	@Test
@@ -304,7 +304,7 @@ class SolutionServiceTest {
 		assertThat(response.language()).isEqualTo("Java");
 		assertThat(response.codeLength()).isEqualTo(10);
 		assertThat(response.commentCount()).isEqualTo(0);
-		assertThat(response.solvedDateTime()).isEqualTo(DateFormatUtil.formatDate(LocalDateTime.now().toLocalDate()));
+		assertThat(response.solvedDateTime()).isEqualTo(DateFormatUtil.formatDateTime(LocalDateTime.now()));
 	}
 
 	@Test

--- a/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
@@ -24,6 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockMultipartFile;
 
+import com.gamzabat.algohub.common.DateFormatUtil;
 import com.gamzabat.algohub.constants.BOJResultConstants;
 import com.gamzabat.algohub.enums.Role;
 import com.gamzabat.algohub.exception.StudyGroupValidationException;
@@ -112,21 +113,25 @@ class StudyGroupServiceTest {
 			.studyGroup(group)
 			.user(owner)
 			.role(RoleOfGroupMember.OWNER)
+			.joinDate(LocalDate.now())
 			.build();
 		groupMember1 = GroupMember.builder()
 			.studyGroup(group)
 			.user(user)
 			.role(RoleOfGroupMember.OWNER)
+			.joinDate(LocalDate.now())
 			.build();
 		groupMember2 = GroupMember.builder()
 			.studyGroup(group)
 			.user(user2)
 			.role(RoleOfGroupMember.PARTICIPANT)
+			.joinDate(LocalDate.now())
 			.build();
 		groupMember3 = GroupMember.builder()
 			.studyGroup(group)
 			.user(user3)
 			.role(RoleOfGroupMember.ADMIN)
+			.joinDate(LocalDate.now())
 			.build();
 
 		problem1 = Problem.builder()
@@ -351,32 +356,34 @@ class StudyGroupServiceTest {
 		for (int i = 0; i < 10; i++) {
 			assertThat(done.get(i).name()).isEqualTo("name" + i);
 			assertThat(done.get(i).ownerNickname()).isEqualTo("nickname1");
-			assertThat(done.get(i).startDate()).isEqualTo(LocalDate.now().minusDays(i + 30));
-			assertThat(done.get(i).endDate()).isEqualTo(LocalDate.now().minusDays(30));
+			assertThat(done.get(i).startDate()).isEqualTo(DateFormatUtil.formatDate(LocalDate.now().minusDays(i + 30)));
+			assertThat(done.get(i).endDate()).isEqualTo(DateFormatUtil.formatDate(LocalDate.now().minusDays(30)));
 			assertThat(done.get(i).isBookmarked()).isTrue();
 			assertThat(done.get(i).isOwner()).isTrue();
 		}
 		for (int i = 0; i < 10; i++) {
 			assertThat(inProgress.get(i).name()).isEqualTo("name" + i);
 			assertThat(inProgress.get(i).ownerNickname()).isEqualTo("nickname1");
-			assertThat(inProgress.get(i).startDate()).isEqualTo(LocalDate.now().minusDays(i));
-			assertThat(inProgress.get(i).endDate()).isEqualTo(LocalDate.now().plusDays(i));
+			assertThat(inProgress.get(i).startDate()).isEqualTo(
+				DateFormatUtil.formatDate(LocalDate.now().minusDays(i)));
+			assertThat(inProgress.get(i).endDate()).isEqualTo(DateFormatUtil.formatDate(LocalDate.now().plusDays(i)));
 			assertThat(inProgress.get(i).isBookmarked()).isFalse();
 			assertThat(inProgress.get(i).isOwner()).isTrue();
 		}
 		for (int i = 0; i < 10; i++) {
 			assertThat(queued.get(i).name()).isEqualTo("name" + i);
 			assertThat(queued.get(i).ownerNickname()).isEqualTo("nickname2");
-			assertThat(queued.get(i).startDate()).isEqualTo(LocalDate.now().plusDays(30));
-			assertThat(queued.get(i).endDate()).isEqualTo(LocalDate.now().plusDays(i + 30));
+			assertThat(queued.get(i).startDate()).isEqualTo(DateFormatUtil.formatDate(LocalDate.now().plusDays(30)));
+			assertThat(queued.get(i).endDate()).isEqualTo(DateFormatUtil.formatDate(LocalDate.now().plusDays(i + 30)));
 			assertThat(queued.get(i).isBookmarked()).isFalse();
 			assertThat(queued.get(i).isOwner()).isFalse();
 		}
 		for (int i = 0; i < 10; i++) {
 			assertThat(bookmarked.get(i).name()).isEqualTo("name" + i);
 			assertThat(bookmarked.get(i).ownerNickname()).isEqualTo("nickname1");
-			assertThat(bookmarked.get(i).startDate()).isEqualTo(LocalDate.now().minusDays(i + 30));
-			assertThat(bookmarked.get(i).endDate()).isEqualTo(LocalDate.now().minusDays(30));
+			assertThat(bookmarked.get(i).startDate()).isEqualTo(
+				DateFormatUtil.formatDate(LocalDate.now().minusDays(i + 30)));
+			assertThat(bookmarked.get(i).endDate()).isEqualTo(DateFormatUtil.formatDate(LocalDate.now().minusDays(30)));
 			assertThat(bookmarked.get(i).isBookmarked()).isTrue();
 			assertThat(bookmarked.get(i).isOwner()).isTrue();
 		}


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
https://github.com/GAMZA-BAT/algohub-server/issues/120

## 🚀 Description
<!-- 작업 내용 -->
- 기존에 날짜 관련해서 Date 타입으로 반환하거나, `yyyy-MM-dd` 형태이던 필드들을 `yyyy.MM.dd` 로 format 해서 전달하도록 수정했습니다.
<p align="center">
  <img width="189" alt="image" src="https://github.com/user-attachments/assets/e66b811c-7d89-4226-b8c0-dd8798e387c7">
</p>

- 또한 시,분,초 단위의 정보는 필요 없어서 모두 날짜 형태로만 반환하도록 수정했습니다. 
- 전역적으로 사용되는 포매터인만큼, util적 특성을 띈다고 판단해 `DateFormatUtil` 클래스를 생성했습니다.
- `formatDate(LocalDate date)` 메소드가 해당 형태로 변환한 후 String을 반환하도록 만들었습니다.
- 거의 대부분의 Get DTO를 수정했다고 보시면 될 듯 합니다.

- (10/22 수정) 풀이 조회는 `solvedDate`가 `yyyy.MM.dd HH:mm:ss` 형태여야 한다는 요구가 있어, `formatDateTime(LocalDateTime dateTime)` 메소드를 추가 구현했습니다.

## 📢 Review Point

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->