### PR TITLE
feat : 그룹 내 유저 role 조회 API 추가

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupController.java
@@ -160,4 +160,11 @@ public class StudyGroupController {
 		studyGroupService.updateGroupMemberRole(user, request);
 		return ResponseEntity.ok().body("OK");
 	}
+
+	@GetMapping(value = "/role")
+	@Operation(summary = "스터디 그룹 내 유저의 Role 조회 API", description = "특정 스터디 그룹 내에서 유저의 Role을 조회하는 API")
+	public ResponseEntity<String> getGroupRole(@AuthedUser User user, @RequestParam Long groupId) {
+		String response = studyGroupService.getRoleInGroup(user, groupId);
+		return ResponseEntity.ok().body(response);
+	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/studygroup/service/StudyGroupService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/studygroup/service/StudyGroupService.java
@@ -1,5 +1,20 @@
 package com.gamzabat.algohub.feature.studygroup.service;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
 import com.aventrix.jnanoid.jnanoid.NanoIdUtils;
 import com.gamzabat.algohub.constants.BOJResultConstants;
 import com.gamzabat.algohub.exception.StudyGroupValidationException;
@@ -11,7 +26,17 @@ import com.gamzabat.algohub.feature.solution.repository.SolutionRepository;
 import com.gamzabat.algohub.feature.studygroup.domain.BookmarkedStudyGroup;
 import com.gamzabat.algohub.feature.studygroup.domain.GroupMember;
 import com.gamzabat.algohub.feature.studygroup.domain.StudyGroup;
-import com.gamzabat.algohub.feature.studygroup.dto.*;
+import com.gamzabat.algohub.feature.studygroup.dto.CheckSolvedProblemResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.CreateGroupRequest;
+import com.gamzabat.algohub.feature.studygroup.dto.CreateGroupResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.EditGroupRequest;
+import com.gamzabat.algohub.feature.studygroup.dto.GetGroupMemberResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.GetGroupResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.GetRankingResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.GetStudyGroupListsResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.GetStudyGroupResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.GetStudyGroupWithCodeResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.UpdateGroupMemberRoleRequest;
 import com.gamzabat.algohub.feature.studygroup.etc.RoleOfGroupMember;
 import com.gamzabat.algohub.feature.studygroup.exception.CannotFoundGroupException;
 import com.gamzabat.algohub.feature.studygroup.exception.CannotFoundProblemException;
@@ -22,394 +47,392 @@ import com.gamzabat.algohub.feature.studygroup.repository.GroupMemberRepository;
 import com.gamzabat.algohub.feature.studygroup.repository.StudyGroupRepository;
 import com.gamzabat.algohub.feature.user.domain.User;
 import com.gamzabat.algohub.feature.user.repository.UserRepository;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class StudyGroupService {
-    private final StudyGroupRepository groupRepository;
-    private final GroupMemberRepository groupMemberRepository;
-    private final ImageService imageService;
-    private final SolutionRepository solutionRepository;
-    private final ProblemRepository problemRepository;
-    private final UserRepository userRepository;
-    private final StudyGroupRepository studyGroupRepository;
-    private final BookmarkedStudyGroupRepository bookmarkedStudyGroupRepository;
-
-    @Transactional
-    public CreateGroupResponse createGroup(User user, CreateGroupRequest request, MultipartFile profileImage) {
-        String imageUrl = imageService.saveImage(profileImage);
-        String inviteCode = NanoIdUtils.randomNanoId();
-        StudyGroup group = StudyGroup.builder()
-                .name(request.name())
-                .startDate(request.startDate())
-                .endDate(request.endDate())
-                .introduction(request.introduction())
-                .groupImage(imageUrl)
-                .groupCode(inviteCode)
-                .build();
-
-        groupRepository.save(group);
-        groupMemberRepository.save(GroupMember.builder()
-                .studyGroup(group)
-                .user(user)
-                .role(RoleOfGroupMember.OWNER)
-                .joinDate(LocalDate.now())
-                .build()
-        );
-        log.info("success to save study group");
-        return new CreateGroupResponse(inviteCode);
-    }
-
-    @Transactional
-    public void joinGroupWithCode(User user, String code) {
-        StudyGroup studyGroup = groupRepository.findByGroupCode(code)
-                .orElseThrow(() -> new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다."));
-
-        if (groupMemberRepository.existsByUserAndStudyGroup(user, studyGroup))
-            throw new StudyGroupValidationException(HttpStatus.BAD_REQUEST.value(), "이미 참여한 그룹 입니다.");
-
-        groupMemberRepository.save(
-                GroupMember.builder()
-                        .studyGroup(studyGroup)
-                        .user(user)
-                        .role(RoleOfGroupMember.PARTICIPANT)
-                        .joinDate(LocalDate.now())
-                        .build()
-        );
-        log.info("success to join study group");
-    }
-
-    @Transactional
-    public void deleteGroup(User user, Long groupId) {
-        StudyGroup studyGroup = groupRepository.findById(groupId)
-                .orElseThrow(() -> new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다."));
-
-        GroupMember groupMember = groupMemberRepository.findByUserAndStudyGroup(user, studyGroup)
-                .orElseThrow(
-                        () -> new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "이미 참여하지 않은 그룹 입니다."));
-
-        if (RoleOfGroupMember.isOwner(groupMember)) { // owner
-            bookmarkedStudyGroupRepository.deleteAll(bookmarkedStudyGroupRepository.findAllByStudyGroup(studyGroup));
-            groupMemberRepository.delete(groupMember);
-            groupRepository.delete(studyGroup);
-        } else { // member
-            deleteMemberFromStudyGroup(user, studyGroup, groupMember);
-        }
-        log.info("success to delete(exit) study group");
-    }
-
-    @Transactional
-    public void deleteMember(User user, Long userId, Long groupId) {
-        StudyGroup group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다."));
-        GroupMember owner = groupMemberRepository.findByUserAndStudyGroup(user, group)
-                .orElseThrow(
-                        () -> new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(),
-                                "멤버 삭제 권한이 없습니다. : 참여하지 않은 그룹 입니다."));
-
-        if (RoleOfGroupMember.isOwner(owner)) {
-            User targetUser = userRepository.findById(userId)
-                    .orElseThrow(() -> new CannotFoundUserException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 유저입니다."));
-
-            GroupMember groupMember = groupMemberRepository.findByUserAndStudyGroup(targetUser, group)
-                    .orElseThrow(
-                            () -> new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "이미 참여하지 않은 회원입니다."));
-
-            deleteMemberFromStudyGroup(user, group, groupMember);
-        } else {
-            throw new UserValidationException("멤버를 삭제 할 권한이 없습니다.");
-        }
-    }
-
-    private void deleteMemberFromStudyGroup(User user, StudyGroup studyGroup, GroupMember groupMember) {
-        bookmarkedStudyGroupRepository.findByUserAndStudyGroup(user, studyGroup)
-                .ifPresent(bookmarkedStudyGroupRepository::delete);
-        groupMemberRepository.delete(groupMember);
-    }
-
-    @Transactional(readOnly = true)
-    public GetStudyGroupListsResponse getStudyGroupList(User user) {
-        List<StudyGroup> groups = groupRepository.findAllByUser(user);
-
-        List<GetStudyGroupResponse> bookmarked = bookmarkedStudyGroupRepository.findAllByUser(user).stream()
-                .map(bookmark -> GetStudyGroupResponse.toDTO(bookmark.getStudyGroup(), user, true,
-                        getStudyGroupOwner(bookmark.getStudyGroup())))
-                .toList();
-
-        LocalDate today = LocalDate.now();
-
-        List<GetStudyGroupResponse> done = groups.stream()
-                .filter(group -> group.getEndDate() != null && group.getEndDate().isBefore(today))
-                .map(
-                        group -> GetStudyGroupResponse.toDTO(group, user, isBookmarked(user, group), getStudyGroupOwner(group)))
-                .toList();
-
-        List<GetStudyGroupResponse> inProgress = groups.stream()
-                .filter(
-                        group -> !(group.getStartDate() == null || group.getStartDate().isAfter(today))
-                                && !(group.getEndDate() == null || group.getEndDate().isBefore(today)))
-                .map(
-                        group -> GetStudyGroupResponse.toDTO(group, user, isBookmarked(user, group), getStudyGroupOwner(group)))
-                .toList();
-
-        List<GetStudyGroupResponse> queued = groups.stream()
-                .filter(group -> group.getStartDate() != null && group.getStartDate().isAfter(today))
-                .map(
-                        group -> GetStudyGroupResponse.toDTO(group, user, isBookmarked(user, group), getStudyGroupOwner(group)))
-                .toList();
-
-        GetStudyGroupListsResponse response = new GetStudyGroupListsResponse(bookmarked, done, inProgress, queued);
-
-        log.info("success to get study group list");
-        return response;
-    }
-
-    private User getStudyGroupOwner(StudyGroup group) {
-        return groupMemberRepository.findByStudyGroupAndRole(group, RoleOfGroupMember.OWNER).getUser();
-    }
-
-    @Transactional
-    public void editGroup(User user, EditGroupRequest request, MultipartFile groupImage) {
-        StudyGroup group = groupRepository.findById(request.id())
-                .orElseThrow(() -> new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다."));
-
-        GroupMember groupMember = groupMemberRepository.findByUserAndStudyGroup(user, group)
-                .orElseThrow(
-                        () -> new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "참여하지 않은 그룹 입니다."));
-
-        if (!RoleOfGroupMember.isOwner(groupMember))
-            throw new StudyGroupValidationException(HttpStatus.FORBIDDEN.value(), "그룹 정보 수정에 대한 권한이 없습니다.");
-
-        if (groupImage != null) {
-            if (group.getGroupImage() != null)
-                imageService.deleteImage(group.getGroupImage());
-            String imageUrl = imageService.saveImage(groupImage);
-            group.editGroupImage(imageUrl);
-        }
-        group.editGroupInfo(
-                request.name(),
-                request.startDate(),
-                request.endDate(),
-                request.introduction()
-        );
-        log.info("success to edit group info");
-    }
-
-    @Transactional(readOnly = true)
-    public List<GetGroupMemberResponse> getGroupMemberList(User user, Long id) {
-        StudyGroup group = groupRepository.findById(id)
-                .orElseThrow(() -> new CannotFoundGroupException("그룹을 찾을 수 없습니다."));
-
-        if (!groupMemberRepository.existsByUserAndStudyGroup(user, group))
-            throw new GroupMemberValidationException(HttpStatus.FORBIDDEN.value(), "그룹 정보를 확인할 권한이 없습니다");
-
-        List<GroupMember> groupMembers = groupMemberRepository.findAllByStudyGroup(group);
-
-        List<GetGroupMemberResponse> responseList = new ArrayList<>();
-
-        for (GroupMember groupMember : groupMembers) {
-            String nickname = groupMember.getUser().getNickname();
-            LocalDate joinDate = groupMember.getJoinDate();
-
-            Long correctSolution = solutionRepository.countDistinctCorrectSolutionsByUserAndGroup(
-                    groupMember.getUser(), id, BOJResultConstants.CORRECT);
-            Long problems = problemRepository.countProblemsByGroupId(id);
-            String achivement;
-            if (correctSolution == 0) {
-                achivement = "0%";
-            } else {
-                achivement = getPercentage(correctSolution, problems) + "%";
-            }
-
-            RoleOfGroupMember role = groupMember.getRole();
-            String profileImage = groupMember.getUser().getProfileImage();
-            Long userId = groupMember.getUser().getId();
-            responseList.add(
-                    new GetGroupMemberResponse(nickname, joinDate, achivement, role, profileImage, userId));
-        }
-        responseList.sort(Comparator.comparing(GetGroupMemberResponse::getRole));
-
-        return responseList;
-    }
-
-    @Transactional(readOnly = true)
-    public List<CheckSolvedProblemResponse> getCheckingSolvedProblem(User user, Long problemId) {
-        Problem problem = problemRepository.findById(problemId)
-                .orElseThrow(() -> new CannotFoundProblemException("문제를 찾을 수 없습니다."));
-        StudyGroup studyGroup = problem.getStudyGroup();
-
-        if (groupMemberRepository.existsByUserAndStudyGroup(user, studyGroup)) {
-            List<GroupMember> groupMembers = groupMemberRepository.findAllByStudyGroup(studyGroup);
-
-            List<CheckSolvedProblemResponse> responseList = new ArrayList<>();
-
-            for (GroupMember groupMember : groupMembers) {
-                String profileImage = groupMember.getUser().getProfileImage();
-                Long groupMemberId = groupMember.getUser().getId();
-                String nickname = groupMember.getUser().getNickname();
-                Boolean solved = solutionRepository.existsByUserAndProblem(groupMember.getUser(), problem);
-                responseList.add(new CheckSolvedProblemResponse(groupMemberId, profileImage, nickname, solved));
-            }
-            return responseList;
-        } else {
-            throw new UserValidationException("풀이 여부 목록을 확인할 권한이 없습니다.");
-        }
-    }
-
-    @Transactional(readOnly = true)
-    public String getGroupCode(User user, Long groupId) {
-        StudyGroup studyGroup = groupRepository.findById(groupId)
-                .orElseThrow(() -> new CannotFoundGroupException("그룹을 찾지 못했습니다."));
-        GroupMember owner = groupMemberRepository.findByUserAndStudyGroup(user, studyGroup)
-                .orElseThrow(
-                        () -> new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "참여하지 않은 그룹 입니다."));
-
-        if (RoleOfGroupMember.isOwner(owner))
-            return studyGroup.getGroupCode();
-        else
-            throw new UserValidationException("초대 코드를 조회할 권한이 없습니다.");
-    }
-
-    @Transactional(readOnly = true)
-    public GetStudyGroupWithCodeResponse getGroupByCode(String code) {
-        StudyGroup group = groupRepository.findByGroupCode(code)
-                .orElseThrow(() -> new CannotFoundGroupException("그룹을 찾을 수 없습니다."));
-        return GetStudyGroupWithCodeResponse.toDTO(group);
-    }
-
-    @Transactional(readOnly = true)
-    public List<GetRankingResponse> getTopRank(User user, Long groupId) {
-
-        StudyGroup group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new CannotFoundGroupException("그룹을 찾을 수 없습니다."));
-
-        if (!groupMemberRepository.existsByUserAndStudyGroup(user, group)) {
-            throw new UserValidationException("랭킹을 확인할 권한이 없습니다.");
-        }
-
-        List<GetRankingResponse> rankingResponses = solutionRepository.findTopUsersByGroup(group,
-                BOJResultConstants.CORRECT);
-        return IntStream.range(0, rankingResponses.size())
-                .mapToObj(i -> {
-                    GetRankingResponse response = rankingResponses.get(i);
-                    return new GetRankingResponse(response.getUserNickname(), response.getProfileImage(), i + 1,
-                            response.getSolvedCount());
-                })
-                .limit(3)
-                .collect(Collectors.toList());
-    }
-
-    @Transactional(readOnly = true)
-    public List<GetRankingResponse> getAllRank(User user, Long groupId) {
-
-        StudyGroup group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new CannotFoundGroupException("그룹을 찾을 수 없습니다."));
-
-        if (!groupMemberRepository.existsByUserAndStudyGroup(user, group)) {
-            throw new UserValidationException("랭킹을 확인할 권한이 없습니다.");
-        }
-
-        List<GetRankingResponse> rankingResponses = solutionRepository.findTopUsersByGroup(group,
-                BOJResultConstants.CORRECT);
-        return IntStream.range(0, rankingResponses.size())
-                .mapToObj(i -> {
-                    GetRankingResponse response = rankingResponses.get(i);
-                    return new GetRankingResponse(response.getUserNickname(), response.getProfileImage(), i + 1,
-                            response.getSolvedCount());
-                })
-                .collect(Collectors.toList());
-    }
-
-    @Transactional(readOnly = true)
-    public GetGroupResponse getGroup(User user, Long groupId) {
-
-        StudyGroup group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new CannotFoundGroupException("그룹을 찾을 수 없습니다."));
-
-        GroupMember member = groupMemberRepository.findByUserAndStudyGroup(user, group)
-                .orElseThrow(
-                        () -> new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "참여하지 않은 그룹 입니다."));
-
-        GetGroupResponse response = new GetGroupResponse(group.getId(), group.getName(), group.getStartDate(),
-                group.getEndDate(), group.getIntroduction(), group.getGroupImage(), RoleOfGroupMember.isOwner(member),
-                getStudyGroupOwner(group).getNickname());
-        return response;
-    }
-
-    private String getPercentage(Long numerator, Long denominator) {
-        if (denominator == 0) {
-            throw new ArithmeticException("Division by zero");
-        }
-
-        BigDecimal num = new BigDecimal(numerator);
-        BigDecimal den = new BigDecimal(denominator);
-        BigDecimal percentage = num.multiply(BigDecimal.valueOf(100)).divide(den, 0, RoundingMode.HALF_UP);
-
-        return percentage.toString();
-    }
-
-    @Transactional
-    public String updateBookmarkGroup(User user, Long groupId) {
-        StudyGroup studyGroup = studyGroupRepository.findById(groupId)
-                .orElseThrow(() -> new CannotFoundGroupException("존재하지 않는 그룹 입니다."));
-
-        if (!groupMemberRepository.existsByUserAndStudyGroup(user, studyGroup))
-            throw new StudyGroupValidationException(HttpStatus.BAD_REQUEST.value(), "참여하지 않은 그룹 입니다.");
-
-        Optional<BookmarkedStudyGroup> bookmarked = bookmarkedStudyGroupRepository.findByUserAndStudyGroup(user,
-                studyGroup);
-
-        if (bookmarked.isEmpty()) {
-            bookmarkedStudyGroupRepository.save(
-                    BookmarkedStudyGroup.builder().studyGroup(studyGroup).user(user).build());
-            return "스터디 그룹 즐겨찾기 추가 성공";
-        } else {
-            bookmarkedStudyGroupRepository.delete(bookmarked.get());
-            return "스터디 그룹 즐겨찾기 삭제 성공";
-        }
-    }
-
-    private boolean isBookmarked(User user, StudyGroup group) {
-        return bookmarkedStudyGroupRepository.existsByUserAndStudyGroup(user, group);
-    }
-
-    @Transactional
-    public void updateGroupMemberRole(User user, UpdateGroupMemberRoleRequest request) {
-        StudyGroup group = studyGroupRepository.findById(request.studyGroupId())
-                .orElseThrow(() -> new CannotFoundGroupException("존재하지 않는 그룹입니다."));
-
-        GroupMember owner = groupMemberRepository.findByUserAndStudyGroup(user, group)
-                .orElseThrow(
-                        () -> new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "참여하지 않은 그룹 입니다."));
-
-        if (!RoleOfGroupMember.isOwner(owner))
-            throw new StudyGroupValidationException(HttpStatus.FORBIDDEN.value(), "스터디 그룹의 멤버 역할을 수정할 권한이 없습니다.");
-
-        User targetUser = userRepository.findById(request.memberId())
-                .orElseThrow(() -> new UserValidationException("존재하지 않는 회원입니다."));
-
-        GroupMember member = groupMemberRepository.findByUserAndStudyGroup(targetUser, group)
-                .orElseThrow(
-                        () -> new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "해당 스터디 그룹에 참여하지 않은 회원입니다."));
-
-        member.updateRole(RoleOfGroupMember.fromValue(request.role()));
-        log.info("success to update group member role");
-    }
+	private final StudyGroupRepository groupRepository;
+	private final GroupMemberRepository groupMemberRepository;
+	private final ImageService imageService;
+	private final SolutionRepository solutionRepository;
+	private final ProblemRepository problemRepository;
+	private final UserRepository userRepository;
+	private final StudyGroupRepository studyGroupRepository;
+	private final BookmarkedStudyGroupRepository bookmarkedStudyGroupRepository;
+
+	@Transactional
+	public CreateGroupResponse createGroup(User user, CreateGroupRequest request, MultipartFile profileImage) {
+		String imageUrl = imageService.saveImage(profileImage);
+		String inviteCode = NanoIdUtils.randomNanoId();
+		StudyGroup group = StudyGroup.builder()
+			.name(request.name())
+			.startDate(request.startDate())
+			.endDate(request.endDate())
+			.introduction(request.introduction())
+			.groupImage(imageUrl)
+			.groupCode(inviteCode)
+			.build();
+
+		groupRepository.save(group);
+		groupMemberRepository.save(GroupMember.builder()
+			.studyGroup(group)
+			.user(user)
+			.role(RoleOfGroupMember.OWNER)
+			.joinDate(LocalDate.now())
+			.build()
+		);
+		log.info("success to save study group");
+		return new CreateGroupResponse(inviteCode);
+	}
+
+	@Transactional
+	public void joinGroupWithCode(User user, String code) {
+		StudyGroup studyGroup = groupRepository.findByGroupCode(code)
+			.orElseThrow(() -> new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다."));
+
+		if (groupMemberRepository.existsByUserAndStudyGroup(user, studyGroup))
+			throw new StudyGroupValidationException(HttpStatus.BAD_REQUEST.value(), "이미 참여한 그룹 입니다.");
+
+		groupMemberRepository.save(
+			GroupMember.builder()
+				.studyGroup(studyGroup)
+				.user(user)
+				.role(RoleOfGroupMember.PARTICIPANT)
+				.joinDate(LocalDate.now())
+				.build()
+		);
+		log.info("success to join study group");
+	}
+
+	@Transactional
+	public void deleteGroup(User user, Long groupId) {
+		StudyGroup studyGroup = groupRepository.findById(groupId)
+			.orElseThrow(() -> new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다."));
+
+		GroupMember groupMember = groupMemberRepository.findByUserAndStudyGroup(user, studyGroup)
+			.orElseThrow(
+				() -> new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "이미 참여하지 않은 그룹 입니다."));
+
+		if (RoleOfGroupMember.isOwner(groupMember)) { // owner
+			bookmarkedStudyGroupRepository.deleteAll(bookmarkedStudyGroupRepository.findAllByStudyGroup(studyGroup));
+			groupMemberRepository.delete(groupMember);
+			groupRepository.delete(studyGroup);
+		} else { // member
+			deleteMemberFromStudyGroup(user, studyGroup, groupMember);
+		}
+		log.info("success to delete(exit) study group");
+	}
+
+	@Transactional
+	public void deleteMember(User user, Long userId, Long groupId) {
+		StudyGroup group = groupRepository.findById(groupId)
+			.orElseThrow(() -> new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다."));
+		GroupMember owner = groupMemberRepository.findByUserAndStudyGroup(user, group)
+			.orElseThrow(
+				() -> new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(),
+					"멤버 삭제 권한이 없습니다. : 참여하지 않은 그룹 입니다."));
+
+		if (RoleOfGroupMember.isOwner(owner)) {
+			User targetUser = userRepository.findById(userId)
+				.orElseThrow(() -> new CannotFoundUserException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 유저입니다."));
+
+			GroupMember groupMember = groupMemberRepository.findByUserAndStudyGroup(targetUser, group)
+				.orElseThrow(
+					() -> new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "이미 참여하지 않은 회원입니다."));
+
+			deleteMemberFromStudyGroup(user, group, groupMember);
+		} else {
+			throw new UserValidationException("멤버를 삭제 할 권한이 없습니다.");
+		}
+	}
+
+	private void deleteMemberFromStudyGroup(User user, StudyGroup studyGroup, GroupMember groupMember) {
+		bookmarkedStudyGroupRepository.findByUserAndStudyGroup(user, studyGroup)
+			.ifPresent(bookmarkedStudyGroupRepository::delete);
+		groupMemberRepository.delete(groupMember);
+	}
+
+	@Transactional(readOnly = true)
+	public GetStudyGroupListsResponse getStudyGroupList(User user) {
+		List<StudyGroup> groups = groupRepository.findAllByUser(user);
+
+		List<GetStudyGroupResponse> bookmarked = bookmarkedStudyGroupRepository.findAllByUser(user).stream()
+			.map(bookmark -> GetStudyGroupResponse.toDTO(bookmark.getStudyGroup(), user, true,
+				getStudyGroupOwner(bookmark.getStudyGroup())))
+			.toList();
+
+		LocalDate today = LocalDate.now();
+
+		List<GetStudyGroupResponse> done = groups.stream()
+			.filter(group -> group.getEndDate() != null && group.getEndDate().isBefore(today))
+			.map(
+				group -> GetStudyGroupResponse.toDTO(group, user, isBookmarked(user, group), getStudyGroupOwner(group)))
+			.toList();
+
+		List<GetStudyGroupResponse> inProgress = groups.stream()
+			.filter(
+				group -> !(group.getStartDate() == null || group.getStartDate().isAfter(today))
+					&& !(group.getEndDate() == null || group.getEndDate().isBefore(today)))
+			.map(
+				group -> GetStudyGroupResponse.toDTO(group, user, isBookmarked(user, group), getStudyGroupOwner(group)))
+			.toList();
+
+		List<GetStudyGroupResponse> queued = groups.stream()
+			.filter(group -> group.getStartDate() != null && group.getStartDate().isAfter(today))
+			.map(
+				group -> GetStudyGroupResponse.toDTO(group, user, isBookmarked(user, group), getStudyGroupOwner(group)))
+			.toList();
+
+		GetStudyGroupListsResponse response = new GetStudyGroupListsResponse(bookmarked, done, inProgress, queued);
+
+		log.info("success to get study group list");
+		return response;
+	}
+
+	private User getStudyGroupOwner(StudyGroup group) {
+		return groupMemberRepository.findByStudyGroupAndRole(group, RoleOfGroupMember.OWNER).getUser();
+	}
+
+	@Transactional
+	public void editGroup(User user, EditGroupRequest request, MultipartFile groupImage) {
+		StudyGroup group = groupRepository.findById(request.id())
+			.orElseThrow(() -> new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다."));
+
+		GroupMember groupMember = groupMemberRepository.findByUserAndStudyGroup(user, group)
+			.orElseThrow(
+				() -> new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "참여하지 않은 그룹 입니다."));
+
+		if (!RoleOfGroupMember.isOwner(groupMember))
+			throw new StudyGroupValidationException(HttpStatus.FORBIDDEN.value(), "그룹 정보 수정에 대한 권한이 없습니다.");
+
+		if (groupImage != null) {
+			if (group.getGroupImage() != null)
+				imageService.deleteImage(group.getGroupImage());
+			String imageUrl = imageService.saveImage(groupImage);
+			group.editGroupImage(imageUrl);
+		}
+		group.editGroupInfo(
+			request.name(),
+			request.startDate(),
+			request.endDate(),
+			request.introduction()
+		);
+		log.info("success to edit group info");
+	}
+
+	@Transactional(readOnly = true)
+	public List<GetGroupMemberResponse> getGroupMemberList(User user, Long id) {
+		StudyGroup group = groupRepository.findById(id)
+			.orElseThrow(() -> new CannotFoundGroupException("그룹을 찾을 수 없습니다."));
+
+		if (!groupMemberRepository.existsByUserAndStudyGroup(user, group))
+			throw new GroupMemberValidationException(HttpStatus.FORBIDDEN.value(), "그룹 정보를 확인할 권한이 없습니다");
+
+		List<GroupMember> groupMembers = groupMemberRepository.findAllByStudyGroup(group);
+
+		List<GetGroupMemberResponse> responseList = new ArrayList<>();
+
+		for (GroupMember groupMember : groupMembers) {
+			String nickname = groupMember.getUser().getNickname();
+			LocalDate joinDate = groupMember.getJoinDate();
+
+			Long correctSolution = solutionRepository.countDistinctCorrectSolutionsByUserAndGroup(
+				groupMember.getUser(), id, BOJResultConstants.CORRECT);
+			Long problems = problemRepository.countProblemsByGroupId(id);
+			String achivement;
+			if (correctSolution == 0) {
+				achivement = "0%";
+			} else {
+				achivement = getPercentage(correctSolution, problems) + "%";
+			}
+
+			RoleOfGroupMember role = groupMember.getRole();
+			String profileImage = groupMember.getUser().getProfileImage();
+			Long userId = groupMember.getUser().getId();
+			responseList.add(
+				new GetGroupMemberResponse(nickname, joinDate, achivement, role, profileImage, userId));
+		}
+		responseList.sort(Comparator.comparing(GetGroupMemberResponse::getRole));
+
+		return responseList;
+	}
+
+	@Transactional(readOnly = true)
+	public List<CheckSolvedProblemResponse> getCheckingSolvedProblem(User user, Long problemId) {
+		Problem problem = problemRepository.findById(problemId)
+			.orElseThrow(() -> new CannotFoundProblemException("문제를 찾을 수 없습니다."));
+		StudyGroup studyGroup = problem.getStudyGroup();
+
+		if (groupMemberRepository.existsByUserAndStudyGroup(user, studyGroup)) {
+			List<GroupMember> groupMembers = groupMemberRepository.findAllByStudyGroup(studyGroup);
+
+			List<CheckSolvedProblemResponse> responseList = new ArrayList<>();
+
+			for (GroupMember groupMember : groupMembers) {
+				String profileImage = groupMember.getUser().getProfileImage();
+				Long groupMemberId = groupMember.getUser().getId();
+				String nickname = groupMember.getUser().getNickname();
+				Boolean solved = solutionRepository.existsByUserAndProblem(groupMember.getUser(), problem);
+				responseList.add(new CheckSolvedProblemResponse(groupMemberId, profileImage, nickname, solved));
+			}
+			return responseList;
+		} else {
+			throw new UserValidationException("풀이 여부 목록을 확인할 권한이 없습니다.");
+		}
+	}
+
+	@Transactional(readOnly = true)
+	public String getGroupCode(User user, Long groupId) {
+		StudyGroup studyGroup = groupRepository.findById(groupId)
+			.orElseThrow(() -> new CannotFoundGroupException("그룹을 찾지 못했습니다."));
+		GroupMember owner = groupMemberRepository.findByUserAndStudyGroup(user, studyGroup)
+			.orElseThrow(
+				() -> new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "참여하지 않은 그룹 입니다."));
+
+		if (RoleOfGroupMember.isOwner(owner))
+			return studyGroup.getGroupCode();
+		else
+			throw new UserValidationException("초대 코드를 조회할 권한이 없습니다.");
+	}
+
+	@Transactional(readOnly = true)
+	public GetStudyGroupWithCodeResponse getGroupByCode(String code) {
+		StudyGroup group = groupRepository.findByGroupCode(code)
+			.orElseThrow(() -> new CannotFoundGroupException("그룹을 찾을 수 없습니다."));
+		return GetStudyGroupWithCodeResponse.toDTO(group);
+	}
+
+	@Transactional(readOnly = true)
+	public List<GetRankingResponse> getTopRank(User user, Long groupId) {
+
+		StudyGroup group = groupRepository.findById(groupId)
+			.orElseThrow(() -> new CannotFoundGroupException("그룹을 찾을 수 없습니다."));
+
+		if (!groupMemberRepository.existsByUserAndStudyGroup(user, group)) {
+			throw new UserValidationException("랭킹을 확인할 권한이 없습니다.");
+		}
+
+		List<GetRankingResponse> rankingResponses = solutionRepository.findTopUsersByGroup(group,
+			BOJResultConstants.CORRECT);
+		return IntStream.range(0, rankingResponses.size())
+			.mapToObj(i -> {
+				GetRankingResponse response = rankingResponses.get(i);
+				return new GetRankingResponse(response.getUserNickname(), response.getProfileImage(), i + 1,
+					response.getSolvedCount());
+			})
+			.limit(3)
+			.collect(Collectors.toList());
+	}
+
+	@Transactional(readOnly = true)
+	public List<GetRankingResponse> getAllRank(User user, Long groupId) {
+
+		StudyGroup group = groupRepository.findById(groupId)
+			.orElseThrow(() -> new CannotFoundGroupException("그룹을 찾을 수 없습니다."));
+
+		if (!groupMemberRepository.existsByUserAndStudyGroup(user, group)) {
+			throw new UserValidationException("랭킹을 확인할 권한이 없습니다.");
+		}
+
+		List<GetRankingResponse> rankingResponses = solutionRepository.findTopUsersByGroup(group,
+			BOJResultConstants.CORRECT);
+		return IntStream.range(0, rankingResponses.size())
+			.mapToObj(i -> {
+				GetRankingResponse response = rankingResponses.get(i);
+				return new GetRankingResponse(response.getUserNickname(), response.getProfileImage(), i + 1,
+					response.getSolvedCount());
+			})
+			.collect(Collectors.toList());
+	}
+
+	@Transactional(readOnly = true)
+	public GetGroupResponse getGroup(User user, Long groupId) {
+
+		StudyGroup group = groupRepository.findById(groupId)
+			.orElseThrow(() -> new CannotFoundGroupException("그룹을 찾을 수 없습니다."));
+
+		GroupMember member = groupMemberRepository.findByUserAndStudyGroup(user, group)
+			.orElseThrow(
+				() -> new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "참여하지 않은 그룹 입니다."));
+
+		GetGroupResponse response = new GetGroupResponse(group.getId(), group.getName(), group.getStartDate(),
+			group.getEndDate(), group.getIntroduction(), group.getGroupImage(), RoleOfGroupMember.isOwner(member),
+			getStudyGroupOwner(group).getNickname());
+		return response;
+	}
+
+	private String getPercentage(Long numerator, Long denominator) {
+		if (denominator == 0) {
+			throw new ArithmeticException("Division by zero");
+		}
+
+		BigDecimal num = new BigDecimal(numerator);
+		BigDecimal den = new BigDecimal(denominator);
+		BigDecimal percentage = num.multiply(BigDecimal.valueOf(100)).divide(den, 0, RoundingMode.HALF_UP);
+
+		return percentage.toString();
+	}
+
+	@Transactional
+	public String updateBookmarkGroup(User user, Long groupId) {
+		StudyGroup studyGroup = studyGroupRepository.findById(groupId)
+			.orElseThrow(() -> new CannotFoundGroupException("존재하지 않는 그룹 입니다."));
+
+		if (!groupMemberRepository.existsByUserAndStudyGroup(user, studyGroup))
+			throw new StudyGroupValidationException(HttpStatus.BAD_REQUEST.value(), "참여하지 않은 그룹 입니다.");
+
+		Optional<BookmarkedStudyGroup> bookmarked = bookmarkedStudyGroupRepository.findByUserAndStudyGroup(user,
+			studyGroup);
+
+		if (bookmarked.isEmpty()) {
+			bookmarkedStudyGroupRepository.save(
+				BookmarkedStudyGroup.builder().studyGroup(studyGroup).user(user).build());
+			return "스터디 그룹 즐겨찾기 추가 성공";
+		} else {
+			bookmarkedStudyGroupRepository.delete(bookmarked.get());
+			return "스터디 그룹 즐겨찾기 삭제 성공";
+		}
+	}
+
+	private boolean isBookmarked(User user, StudyGroup group) {
+		return bookmarkedStudyGroupRepository.existsByUserAndStudyGroup(user, group);
+	}
+
+	@Transactional
+	public void updateGroupMemberRole(User user, UpdateGroupMemberRoleRequest request) {
+		StudyGroup group = studyGroupRepository.findById(request.studyGroupId())
+			.orElseThrow(() -> new CannotFoundGroupException("존재하지 않는 그룹입니다."));
+
+		GroupMember owner = groupMemberRepository.findByUserAndStudyGroup(user, group)
+			.orElseThrow(
+				() -> new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "참여하지 않은 그룹 입니다."));
+
+		if (!RoleOfGroupMember.isOwner(owner))
+			throw new StudyGroupValidationException(HttpStatus.FORBIDDEN.value(), "스터디 그룹의 멤버 역할을 수정할 권한이 없습니다.");
+
+		User targetUser = userRepository.findById(request.memberId())
+			.orElseThrow(() -> new UserValidationException("존재하지 않는 회원입니다."));
+
+		GroupMember member = groupMemberRepository.findByUserAndStudyGroup(targetUser, group)
+			.orElseThrow(
+				() -> new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "해당 스터디 그룹에 참여하지 않은 회원입니다."));
+
+		member.updateRole(RoleOfGroupMember.fromValue(request.role()));
+		log.info("success to update group member role");
+	}
+
+	@Transactional(readOnly = true)
+	public String getRoleInGroup(User user, Long groupId) {
+		StudyGroup group = groupRepository.findById(groupId)
+			.orElseThrow(() -> new CannotFoundGroupException("존재하지 않는 그룹입니다."));
+
+		GroupMember member = groupMemberRepository.findByUserAndStudyGroup(user, group)
+			.orElseThrow(() -> new GroupMemberValidationException(HttpStatus.NOT_FOUND.value(), "참여하지 않은 그룹입니다."));
+
+		return member.getRole().getValue();
+	}
 }

--- a/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
@@ -1,23 +1,18 @@
 package com.gamzabat.algohub.feature.studygroup.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.gamzabat.algohub.common.jwt.TokenProvider;
-import com.gamzabat.algohub.config.SpringSecurityConfig;
-import com.gamzabat.algohub.exception.StudyGroupValidationException;
-import com.gamzabat.algohub.exception.UserValidationException;
-import com.gamzabat.algohub.feature.image.service.ImageService;
-import com.gamzabat.algohub.feature.problem.repository.ProblemRepository;
-import com.gamzabat.algohub.feature.solution.exception.CannotFoundSolutionException;
-import com.gamzabat.algohub.feature.solution.repository.SolutionRepository;
-import com.gamzabat.algohub.feature.studygroup.dto.*;
-import com.gamzabat.algohub.feature.studygroup.etc.RoleOfGroupMember;
-import com.gamzabat.algohub.feature.studygroup.exception.CannotFoundGroupException;
-import com.gamzabat.algohub.feature.studygroup.exception.GroupMemberValidationException;
-import com.gamzabat.algohub.feature.studygroup.repository.GroupMemberRepository;
-import com.gamzabat.algohub.feature.studygroup.repository.StudyGroupRepository;
-import com.gamzabat.algohub.feature.studygroup.service.StudyGroupService;
-import com.gamzabat.algohub.feature.user.domain.User;
-import com.gamzabat.algohub.feature.user.repository.UserRepository;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,725 +29,785 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
-import static org.hamcrest.Matchers.hasItems;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gamzabat.algohub.common.jwt.TokenProvider;
+import com.gamzabat.algohub.config.SpringSecurityConfig;
+import com.gamzabat.algohub.exception.StudyGroupValidationException;
+import com.gamzabat.algohub.exception.UserValidationException;
+import com.gamzabat.algohub.feature.image.service.ImageService;
+import com.gamzabat.algohub.feature.problem.repository.ProblemRepository;
+import com.gamzabat.algohub.feature.solution.exception.CannotFoundSolutionException;
+import com.gamzabat.algohub.feature.solution.repository.SolutionRepository;
+import com.gamzabat.algohub.feature.studygroup.dto.CheckSolvedProblemResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.CreateGroupRequest;
+import com.gamzabat.algohub.feature.studygroup.dto.CreateGroupResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.EditGroupRequest;
+import com.gamzabat.algohub.feature.studygroup.dto.GetGroupMemberResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.GetStudyGroupListsResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.GetStudyGroupResponse;
+import com.gamzabat.algohub.feature.studygroup.dto.UpdateGroupMemberRoleRequest;
+import com.gamzabat.algohub.feature.studygroup.etc.RoleOfGroupMember;
+import com.gamzabat.algohub.feature.studygroup.exception.CannotFoundGroupException;
+import com.gamzabat.algohub.feature.studygroup.exception.GroupMemberValidationException;
+import com.gamzabat.algohub.feature.studygroup.repository.GroupMemberRepository;
+import com.gamzabat.algohub.feature.studygroup.repository.StudyGroupRepository;
+import com.gamzabat.algohub.feature.studygroup.service.StudyGroupService;
+import com.gamzabat.algohub.feature.user.domain.User;
+import com.gamzabat.algohub.feature.user.repository.UserRepository;
 
 @WebMvcTest(StudyGroupController.class)
 @WithMockUser
 @Import(SpringSecurityConfig.class)
 class StudyGroupControllerTest {
-    private final Long userId = 0L;
-    private final String token = "token";
-    private final Long groupId = 1L;
-    private final String code = "invitationCode";
-    private final Long problemId = 10L;
-    @Autowired
-    private MockMvc mockMvc;
-    @Autowired
-    private ObjectMapper objectMapper;
-    @MockBean
-    private StudyGroupService studyGroupService;
-    @MockBean
-    private StudyGroupRepository studyGroupRepository;
-    @MockBean
-    private GroupMemberRepository groupMemberRepository;
-    @MockBean
-    private ImageService imageService;
-    @MockBean
-    private SolutionRepository solutionRepository;
-    @MockBean
-    private ProblemRepository problemRepository;
-    @MockBean
-    private TokenProvider tokenProvider;
-    @MockBean
-    private UserRepository userRepository;
-    private User user;
+	private final Long userId = 0L;
+	private final String token = "token";
+	private final Long groupId = 1L;
+	private final String code = "invitationCode";
+	private final Long problemId = 10L;
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@MockBean
+	private StudyGroupService studyGroupService;
+	@MockBean
+	private StudyGroupRepository studyGroupRepository;
+	@MockBean
+	private GroupMemberRepository groupMemberRepository;
+	@MockBean
+	private ImageService imageService;
+	@MockBean
+	private SolutionRepository solutionRepository;
+	@MockBean
+	private ProblemRepository problemRepository;
+	@MockBean
+	private TokenProvider tokenProvider;
+	@MockBean
+	private UserRepository userRepository;
+	private User user;
 
-    @BeforeEach
-    void setUp() {
-        user = User.builder().email("email").password("password").build();
-        when(tokenProvider.getUserEmail(token)).thenReturn("email");
-        when(userRepository.findByEmail("email")).thenReturn(Optional.ofNullable(user));
-    }
+	@BeforeEach
+	void setUp() {
+		user = User.builder().email("email").password("password").build();
+		when(tokenProvider.getUserEmail(token)).thenReturn("email");
+		when(userRepository.findByEmail("email")).thenReturn(Optional.ofNullable(user));
+	}
 
-    @Test
-    @DisplayName("그룹 생성 성공")
-    void createGroup() throws Exception {
-        // given
-        CreateGroupRequest request = new CreateGroupRequest("name", LocalDate.now(), LocalDate.now().plusDays(30),
-                "introduction");
-        CreateGroupResponse response = new CreateGroupResponse("inviteCode");
-        MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
-                objectMapper.writeValueAsString(request).getBytes());
-        MockMultipartFile profileImage = new MockMultipartFile("profileImage", "profile.jpg", "image/jpeg",
-                "image".getBytes());
-        when(studyGroupService.createGroup(any(User.class), any(CreateGroupRequest.class),
-                any(MultipartFile.class))).thenReturn(response);
-        // when, then
-        mockMvc.perform(multipart("/api/group")
-                        .file(requestPart)
-                        .file(profileImage)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .header("Authorization", token)
-                        .with(request1 -> {
-                            request1.setMethod("POST");
-                            return request1;
-                        }))
-                .andExpect(status().isOk())
-                .andExpect(content().json(objectMapper.writeValueAsString(response)));
+	@Test
+	@DisplayName("그룹 생성 성공")
+	void createGroup() throws Exception {
+		// given
+		CreateGroupRequest request = new CreateGroupRequest("name", LocalDate.now(), LocalDate.now().plusDays(30),
+			"introduction");
+		CreateGroupResponse response = new CreateGroupResponse("inviteCode");
+		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
+			objectMapper.writeValueAsString(request).getBytes());
+		MockMultipartFile profileImage = new MockMultipartFile("profileImage", "profile.jpg", "image/jpeg",
+			"image".getBytes());
+		when(studyGroupService.createGroup(any(User.class), any(CreateGroupRequest.class),
+			any(MultipartFile.class))).thenReturn(response);
+		// when, then
+		mockMvc.perform(multipart("/api/group")
+				.file(requestPart)
+				.file(profileImage)
+				.contentType(MediaType.MULTIPART_FORM_DATA)
+				.header("Authorization", token)
+				.with(request1 -> {
+					request1.setMethod("POST");
+					return request1;
+				}))
+			.andExpect(status().isOk())
+			.andExpect(content().json(objectMapper.writeValueAsString(response)));
 
-        verify(studyGroupService, times(1)).createGroup(user, request, profileImage);
-    }
+		verify(studyGroupService, times(1)).createGroup(user, request, profileImage);
+	}
 
-    @ParameterizedTest
-    @CsvSource(value = {
-            "'', '2024-07-01', '2024-07-29','', name : 스터디 이름은 1글자 이상 15글자 이하로 작성해야 합니다.",
-            "name, null, '2024-07-29','', startDate : 스터디 시작 날짜는 필수 입력 입니다.",
-            "name, '2024-07-01',null,'', endDate : 스터디 종료 날짜는 필수 입력 입니다."
-    }, nullValues = "null")
-    @DisplayName("그룹 생성 실패 : 잘못된 요청")
-    void createGroupFailed_1(String name, LocalDate startDate, LocalDate endDate, String introduction,
-                             String exceptionMessage) throws Exception {
-        // given
-        CreateGroupRequest request = new CreateGroupRequest(name, startDate, endDate, introduction);
-        MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
-                objectMapper.writeValueAsString(request).getBytes());
-        MockMultipartFile profileImage = new MockMultipartFile("profileImage", "profile.jpg", "image/jpeg",
-                "image".getBytes());
-        // when, then
-        mockMvc.perform(multipart("/api/group")
-                        .file(requestPart)
-                        .file(profileImage)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .header("Authorization", token)
-                        .with(request1 -> {
-                            request1.setMethod("POST");
-                            return request1;
-                        }))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("그룹 생성 요청이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.messages", hasItems(exceptionMessage)));
-    }
+	@ParameterizedTest
+	@CsvSource(value = {
+		"'', '2024-07-01', '2024-07-29','', name : 스터디 이름은 1글자 이상 15글자 이하로 작성해야 합니다.",
+		"name, null, '2024-07-29','', startDate : 스터디 시작 날짜는 필수 입력 입니다.",
+		"name, '2024-07-01',null,'', endDate : 스터디 종료 날짜는 필수 입력 입니다."
+	}, nullValues = "null")
+	@DisplayName("그룹 생성 실패 : 잘못된 요청")
+	void createGroupFailed_1(String name, LocalDate startDate, LocalDate endDate, String introduction,
+		String exceptionMessage) throws Exception {
+		// given
+		CreateGroupRequest request = new CreateGroupRequest(name, startDate, endDate, introduction);
+		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
+			objectMapper.writeValueAsString(request).getBytes());
+		MockMultipartFile profileImage = new MockMultipartFile("profileImage", "profile.jpg", "image/jpeg",
+			"image".getBytes());
+		// when, then
+		mockMvc.perform(multipart("/api/group")
+				.file(requestPart)
+				.file(profileImage)
+				.contentType(MediaType.MULTIPART_FORM_DATA)
+				.header("Authorization", token)
+				.with(request1 -> {
+					request1.setMethod("POST");
+					return request1;
+				}))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("그룹 생성 요청이 올바르지 않습니다."))
+			.andExpect(jsonPath("$.messages", hasItems(exceptionMessage)));
+	}
 
-    @Test
-    @DisplayName("그룹 코드를 사용해 그룹 참여 성공")
-    void joinGroupWithCode() throws Exception {
-        // given
-        doNothing().when(studyGroupService).joinGroupWithCode(any(User.class), anyString());
-        // when, then
-        mockMvc.perform(post("/api/group/{code}/join", code)
-                        .header("Authorization", token)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().string("OK"));
+	@Test
+	@DisplayName("그룹 코드를 사용해 그룹 참여 성공")
+	void joinGroupWithCode() throws Exception {
+		// given
+		doNothing().when(studyGroupService).joinGroupWithCode(any(User.class), anyString());
+		// when, then
+		mockMvc.perform(post("/api/group/{code}/join", code)
+				.header("Authorization", token)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().string("OK"));
 
-        verify(studyGroupService, times(1)).joinGroupWithCode(user, code);
-    }
+		verify(studyGroupService, times(1)).joinGroupWithCode(user, code);
+	}
 
-    @Test
-    @DisplayName("그룹 코드를 사용해 그룹 참여 실패 : 존재하지 않는 그룹")
-    void joinGroupWithCodeFailed_1() throws Exception {
-        // given
-        doThrow(new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다.")).when(
-                studyGroupService).joinGroupWithCode(any(User.class), anyString());
-        // when, then
-        mockMvc.perform(post("/api/group/{code}/join", code)
-                        .header("Authorization", token)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.error").value("존재하지 않는 그룹 입니다."));
+	@Test
+	@DisplayName("그룹 코드를 사용해 그룹 참여 실패 : 존재하지 않는 그룹")
+	void joinGroupWithCodeFailed_1() throws Exception {
+		// given
+		doThrow(new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다.")).when(
+			studyGroupService).joinGroupWithCode(any(User.class), anyString());
+		// when, then
+		mockMvc.perform(post("/api/group/{code}/join", code)
+				.header("Authorization", token)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.error").value("존재하지 않는 그룹 입니다."));
 
-        verify(studyGroupService, times(1)).joinGroupWithCode(user, code);
-    }
+		verify(studyGroupService, times(1)).joinGroupWithCode(user, code);
+	}
 
-    @Test
-    @DisplayName("그룹 코드를 사용해 그룹 참여 실패 : 이미 참여한 그룹")
-    void joinGroupWithCodeFailed_2() throws Exception {
-        // given
-        doThrow(new StudyGroupValidationException(HttpStatus.BAD_REQUEST.value(), "이미 참여한 그룹 입니다.")).when(
-                studyGroupService).joinGroupWithCode(any(User.class), anyString());
-        // when, then
-        mockMvc.perform(post("/api/group/{code}/join", code)
-                        .header("Authorization", token)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("이미 참여한 그룹 입니다."));
+	@Test
+	@DisplayName("그룹 코드를 사용해 그룹 참여 실패 : 이미 참여한 그룹")
+	void joinGroupWithCodeFailed_2() throws Exception {
+		// given
+		doThrow(new StudyGroupValidationException(HttpStatus.BAD_REQUEST.value(), "이미 참여한 그룹 입니다.")).when(
+			studyGroupService).joinGroupWithCode(any(User.class), anyString());
+		// when, then
+		mockMvc.perform(post("/api/group/{code}/join", code)
+				.header("Authorization", token)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("이미 참여한 그룹 입니다."));
 
-        verify(studyGroupService, times(1)).joinGroupWithCode(user, code);
-    }
+		verify(studyGroupService, times(1)).joinGroupWithCode(user, code);
+	}
 
-    @Test
-    @DisplayName("그룹 목록 조회 성공")
-    void getStudyGroupList() throws Exception {
-        // given
-        List<GetStudyGroupResponse> bookmarked = new ArrayList<>();
-        List<GetStudyGroupResponse> done = new ArrayList<>();
-        List<GetStudyGroupResponse> inProgress = new ArrayList<>();
-        List<GetStudyGroupResponse> queued = new ArrayList<>();
+	@Test
+	@DisplayName("그룹 목록 조회 성공")
+	void getStudyGroupList() throws Exception {
+		// given
+		List<GetStudyGroupResponse> bookmarked = new ArrayList<>();
+		List<GetStudyGroupResponse> done = new ArrayList<>();
+		List<GetStudyGroupResponse> inProgress = new ArrayList<>();
+		List<GetStudyGroupResponse> queued = new ArrayList<>();
 
-        for (int i = 0; i < 10; i++) {
-            bookmarked.add(new GetStudyGroupResponse(
-                    (long) i, "name" + i, "groupImage" + 1,
-                    LocalDate.now(), LocalDate.now().plusDays(i),
-                    "introduction" + 1, "nickname", true, true
-            ));
-        }
+		for (int i = 0; i < 10; i++) {
+			bookmarked.add(new GetStudyGroupResponse(
+				(long)i, "name" + i, "groupImage" + 1,
+				LocalDate.now(), LocalDate.now().plusDays(i),
+				"introduction" + 1, "nickname", true, true
+			));
+		}
 
-        for (int i = 0; i < 10; i++) {
-            done.add(new GetStudyGroupResponse(
-                    (long) i, "name" + i, "groupImage" + 1,
-                    LocalDate.now(), LocalDate.now().plusDays(i),
-                    "introduction" + 1, "nickname", true, true
-            ));
-        }
-        for (int i = 0; i < 10; i++) {
-            inProgress.add(new GetStudyGroupResponse(
-                    (long) i, "name" + i, "groupImage" + 1,
-                    LocalDate.now(), LocalDate.now().plusDays(i),
-                    "introduction" + 1, "nickname", true, true
-            ));
-        }
-        for (int i = 0; i < 10; i++) {
-            queued.add(new GetStudyGroupResponse(
-                    (long) i, "name" + i, "groupImage" + 1,
-                    LocalDate.now(), LocalDate.now().plusDays(i),
-                    "introduction" + 1, "nickname", true, true
-            ));
-        }
-        GetStudyGroupListsResponse response = new GetStudyGroupListsResponse(bookmarked, done, inProgress, queued);
-        when(studyGroupService.getStudyGroupList(user)).thenReturn(response);
-        // when, then
-        mockMvc.perform(get("/api/group/list")
-                        .header("Authorization", token)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().json(objectMapper.writeValueAsString(response)));
+		for (int i = 0; i < 10; i++) {
+			done.add(new GetStudyGroupResponse(
+				(long)i, "name" + i, "groupImage" + 1,
+				LocalDate.now(), LocalDate.now().plusDays(i),
+				"introduction" + 1, "nickname", true, true
+			));
+		}
+		for (int i = 0; i < 10; i++) {
+			inProgress.add(new GetStudyGroupResponse(
+				(long)i, "name" + i, "groupImage" + 1,
+				LocalDate.now(), LocalDate.now().plusDays(i),
+				"introduction" + 1, "nickname", true, true
+			));
+		}
+		for (int i = 0; i < 10; i++) {
+			queued.add(new GetStudyGroupResponse(
+				(long)i, "name" + i, "groupImage" + 1,
+				LocalDate.now(), LocalDate.now().plusDays(i),
+				"introduction" + 1, "nickname", true, true
+			));
+		}
+		GetStudyGroupListsResponse response = new GetStudyGroupListsResponse(bookmarked, done, inProgress, queued);
+		when(studyGroupService.getStudyGroupList(user)).thenReturn(response);
+		// when, then
+		mockMvc.perform(get("/api/group/list")
+				.header("Authorization", token)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().json(objectMapper.writeValueAsString(response)));
 
-        verify(studyGroupService, times(1)).getStudyGroupList(any(User.class));
-    }
+		verify(studyGroupService, times(1)).getStudyGroupList(any(User.class));
+	}
 
-    @Test
-    @DisplayName("그룹 탈퇴 성공")
-    void leaveGroup() throws Exception {
-        // given
-        doNothing().when(studyGroupService).deleteGroup(user, groupId);
-        // when, then
-        mockMvc.perform(delete("/api/group/leave")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().string("OK"));
+	@Test
+	@DisplayName("그룹 탈퇴 성공")
+	void leaveGroup() throws Exception {
+		// given
+		doNothing().when(studyGroupService).deleteGroup(user, groupId);
+		// when, then
+		mockMvc.perform(delete("/api/group/leave")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().string("OK"));
 
-        verify(studyGroupService, times(1)).deleteGroup(any(User.class), anyLong());
-    }
+		verify(studyGroupService, times(1)).deleteGroup(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("그룹 탈퇴 실패 : 존재하지 않는 그룹")
-    void leaveGroupFailed_1() throws Exception {
-        // given
-        doThrow(new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다.")).when(
-                studyGroupService).deleteGroup(user, groupId);
-        // when, then
-        mockMvc.perform(delete("/api/group/leave")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.error").value("존재하지 않는 그룹 입니다."));
+	@Test
+	@DisplayName("그룹 탈퇴 실패 : 존재하지 않는 그룹")
+	void leaveGroupFailed_1() throws Exception {
+		// given
+		doThrow(new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다.")).when(
+			studyGroupService).deleteGroup(user, groupId);
+		// when, then
+		mockMvc.perform(delete("/api/group/leave")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.error").value("존재하지 않는 그룹 입니다."));
 
-        verify(studyGroupService, times(1)).deleteGroup(any(User.class), anyLong());
-    }
+		verify(studyGroupService, times(1)).deleteGroup(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("그룹 탈퇴 실패 : 이미 참여 안한 그룹")
-    void leaveGroupFailed_2() throws Exception {
-        // given
-        doThrow(new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "이미 참여하지 않은 그룹 입니다.")).when(
-                studyGroupService).deleteGroup(user, groupId);
-        // when, then
-        mockMvc.perform(delete("/api/group/leave")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("이미 참여하지 않은 그룹 입니다."));
+	@Test
+	@DisplayName("그룹 탈퇴 실패 : 이미 참여 안한 그룹")
+	void leaveGroupFailed_2() throws Exception {
+		// given
+		doThrow(new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "이미 참여하지 않은 그룹 입니다.")).when(
+			studyGroupService).deleteGroup(user, groupId);
+		// when, then
+		mockMvc.perform(delete("/api/group/leave")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("이미 참여하지 않은 그룹 입니다."));
 
-        verify(studyGroupService, times(1)).deleteGroup(any(User.class), anyLong());
-    }
+		verify(studyGroupService, times(1)).deleteGroup(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("그룹 멤버 삭제 성공")
-    void deleteUser() throws Exception {
-        // given
-        doNothing().when(studyGroupService).deleteMember(any(User.class), anyLong(), anyLong());
-        // when, then
-        mockMvc.perform(delete("/api/group/delete")
-                        .header("Authorization", token)
-                        .param("userId", String.valueOf(userId))
-                        .param("groupId", String.valueOf(groupId))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().string("OK"));
-        verify(studyGroupService, times(1)).deleteMember(user, userId, groupId);
-    }
+	@Test
+	@DisplayName("그룹 멤버 삭제 성공")
+	void deleteUser() throws Exception {
+		// given
+		doNothing().when(studyGroupService).deleteMember(any(User.class), anyLong(), anyLong());
+		// when, then
+		mockMvc.perform(delete("/api/group/delete")
+				.header("Authorization", token)
+				.param("userId", String.valueOf(userId))
+				.param("groupId", String.valueOf(groupId))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().string("OK"));
+		verify(studyGroupService, times(1)).deleteMember(user, userId, groupId);
+	}
 
-    @Test
-    @DisplayName("그룹 탈퇴 실패 : 참여하지 않은 그룹")
-    void deleteMemberFailed_1() throws Exception {
-        // given
-        doThrow(new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(),
-                "멤버 삭제 권한이 없습니다. : 참여하지 않은 그룹 입니다.")).when(
-                studyGroupService).deleteGroup(user, groupId);
-        // when, then
-        mockMvc.perform(delete("/api/group/leave")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("멤버 삭제 권한이 없습니다. : 참여하지 않은 그룹 입니다."));
-    }
+	@Test
+	@DisplayName("그룹 탈퇴 실패 : 참여하지 않은 그룹")
+	void deleteMemberFailed_1() throws Exception {
+		// given
+		doThrow(new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(),
+			"멤버 삭제 권한이 없습니다. : 참여하지 않은 그룹 입니다.")).when(
+			studyGroupService).deleteGroup(user, groupId);
+		// when, then
+		mockMvc.perform(delete("/api/group/leave")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("멤버 삭제 권한이 없습니다. : 참여하지 않은 그룹 입니다."));
+	}
 
-    @Test
-    @DisplayName("그룹 탈퇴 실패 : 권한 없음")
-    void deleteMemberFailed_2() throws Exception {
-        // given
-        doThrow(new UserValidationException("멤버를 삭제 할 권한이 없습니다.")).when(
-                studyGroupService).deleteGroup(user, groupId);
-        // when, then
-        mockMvc.perform(delete("/api/group/leave")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("멤버를 삭제 할 권한이 없습니다."));
-    }
+	@Test
+	@DisplayName("그룹 탈퇴 실패 : 권한 없음")
+	void deleteMemberFailed_2() throws Exception {
+		// given
+		doThrow(new UserValidationException("멤버를 삭제 할 권한이 없습니다.")).when(
+			studyGroupService).deleteGroup(user, groupId);
+		// when, then
+		mockMvc.perform(delete("/api/group/leave")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("멤버를 삭제 할 권한이 없습니다."));
+	}
 
-    @Test
-    @DisplayName("그룹 정보 수정 성공")
-    void editGroup() throws Exception {
-        // given
-        EditGroupRequest request = new EditGroupRequest(groupId, "name", LocalDate.now(), LocalDate.now().plusDays(30),
-                "editedIntroduction");
-        MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
-                objectMapper.writeValueAsBytes(request));
-        MockMultipartFile groupImage = new MockMultipartFile("groupImage", "group.jpg", "image/jpeg",
-                "image".getBytes());
-        doNothing().when(studyGroupService)
-                .editGroup(any(User.class), any(EditGroupRequest.class), any(MultipartFile.class));
-        // when, then
-        mockMvc.perform(multipart("/api/group")
-                        .file(requestPart)
-                        .file(groupImage) // 파라미터 이름이랑 똑같이 해줘야 함
-                        .header("Authorization", token)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .with(request1 -> {
-                            request1.setMethod("PATCH");
-                            return request1;
-                        }))
-                .andExpect(status().isOk())
-                .andExpect(content().string("OK"));
+	@Test
+	@DisplayName("그룹 정보 수정 성공")
+	void editGroup() throws Exception {
+		// given
+		EditGroupRequest request = new EditGroupRequest(groupId, "name", LocalDate.now(), LocalDate.now().plusDays(30),
+			"editedIntroduction");
+		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
+			objectMapper.writeValueAsBytes(request));
+		MockMultipartFile groupImage = new MockMultipartFile("groupImage", "group.jpg", "image/jpeg",
+			"image".getBytes());
+		doNothing().when(studyGroupService)
+			.editGroup(any(User.class), any(EditGroupRequest.class), any(MultipartFile.class));
+		// when, then
+		mockMvc.perform(multipart("/api/group")
+				.file(requestPart)
+				.file(groupImage) // 파라미터 이름이랑 똑같이 해줘야 함
+				.header("Authorization", token)
+				.contentType(MediaType.MULTIPART_FORM_DATA)
+				.with(request1 -> {
+					request1.setMethod("PATCH");
+					return request1;
+				}))
+			.andExpect(status().isOk())
+			.andExpect(content().string("OK"));
 
-        verify(studyGroupService, times(1)).editGroup(any(User.class), any(EditGroupRequest.class),
-                any(MultipartFile.class));
-    }
+		verify(studyGroupService, times(1)).editGroup(any(User.class), any(EditGroupRequest.class),
+			any(MultipartFile.class));
+	}
 
-    @Test
-    @DisplayName("그룹 정보 수정 실패 : 잘못된 요청__잘못된 id")
-    void editGroupFailed_1() throws Exception {
-        // given
-        EditGroupRequest request = new EditGroupRequest(null, "name", LocalDate.now(), LocalDate.now().plusDays(30),
-                "editedIntroduction");
-        MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
-                objectMapper.writeValueAsBytes(request));
-        MockMultipartFile groupImage = new MockMultipartFile("groupImage", "group.jpg", "image/jpeg",
-                "image".getBytes());
-        // when, then
-        mockMvc.perform(multipart("/api/group")
-                        .file(requestPart)
-                        .file(groupImage)
-                        .header("Authorization", token)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .with(request1 -> {
-                            request1.setMethod("PATCH");
-                            return request1;
-                        }))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("그룹 정보 수정 요청이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.messages", hasItems("id : 그룹 고유 아이디는 필수 입력 입니다.")));
-    }
+	@Test
+	@DisplayName("그룹 정보 수정 실패 : 잘못된 요청__잘못된 id")
+	void editGroupFailed_1() throws Exception {
+		// given
+		EditGroupRequest request = new EditGroupRequest(null, "name", LocalDate.now(), LocalDate.now().plusDays(30),
+			"editedIntroduction");
+		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
+			objectMapper.writeValueAsBytes(request));
+		MockMultipartFile groupImage = new MockMultipartFile("groupImage", "group.jpg", "image/jpeg",
+			"image".getBytes());
+		// when, then
+		mockMvc.perform(multipart("/api/group")
+				.file(requestPart)
+				.file(groupImage)
+				.header("Authorization", token)
+				.contentType(MediaType.MULTIPART_FORM_DATA)
+				.with(request1 -> {
+					request1.setMethod("PATCH");
+					return request1;
+				}))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("그룹 정보 수정 요청이 올바르지 않습니다."))
+			.andExpect(jsonPath("$.messages", hasItems("id : 그룹 고유 아이디는 필수 입력 입니다.")));
+	}
 
-    @Test
-    @DisplayName("그룹 정보 수정 실패 : 잘못된 요청__스터디 이름이 15글자 초과")
-    void editGroupFailed_nameTooLong() throws Exception {
-        // given
-        EditGroupRequest request = new EditGroupRequest(1L, "이름이너무긴스터디이름이네요하하", LocalDate.now(), LocalDate.now().plusDays(30),
-                "editedIntroduction"); // 16글자
-        MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
-                objectMapper.writeValueAsBytes(request));
-        MockMultipartFile groupImage = new MockMultipartFile("groupImage", "group.jpg", "image/jpeg",
-                "image".getBytes());
+	@Test
+	@DisplayName("그룹 정보 수정 실패 : 잘못된 요청__스터디 이름이 15글자 초과")
+	void editGroupFailed_nameTooLong() throws Exception {
+		// given
+		EditGroupRequest request = new EditGroupRequest(1L, "이름이너무긴스터디이름이네요하하", LocalDate.now(),
+			LocalDate.now().plusDays(30),
+			"editedIntroduction"); // 16글자
+		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
+			objectMapper.writeValueAsBytes(request));
+		MockMultipartFile groupImage = new MockMultipartFile("groupImage", "group.jpg", "image/jpeg",
+			"image".getBytes());
 
-        // when, then
-        mockMvc.perform(multipart("/api/group")
-                        .file(requestPart)
-                        .file(groupImage)
-                        .header("Authorization", token)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .with(request1 -> {
-                            request1.setMethod("PATCH");
-                            return request1;
-                        }))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("그룹 정보 수정 요청이 올바르지 않습니다."))
-                .andExpect(jsonPath("$.messages", hasItems("name : 스터디 이름은 1글자 이상 15글자 이하로 작성해야 합니다.")));
-    }
+		// when, then
+		mockMvc.perform(multipart("/api/group")
+				.file(requestPart)
+				.file(groupImage)
+				.header("Authorization", token)
+				.contentType(MediaType.MULTIPART_FORM_DATA)
+				.with(request1 -> {
+					request1.setMethod("PATCH");
+					return request1;
+				}))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("그룹 정보 수정 요청이 올바르지 않습니다."))
+			.andExpect(jsonPath("$.messages", hasItems("name : 스터디 이름은 1글자 이상 15글자 이하로 작성해야 합니다.")));
+	}
 
-    @Test
-    @DisplayName("그룹 정보 수정 실패 : 존재하지 않는 그룹")
-    void editGroupFailed_2() throws Exception {
-        // given
-        EditGroupRequest request = new EditGroupRequest(groupId, "name", LocalDate.now(), LocalDate.now().plusDays(30),
-                "editedIntroduction");
-        MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
-                objectMapper.writeValueAsBytes(request));
-        MockMultipartFile groupImage = new MockMultipartFile("groupImage", "group.jpg", "image/jpeg",
-                "image".getBytes());
-        doThrow(new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다.")).when(
-                        studyGroupService)
-                .editGroup(any(User.class), any(EditGroupRequest.class), any(MultipartFile.class));
-        // when, then
-        mockMvc.perform(multipart("/api/group")
-                        .file(requestPart)
-                        .file(groupImage)
-                        .header("Authorization", token)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .with(request1 -> {
-                            request1.setMethod("PATCH");
-                            return request1;
-                        }))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.error").value("존재하지 않는 그룹 입니다."));
+	@Test
+	@DisplayName("그룹 정보 수정 실패 : 존재하지 않는 그룹")
+	void editGroupFailed_2() throws Exception {
+		// given
+		EditGroupRequest request = new EditGroupRequest(groupId, "name", LocalDate.now(), LocalDate.now().plusDays(30),
+			"editedIntroduction");
+		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
+			objectMapper.writeValueAsBytes(request));
+		MockMultipartFile groupImage = new MockMultipartFile("groupImage", "group.jpg", "image/jpeg",
+			"image".getBytes());
+		doThrow(new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다.")).when(
+				studyGroupService)
+			.editGroup(any(User.class), any(EditGroupRequest.class), any(MultipartFile.class));
+		// when, then
+		mockMvc.perform(multipart("/api/group")
+				.file(requestPart)
+				.file(groupImage)
+				.header("Authorization", token)
+				.contentType(MediaType.MULTIPART_FORM_DATA)
+				.with(request1 -> {
+					request1.setMethod("PATCH");
+					return request1;
+				}))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.error").value("존재하지 않는 그룹 입니다."));
 
-        verify(studyGroupService, times(1)).editGroup(any(User.class), any(EditGroupRequest.class),
-                any(MultipartFile.class));
-    }
+		verify(studyGroupService, times(1)).editGroup(any(User.class), any(EditGroupRequest.class),
+			any(MultipartFile.class));
+	}
 
-    @Test
-    @DisplayName("그룹 정보 수정 실패 : 권한 없음")
-    void editGroupFailed_3() throws Exception {
-        // given
-        EditGroupRequest request = new EditGroupRequest(groupId, "name", LocalDate.now(), LocalDate.now().plusDays(30),
-                "editedIntroduction");
-        MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
-                objectMapper.writeValueAsBytes(request));
-        MockMultipartFile groupImage = new MockMultipartFile("groupImage", "group.jpg", "image/jpeg",
-                "image".getBytes());
-        doThrow(new StudyGroupValidationException(HttpStatus.FORBIDDEN.value(), "그룹 정보 수정에 대한 권한이 없습니다.")).when(
-                        studyGroupService)
-                .editGroup(any(User.class), any(EditGroupRequest.class), any(MultipartFile.class));
-        // when, then
-        mockMvc.perform(multipart("/api/group")
-                        .file(requestPart)
-                        .file(groupImage)
-                        .header("Authorization", token)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                        .with(request1 -> {
-                            request1.setMethod("PATCH");
-                            return request1;
-                        }))
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.error").value("그룹 정보 수정에 대한 권한이 없습니다."));
+	@Test
+	@DisplayName("그룹 정보 수정 실패 : 권한 없음")
+	void editGroupFailed_3() throws Exception {
+		// given
+		EditGroupRequest request = new EditGroupRequest(groupId, "name", LocalDate.now(), LocalDate.now().plusDays(30),
+			"editedIntroduction");
+		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
+			objectMapper.writeValueAsBytes(request));
+		MockMultipartFile groupImage = new MockMultipartFile("groupImage", "group.jpg", "image/jpeg",
+			"image".getBytes());
+		doThrow(new StudyGroupValidationException(HttpStatus.FORBIDDEN.value(), "그룹 정보 수정에 대한 권한이 없습니다.")).when(
+				studyGroupService)
+			.editGroup(any(User.class), any(EditGroupRequest.class), any(MultipartFile.class));
+		// when, then
+		mockMvc.perform(multipart("/api/group")
+				.file(requestPart)
+				.file(groupImage)
+				.header("Authorization", token)
+				.contentType(MediaType.MULTIPART_FORM_DATA)
+				.with(request1 -> {
+					request1.setMethod("PATCH");
+					return request1;
+				}))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.error").value("그룹 정보 수정에 대한 권한이 없습니다."));
 
-        verify(studyGroupService, times(1)).editGroup(any(User.class), any(EditGroupRequest.class),
-                any(MultipartFile.class));
-    }
+		verify(studyGroupService, times(1)).editGroup(any(User.class), any(EditGroupRequest.class),
+			any(MultipartFile.class));
+	}
 
-    @Test
-    @DisplayName("그룹 회원 목록 조회 성공")
-    void getGroupInfo() throws Exception {
-        // given
-        List<GetGroupMemberResponse> response = new ArrayList<>(30);
-        for (int i = 0; i < 30; i++) {
-            response.add(new GetGroupMemberResponse(
-                    "name" + i, LocalDate.now(), "70%", RoleOfGroupMember.ADMIN, "profileImage" + i, (long) i
-            ));
-        }
-        when(studyGroupService.getGroupMemberList(user, groupId)).thenReturn(response);
-        // when, then
-        mockMvc.perform(get("/api/group/member-list")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId)))
-                .andExpect(status().isOk())
-                .andExpect(content().json(objectMapper.writeValueAsString(response)));
+	@Test
+	@DisplayName("그룹 회원 목록 조회 성공")
+	void getGroupInfo() throws Exception {
+		// given
+		List<GetGroupMemberResponse> response = new ArrayList<>(30);
+		for (int i = 0; i < 30; i++) {
+			response.add(new GetGroupMemberResponse(
+				"name" + i, LocalDate.now(), "70%", RoleOfGroupMember.ADMIN, "profileImage" + i, (long)i
+			));
+		}
+		when(studyGroupService.getGroupMemberList(user, groupId)).thenReturn(response);
+		// when, then
+		mockMvc.perform(get("/api/group/member-list")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isOk())
+			.andExpect(content().json(objectMapper.writeValueAsString(response)));
 
-        verify(studyGroupService, times(1)).getGroupMemberList(any(User.class), anyLong());
-    }
+		verify(studyGroupService, times(1)).getGroupMemberList(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("그룹 회원 목록 조회 실패 : 존재하지 않는 그룹")
-    void getGroupInfoFailed_1() throws Exception {
-        // given
-        when(studyGroupService.getGroupMemberList(user, groupId)).thenThrow(
-                new CannotFoundGroupException("그룹을 찾을 수 없습니다."));
-        // when, then
-        mockMvc.perform(get("/api/group/member-list")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId)))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.error").value("그룹을 찾을 수 없습니다."));
+	@Test
+	@DisplayName("그룹 회원 목록 조회 실패 : 존재하지 않는 그룹")
+	void getGroupInfoFailed_1() throws Exception {
+		// given
+		when(studyGroupService.getGroupMemberList(user, groupId)).thenThrow(
+			new CannotFoundGroupException("그룹을 찾을 수 없습니다."));
+		// when, then
+		mockMvc.perform(get("/api/group/member-list")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.error").value("그룹을 찾을 수 없습니다."));
 
-        verify(studyGroupService, times(1)).getGroupMemberList(any(User.class), anyLong());
-    }
+		verify(studyGroupService, times(1)).getGroupMemberList(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("그룹 회원 목록 조회 실패 : 권한 없음")
-    void getGroupInfoFailed_2() throws Exception {
-        // given
-        when(studyGroupService.getGroupMemberList(user, groupId)).thenThrow(
-                new GroupMemberValidationException(HttpStatus.FORBIDDEN.value(), "그룹 내용을 확인할 권한이 없습니다"));
-        // when, then
-        mockMvc.perform(get("/api/group/member-list")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId)))
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.error").value("그룹 내용을 확인할 권한이 없습니다"));
+	@Test
+	@DisplayName("그룹 회원 목록 조회 실패 : 권한 없음")
+	void getGroupInfoFailed_2() throws Exception {
+		// given
+		when(studyGroupService.getGroupMemberList(user, groupId)).thenThrow(
+			new GroupMemberValidationException(HttpStatus.FORBIDDEN.value(), "그룹 내용을 확인할 권한이 없습니다"));
+		// when, then
+		mockMvc.perform(get("/api/group/member-list")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.error").value("그룹 내용을 확인할 권한이 없습니다"));
 
-        verify(studyGroupService, times(1)).getGroupMemberList(any(User.class), anyLong());
-    }
+		verify(studyGroupService, times(1)).getGroupMemberList(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("문제 별 회원 풀이 여부 조회 성공")
-    void getCheckingSolvedProblem() throws Exception {
-        // given
-        List<CheckSolvedProblemResponse> response = new ArrayList<>(30);
-        for (int i = 0; i < 30; i++) {
-            response.add(new CheckSolvedProblemResponse((long) i, "nickname" + i, "profileImage" + i, true));
-        }
-        when(studyGroupService.getCheckingSolvedProblem(any(User.class), anyLong())).thenReturn(response);
-        // when, then
-        mockMvc.perform(get("/api/group/problem-solving")
-                        .header("Authorization", token)
-                        .param("problemId", String.valueOf(problemId)))
-                .andExpect(status().isOk())
-                .andExpect(content().json(objectMapper.writeValueAsString(response)));
-        verify(studyGroupService, times(1)).getCheckingSolvedProblem(any(User.class), anyLong());
-    }
+	@Test
+	@DisplayName("문제 별 회원 풀이 여부 조회 성공")
+	void getCheckingSolvedProblem() throws Exception {
+		// given
+		List<CheckSolvedProblemResponse> response = new ArrayList<>(30);
+		for (int i = 0; i < 30; i++) {
+			response.add(new CheckSolvedProblemResponse((long)i, "nickname" + i, "profileImage" + i, true));
+		}
+		when(studyGroupService.getCheckingSolvedProblem(any(User.class), anyLong())).thenReturn(response);
+		// when, then
+		mockMvc.perform(get("/api/group/problem-solving")
+				.header("Authorization", token)
+				.param("problemId", String.valueOf(problemId)))
+			.andExpect(status().isOk())
+			.andExpect(content().json(objectMapper.writeValueAsString(response)));
+		verify(studyGroupService, times(1)).getCheckingSolvedProblem(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("문제 별 회원 풀이 여부 조회 실패 : 존재하지 않는 문제")
-    void getCheckingSolvedProblemFailed_1() throws Exception {
-        // given
-        when(studyGroupService.getCheckingSolvedProblem(any(User.class), anyLong())).thenThrow(
-                new CannotFoundGroupException("문제를 찾을 수 없습니다."));
-        // when, then
-        mockMvc.perform(get("/api/group/problem-solving")
-                        .header("Authorization", token)
-                        .param("problemId", String.valueOf(problemId)))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.error").value("문제를 찾을 수 없습니다."));
-        verify(studyGroupService, times(1)).getCheckingSolvedProblem(any(User.class), anyLong());
-    }
+	@Test
+	@DisplayName("문제 별 회원 풀이 여부 조회 실패 : 존재하지 않는 문제")
+	void getCheckingSolvedProblemFailed_1() throws Exception {
+		// given
+		when(studyGroupService.getCheckingSolvedProblem(any(User.class), anyLong())).thenThrow(
+			new CannotFoundGroupException("문제를 찾을 수 없습니다."));
+		// when, then
+		mockMvc.perform(get("/api/group/problem-solving")
+				.header("Authorization", token)
+				.param("problemId", String.valueOf(problemId)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.error").value("문제를 찾을 수 없습니다."));
+		verify(studyGroupService, times(1)).getCheckingSolvedProblem(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("문제 별 회원 풀이 여부 조회 실패 : 권한 없음")
-    void getCheckingSolvedProblemFailed_2() throws Exception {
-        // given
-        when(studyGroupService.getCheckingSolvedProblem(any(User.class), anyLong())).thenThrow(
-                new UserValidationException("풀이 여부 목록을 확인할 권한이 없습니다."));
-        // when, then
-        mockMvc.perform(get("/api/group/problem-solving")
-                        .header("Authorization", token)
-                        .param("problemId", String.valueOf(problemId)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("풀이 여부 목록을 확인할 권한이 없습니다."));
-        verify(studyGroupService, times(1)).getCheckingSolvedProblem(any(User.class), anyLong());
-    }
+	@Test
+	@DisplayName("문제 별 회원 풀이 여부 조회 실패 : 권한 없음")
+	void getCheckingSolvedProblemFailed_2() throws Exception {
+		// given
+		when(studyGroupService.getCheckingSolvedProblem(any(User.class), anyLong())).thenThrow(
+			new UserValidationException("풀이 여부 목록을 확인할 권한이 없습니다."));
+		// when, then
+		mockMvc.perform(get("/api/group/problem-solving")
+				.header("Authorization", token)
+				.param("problemId", String.valueOf(problemId)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("풀이 여부 목록을 확인할 권한이 없습니다."));
+		verify(studyGroupService, times(1)).getCheckingSolvedProblem(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("그룹 초대 코드 조회 성공")
-    void getGroupCode() throws Exception {
-        // given
-        when(studyGroupService.getGroupCode(user, groupId)).thenReturn(code);
-        // when, then
-        mockMvc.perform(get("/api/group/group-code")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId)))
-                .andExpect(status().isOk())
-                .andExpect(content().string(code));
-        verify(studyGroupService, times(1)).getGroupCode(any(User.class), anyLong());
-    }
+	@Test
+	@DisplayName("그룹 초대 코드 조회 성공")
+	void getGroupCode() throws Exception {
+		// given
+		when(studyGroupService.getGroupCode(user, groupId)).thenReturn(code);
+		// when, then
+		mockMvc.perform(get("/api/group/group-code")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isOk())
+			.andExpect(content().string(code));
+		verify(studyGroupService, times(1)).getGroupCode(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("그룹 초대 코드 조회 실패 : 존재하지 않는 그룹")
-    void getGroupCodeFailed_1() throws Exception {
-        // given
-        when(studyGroupService.getGroupCode(user, groupId)).thenThrow(new CannotFoundGroupException("그룹을 찾지 못했습니다."));
-        // when, then
-        mockMvc.perform(get("/api/group/group-code")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId)))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.error").value("그룹을 찾지 못했습니다."));
-        verify(studyGroupService, times(1)).getGroupCode(any(User.class), anyLong());
-    }
+	@Test
+	@DisplayName("그룹 초대 코드 조회 실패 : 존재하지 않는 그룹")
+	void getGroupCodeFailed_1() throws Exception {
+		// given
+		when(studyGroupService.getGroupCode(user, groupId)).thenThrow(new CannotFoundGroupException("그룹을 찾지 못했습니다."));
+		// when, then
+		mockMvc.perform(get("/api/group/group-code")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.error").value("그룹을 찾지 못했습니다."));
+		verify(studyGroupService, times(1)).getGroupCode(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("그룹 초대 코드 조회 실패 : 권한 없음")
-    void getGroupCodeFailed_2() throws Exception {
-        // given
-        when(studyGroupService.getGroupCode(user, groupId)).thenThrow(
-                new UserValidationException("초대 코드를 조회할 권한이 없습니다."));
-        // when, then
-        mockMvc.perform(get("/api/group/group-code")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("초대 코드를 조회할 권한이 없습니다."));
-        verify(studyGroupService, times(1)).getGroupCode(any(User.class), anyLong());
-    }
+	@Test
+	@DisplayName("그룹 초대 코드 조회 실패 : 권한 없음")
+	void getGroupCodeFailed_2() throws Exception {
+		// given
+		when(studyGroupService.getGroupCode(user, groupId)).thenThrow(
+			new UserValidationException("초대 코드를 조회할 권한이 없습니다."));
+		// when, then
+		mockMvc.perform(get("/api/group/group-code")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("초대 코드를 조회할 권한이 없습니다."));
+		verify(studyGroupService, times(1)).getGroupCode(any(User.class), anyLong());
+	}
 
-    @Test
-    @DisplayName("스터디 그룹 즐겨찾기 추가 성공")
-    void updateBookmarked_1() throws Exception {
-        // given
-        when(studyGroupService.updateBookmarkGroup(user, groupId)).thenReturn("스터디 그룹 즐겨찾기 추가 성공");
-        // when, then
-        mockMvc.perform(post("/api/group/bookmark")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId)))
-                .andExpect(status().isOk())
-                .andExpect(content().string("스터디 그룹 즐겨찾기 추가 성공"));
-        verify(studyGroupService, times(1)).updateBookmarkGroup(user, groupId);
-    }
+	@Test
+	@DisplayName("스터디 그룹 즐겨찾기 추가 성공")
+	void updateBookmarked_1() throws Exception {
+		// given
+		when(studyGroupService.updateBookmarkGroup(user, groupId)).thenReturn("스터디 그룹 즐겨찾기 추가 성공");
+		// when, then
+		mockMvc.perform(post("/api/group/bookmark")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isOk())
+			.andExpect(content().string("스터디 그룹 즐겨찾기 추가 성공"));
+		verify(studyGroupService, times(1)).updateBookmarkGroup(user, groupId);
+	}
 
-    @Test
-    @DisplayName("스터디 그룹 즐겨찾기 삭제 성공")
-    void updateBookmarked_2() throws Exception {
-        // given
-        when(studyGroupService.updateBookmarkGroup(user, groupId)).thenReturn("스터디 그룹 즐겨찾기 실패 성공");
-        // when, then
-        mockMvc.perform(post("/api/group/bookmark")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId)))
-                .andExpect(status().isOk())
-                .andExpect(content().string("스터디 그룹 즐겨찾기 실패 성공"));
-        verify(studyGroupService, times(1)).updateBookmarkGroup(user, groupId);
-    }
+	@Test
+	@DisplayName("스터디 그룹 즐겨찾기 삭제 성공")
+	void updateBookmarked_2() throws Exception {
+		// given
+		when(studyGroupService.updateBookmarkGroup(user, groupId)).thenReturn("스터디 그룹 즐겨찾기 실패 성공");
+		// when, then
+		mockMvc.perform(post("/api/group/bookmark")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isOk())
+			.andExpect(content().string("스터디 그룹 즐겨찾기 실패 성공"));
+		verify(studyGroupService, times(1)).updateBookmarkGroup(user, groupId);
+	}
 
-    @Test
-    @DisplayName("스터디 그룹 즐겨찾기 추가/삭제 실패 : 존재하지 않는 그룹")
-    void updateBookmarkedFailed_1() throws Exception {
-        // given
-        when(studyGroupService.updateBookmarkGroup(user, groupId)).thenThrow(
-                new CannotFoundSolutionException("존재하지 않는 그룹 입니다."));
-        // when, then
-        mockMvc.perform(post("/api/group/bookmark")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("존재하지 않는 그룹 입니다."));
-        verify(studyGroupService, times(1)).updateBookmarkGroup(user, groupId);
-    }
+	@Test
+	@DisplayName("스터디 그룹 즐겨찾기 추가/삭제 실패 : 존재하지 않는 그룹")
+	void updateBookmarkedFailed_1() throws Exception {
+		// given
+		when(studyGroupService.updateBookmarkGroup(user, groupId)).thenThrow(
+			new CannotFoundSolutionException("존재하지 않는 그룹 입니다."));
+		// when, then
+		mockMvc.perform(post("/api/group/bookmark")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("존재하지 않는 그룹 입니다."));
+		verify(studyGroupService, times(1)).updateBookmarkGroup(user, groupId);
+	}
 
-    @Test
-    @DisplayName("스터디 그룹 즐겨찾기 추가/삭제 실패 : 참여하지 않은 그룹")
-    void updateBookmarkedFailed_2() throws Exception {
-        // given
-        when(studyGroupService.updateBookmarkGroup(user, groupId)).thenThrow(
-                new StudyGroupValidationException(HttpStatus.BAD_REQUEST.value(), "참여하지 않은 그룹 입니다."));
-        // when, then
-        mockMvc.perform(post("/api/group/bookmark")
-                        .header("Authorization", token)
-                        .param("groupId", String.valueOf(groupId)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("참여하지 않은 그룹 입니다."));
-        verify(studyGroupService, times(1)).updateBookmarkGroup(user, groupId);
-    }
+	@Test
+	@DisplayName("스터디 그룹 즐겨찾기 추가/삭제 실패 : 참여하지 않은 그룹")
+	void updateBookmarkedFailed_2() throws Exception {
+		// given
+		when(studyGroupService.updateBookmarkGroup(user, groupId)).thenThrow(
+			new StudyGroupValidationException(HttpStatus.BAD_REQUEST.value(), "참여하지 않은 그룹 입니다."));
+		// when, then
+		mockMvc.perform(post("/api/group/bookmark")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("참여하지 않은 그룹 입니다."));
+		verify(studyGroupService, times(1)).updateBookmarkGroup(user, groupId);
+	}
 
-    @Test
-    @DisplayName("스터디 그룹 멤버 역할 수정 성공")
-    void updateGroupMemberRole() throws Exception {
-        // given
-        UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
-        // when, then
-        mockMvc.perform(patch("/api/group/role")
-                        .header("Authorization", token)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(content().string("OK"));
-        verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
-    }
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 성공")
+	void updateGroupMemberRole() throws Exception {
+		// given
+		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
+		// when, then
+		mockMvc.perform(patch("/api/group/role")
+				.header("Authorization", token)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(content().string("OK"));
+		verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
+	}
 
-    @Test
-    @DisplayName("스터디 그룹 멤버 역할 수정 실패 : 존재하지 않는 그룹")
-    void updateGroupMemberRoleFailed_1() throws Exception {
-        // given
-        UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
-        doThrow(new CannotFoundSolutionException("존재하지 않는 그룹입니다.")).when(studyGroupService)
-                .updateGroupMemberRole(user, request);
-        // when, then
-        mockMvc.perform(patch("/api/group/role")
-                        .header("Authorization", token)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("존재하지 않는 그룹입니다."));
-        verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
-    }
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 실패 : 존재하지 않는 그룹")
+	void updateGroupMemberRoleFailed_1() throws Exception {
+		// given
+		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
+		doThrow(new CannotFoundSolutionException("존재하지 않는 그룹입니다.")).when(studyGroupService)
+			.updateGroupMemberRole(user, request);
+		// when, then
+		mockMvc.perform(patch("/api/group/role")
+				.header("Authorization", token)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("존재하지 않는 그룹입니다."));
+		verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
+	}
 
-    @Test
-    @DisplayName("스터디 그룹 멤버 역할 수정 실패 : 스터디 그룹 멤버 역할 수정 권한 없음")
-    void updateGroupMemberRoleFailed_2() throws Exception {
-        // given
-        UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
-        doThrow(new StudyGroupValidationException(HttpStatus.FORBIDDEN.value(), "스터디 그룹 멤버 역할을 수정할 권한이 없습니다.")).when(
-                studyGroupService).updateGroupMemberRole(user, request);
-        // when, then
-        mockMvc.perform(patch("/api/group/role")
-                        .header("Authorization", token)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.error").value("스터디 그룹 멤버 역할을 수정할 권한이 없습니다."));
-        verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
-    }
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 실패 : 스터디 그룹 멤버 역할 수정 권한 없음")
+	void updateGroupMemberRoleFailed_2() throws Exception {
+		// given
+		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
+		doThrow(new StudyGroupValidationException(HttpStatus.FORBIDDEN.value(), "스터디 그룹 멤버 역할을 수정할 권한이 없습니다.")).when(
+			studyGroupService).updateGroupMemberRole(user, request);
+		// when, then
+		mockMvc.perform(patch("/api/group/role")
+				.header("Authorization", token)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.error").value("스터디 그룹 멤버 역할을 수정할 권한이 없습니다."));
+		verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
+	}
 
-    @Test
-    @DisplayName("스터디 그룹 멤버 역할 수정 실패 : 존재하지 않는 회원")
-    void updateGroupMemberRoleFailed_3() throws Exception {
-        // given
-        UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
-        doThrow(new UserValidationException("존재하지 않는 회원입니다.")).when(
-                studyGroupService).updateGroupMemberRole(user, request);
-        // when, then
-        mockMvc.perform(patch("/api/group/role")
-                        .header("Authorization", token)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("존재하지 않는 회원입니다."));
-        verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
-    }
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 실패 : 존재하지 않는 회원")
+	void updateGroupMemberRoleFailed_3() throws Exception {
+		// given
+		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
+		doThrow(new UserValidationException("존재하지 않는 회원입니다.")).when(
+			studyGroupService).updateGroupMemberRole(user, request);
+		// when, then
+		mockMvc.perform(patch("/api/group/role")
+				.header("Authorization", token)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("존재하지 않는 회원입니다."));
+		verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
+	}
 
-    @Test
-    @DisplayName("스터디 그룹 멤버 역할 수정 실패 : 스터디 그룹에 참여하지 않은 회원")
-    void updateGroupMemberRoleFailed_4() throws Exception {
-        // given
-        UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
-        doThrow(new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "해당 스터디 그룹에 참여하지 않은 회원입니다.")).when(
-                studyGroupService).updateGroupMemberRole(user, request);
-        // when, then
-        mockMvc.perform(patch("/api/group/role")
-                        .header("Authorization", token)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("해당 스터디 그룹에 참여하지 않은 회원입니다."));
-        verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
-    }
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 실패 : 스터디 그룹에 참여하지 않은 회원")
+	void updateGroupMemberRoleFailed_4() throws Exception {
+		// given
+		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(groupId, 20L, "ADMIN");
+		doThrow(new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "해당 스터디 그룹에 참여하지 않은 회원입니다.")).when(
+			studyGroupService).updateGroupMemberRole(user, request);
+		// when, then
+		mockMvc.perform(patch("/api/group/role")
+				.header("Authorization", token)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("해당 스터디 그룹에 참여하지 않은 회원입니다."));
+		verify(studyGroupService, times(1)).updateGroupMemberRole(user, request);
+	}
+
+	@Test
+	@DisplayName("그룹 내 회원 Role 조회 성공")
+	void getRoleInGroup() throws Exception {
+		// given
+		when(studyGroupService.getRoleInGroup(user, groupId)).thenReturn(RoleOfGroupMember.OWNER.getValue());
+		// when, then
+		mockMvc.perform(get("/api/group/role")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isOk())
+			.andExpect(content().string(RoleOfGroupMember.OWNER.getValue()));
+		verify(studyGroupService, times(1)).getRoleInGroup(user, groupId);
+	}
+
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 실패 : 스터디 그룹에 참여하지 않은 회원")
+	void getRoleInGroupFailed_1() throws Exception {
+		// given
+		when(studyGroupService.getRoleInGroup(user, groupId)).thenThrow(
+			new CannotFoundGroupException("존재하지 않는 그룹입니다."));
+		// when, then
+		mockMvc.perform(get("/api/group/role")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.error").value("존재하지 않는 그룹입니다."));
+		verify(studyGroupService, times(1)).getRoleInGroup(user, groupId);
+	}
+
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 실패 : 참여하지 않은 그룹")
+	void getRoleInGroupFailed_2() throws Exception {
+		// given
+		when(studyGroupService.getRoleInGroup(user, groupId)).thenThrow(
+			new GroupMemberValidationException(HttpStatus.NOT_FOUND.value(), "참여하지 않은 그룹입니다."));
+		// when, then
+		mockMvc.perform(get("/api/group/role")
+				.header("Authorization", token)
+				.param("groupId", String.valueOf(groupId)))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.error").value("참여하지 않은 그룹입니다."));
+		verify(studyGroupService, times(1)).getRoleInGroup(user, groupId);
+	}
 }

--- a/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
@@ -661,4 +661,40 @@ class StudyGroupServiceTest {
 			.hasFieldOrPropertyWithValue("code", HttpStatus.BAD_REQUEST.value())
 			.hasFieldOrPropertyWithValue("error", "해당 스터디 그룹에 참여하지 않은 회원입니다.");
 	}
+
+	@Test
+	@DisplayName("그룹 내 회원 Role 조회 성공")
+	void getRoleInGroup() {
+		// given
+		when(studyGroupRepository.findById(groupId)).thenReturn(Optional.of(group));
+		when(groupMemberRepository.findByUserAndStudyGroup(user, group)).thenReturn(Optional.ofNullable(groupMember1));
+		// when
+		String result = studyGroupService.getRoleInGroup(user, groupId);
+		// then
+		assertThat(result).isEqualTo(RoleOfGroupMember.OWNER.getValue());
+	}
+
+	@Test
+	@DisplayName("그룹 내 회원 Role 조회 실패 : 존재하지 않는 그룹")
+	void getRoleInGroupFailed_1() {
+		// given
+		when(studyGroupRepository.findById(groupId)).thenReturn(Optional.empty());
+		// when
+		assertThatThrownBy(() -> studyGroupService.getRoleInGroup(user, groupId))
+			.isInstanceOf(CannotFoundGroupException.class)
+			.hasFieldOrPropertyWithValue("errors", "존재하지 않는 그룹입니다.");
+	}
+
+	@Test
+	@DisplayName("그룹 내 회원 Role 조회 실패 : 참여하지 않은 그룹")
+	void getRoleInGroupFailed_2() {
+		// given
+		when(studyGroupRepository.findById(groupId)).thenReturn(Optional.of(group));
+		when(groupMemberRepository.findByUserAndStudyGroup(user, group)).thenReturn(Optional.empty());
+		// when
+		assertThatThrownBy(() -> studyGroupService.getRoleInGroup(user, groupId))
+			.isInstanceOf(GroupMemberValidationException.class)
+			.hasFieldOrPropertyWithValue("error", "참여하지 않은 그룹입니다.");
+	}
+
 }


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
https://github.com/GAMZA-BAT/algohub-server/issues/125

## 🚀 Description
<!-- 작업 내용 -->
- 그룹내 회원의 role을 `OWNER`, `ADMIN`, `PARTICIPANT`로 응답하는 API를 추가했습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->