### PR TITLE
feat : 문제 생성 시의 알림 로직 제거 및 문제 시작 시 알림 전송 추가

### DIFF
--- a/src/main/java/com/gamzabat/algohub/AlgohubApplication.java
+++ b/src/main/java/com/gamzabat/algohub/AlgohubApplication.java
@@ -2,7 +2,9 @@ package com.gamzabat.algohub;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class AlgohubApplication {
 

--- a/src/main/java/com/gamzabat/algohub/feature/notification/enums/NotificationMessage.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notification/enums/NotificationMessage.java
@@ -1,0 +1,15 @@
+package com.gamzabat.algohub.feature.notification.enums;
+
+public enum NotificationMessage {
+	PROBLEM_STARTED("[%s] 문제가 시작되었습니다! 지금 도전해보세요!");
+
+	private final String message;
+
+	NotificationMessage(String message) {
+		this.message = message;
+	}
+
+	public String format(String... args) {
+		return String.format(message, args);
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/feature/problem/repository/ProblemRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/problem/repository/ProblemRepository.java
@@ -21,6 +21,8 @@ public interface ProblemRepository extends JpaRepository<Problem, Long> {
 
 	List<Problem> findAllByStudyGroupAndStartDateAfter(StudyGroup studyGroup, LocalDate startDate);
 
+	List<Problem> findAllByStartDate(LocalDate startDate);
+
 	@Query("SELECT COUNT(p) FROM Problem p WHERE p.studyGroup.id = :groupId")
 	Long countProblemsByGroupId(@Param("groupId") Long groupId);
 }

--- a/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gamzabat.algohub.constants.BOJResultConstants;
 import com.gamzabat.algohub.exception.ProblemValidationException;
 import com.gamzabat.algohub.exception.StudyGroupValidationException;
+import com.gamzabat.algohub.feature.notification.enums.NotificationMessage;
 import com.gamzabat.algohub.feature.notification.service.NotificationService;
 import com.gamzabat.algohub.feature.problem.domain.Problem;
 import com.gamzabat.algohub.feature.problem.dto.CreateProblemRequest;
@@ -81,13 +82,9 @@ public class ProblemService {
 			.endDate(request.endDate())
 			.build());
 
-		List<GroupMember> members = groupMemberRepository.findAllByStudyGroup(group);
-		List<String> users = members.stream().map(member -> member.getUser().getEmail()).toList();
-		try {
-			notificationService.sendList(users, "새로운 과제가 등록되었습니다.", group, null);
-		} catch (Exception e) {
-			log.info("failed to send notification", e);
-		}
+		if (request.startDate().equals(LocalDate.now()))
+			sendProblemStartedNotification(group, title);
+
 		log.info("success to create problem");
 	}
 
@@ -253,17 +250,11 @@ public class ProblemService {
 	}
 
 	@Scheduled(cron = "0 0 0 * * *")
-	public void sendStartProblemNotification() {
+	public void dailyProblemScheduler() {
 		LocalDate now = LocalDate.now();
 		List<Problem> problems = problemRepository.findAllByStartDate(now);
 		for (Problem problem : problems) {
-			List<GroupMember> members = groupMemberRepository.findAllByStudyGroup(problem.getStudyGroup());
-			List<String> users = members.stream().map(member -> member.getUser().getEmail()).toList();
-			try {
-				notificationService.sendList(users, "새로운 과제가 등록되었습니다.", problem.getStudyGroup(), null);
-			} catch (Exception e) {
-				log.info("failed to send notification", e);
-			}
+			sendProblemStartedNotification(problem.getStudyGroup(), problem.getTitle());
 		}
 	}
 
@@ -336,5 +327,16 @@ public class ProblemService {
 
 	private Boolean isInProgress(Problem problem) {
 		return problem.getEndDate() != null && !LocalDate.now().isAfter(problem.getEndDate());
+	}
+
+	private void sendProblemStartedNotification(StudyGroup group, String title) {
+		List<GroupMember> members = groupMemberRepository.findAllByStudyGroup(group);
+		List<String> users = members.stream().map(member -> member.getUser().getEmail()).toList();
+		try {
+			String message = NotificationMessage.PROBLEM_STARTED.format(title);
+			notificationService.sendList(users, message, group, null);
+		} catch (Exception e) {
+			log.info("failed to send notification", e);
+		}
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
@@ -336,7 +336,7 @@ public class ProblemService {
 			String message = NotificationMessage.PROBLEM_STARTED.format(title);
 			notificationService.sendList(users, message, group, null);
 		} catch (Exception e) {
-			log.info("failed to send notification", e);
+			log.warn("failed to send notification", e);
 		}
 	}
 }

--- a/src/test/java/com/gamzabat/algohub/service/ProblemServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/ProblemServiceTest.java
@@ -124,8 +124,8 @@ class ProblemServiceTest {
 		CreateProblemRequest request = CreateProblemRequest.builder()
 			.groupId(10L)
 			.link("https://www.acmicpc.net/problem/1000")
-			.startDate(LocalDate.now().minusDays(7))
-			.endDate(LocalDate.now())
+			.startDate(LocalDate.now().plusDays(3))
+			.endDate(LocalDate.now().plusDays(10))
 			.build();
 		when(groupRepository.findById(10L)).thenReturn(Optional.ofNullable(group));
 		String apiResult = "[{\"titleKo\":\"A+B\",\"level\":1}]";
@@ -142,9 +142,8 @@ class ProblemServiceTest {
 		assertThat(result.getNumber()).isEqualTo(1000);
 		assertThat(result.getTitle()).isEqualTo("A+B");
 		assertThat(result.getLevel()).isEqualTo(1);
-		assertThat(result.getStartDate()).isEqualTo(LocalDate.now().minusDays(7));
-		assertThat(result.getEndDate()).isEqualTo(LocalDate.now());
-		verify(notificationService, times(1)).sendList(any(), any(), any(), any());
+		assertThat(result.getStartDate()).isEqualTo(LocalDate.now().plusDays(3));
+		assertThat(result.getEndDate()).isEqualTo(LocalDate.now().plusDays(10));
 	}
 
 	@Test
@@ -154,8 +153,8 @@ class ProblemServiceTest {
 		CreateProblemRequest request = CreateProblemRequest.builder()
 			.groupId(10L)
 			.link("https://www.acmicpc.net/problem/1000")
-			.startDate(LocalDate.now().minusDays(7))
-			.endDate(LocalDate.now())
+			.startDate(LocalDate.now())
+			.endDate(LocalDate.now().plusDays(10))
 			.build();
 		when(groupRepository.findById(10L)).thenReturn(Optional.ofNullable(group));
 		when(groupMemberRepository.findByUserAndStudyGroup(user3, group)).thenReturn(Optional.of(groupMember3));
@@ -172,8 +171,8 @@ class ProblemServiceTest {
 		assertThat(result.getNumber()).isEqualTo(1000);
 		assertThat(result.getTitle()).isEqualTo("A+B");
 		assertThat(result.getLevel()).isEqualTo(1);
-		assertThat(result.getStartDate()).isEqualTo(LocalDate.now().minusDays(7));
-		assertThat(result.getEndDate()).isEqualTo(LocalDate.now());
+		assertThat(result.getStartDate()).isEqualTo(LocalDate.now());
+		assertThat(result.getEndDate()).isEqualTo(LocalDate.now().plusDays(10));
 		verify(notificationService, times(1)).sendList(any(), any(), any(), any());
 	}
 
@@ -283,8 +282,8 @@ class ProblemServiceTest {
 		CreateProblemRequest request = CreateProblemRequest.builder()
 			.groupId(10L)
 			.link("https://www.acmicpc.net/problem/1000")
-			.startDate(LocalDate.now().minusDays(7))
-			.endDate(LocalDate.now())
+			.startDate(LocalDate.now())
+			.endDate(LocalDate.now().plusDays(10))
 			.build();
 		when(groupRepository.findById(10L)).thenReturn(Optional.ofNullable(group));
 		String apiResult = "[{\"titleKo\":\"A+B\",\"level\":1}]";


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
https://github.com/GAMZA-BAT/algohub-server/issues/119

## 🚀 Description
<!-- 작업 내용 -->
- 문제 시작 시 그룹 멤버들에게 알림을 전송하는 기능을 추가했습니다.
- 기본적으로 매일 자정에 문제의 `startDate`가 오늘이면 알림을 전송하도록 스케줄러를 만들었습니다.
- 문제 시작을 문제 만든 당일에 하는 경우 바로 알림이 전송되어야 하기에 이 부분도 고려했습니다.
- 그래서 문제를 생성할 때 시작날짜가 오늘이면 바로 알림을 전송하도록 만들었습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->