### PR TITLE
refactor : 문제 풀이 결과 형태 수정

### DIFF
--- a/src/main/java/com/gamzabat/algohub/constants/BOJResultConstants.java
+++ b/src/main/java/com/gamzabat/algohub/constants/BOJResultConstants.java
@@ -9,6 +9,7 @@ public class BOJResultConstants {
 	public static final String MEMORY_OVER = "메모리 초과";
 	public static final String OVER_OUTPUT_LIMIT = "출력 초과";
 	public static final String WRONG_OUTPUT_FORMAT = "출력 형식이 잘못되었습니다";
+	public static final String WRONG_OUTPUT_FORMAT_CUSTOM = "출력 에러";
 
 	private BOJResultConstants() {
 		throw new RuntimeException("Can not instantiate : BOJResultConstants");

--- a/src/main/java/com/gamzabat/algohub/feature/solution/dto/GetSolutionResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/dto/GetSolutionResponse.java
@@ -1,6 +1,7 @@
 package com.gamzabat.algohub.feature.solution.dto;
 
 import com.gamzabat.algohub.common.DateFormatUtil;
+import com.gamzabat.algohub.constants.BOJResultConstants;
 import com.gamzabat.algohub.feature.solution.domain.Solution;
 
 import lombok.Builder;
@@ -17,6 +18,7 @@ public record GetSolutionResponse(Long solutionId,
 								  String language,
 								  Integer codeLength,
 								  Long commentCount) {
+
 	public static GetSolutionResponse toDTO(Solution solution, Long commentCount) {
 		return GetSolutionResponse.builder()
 			.solutionId(solution.getId())
@@ -24,12 +26,21 @@ public record GetSolutionResponse(Long solutionId,
 			.profileImage(solution.getUser().getProfileImage())
 			.solvedDateTime(DateFormatUtil.formatDateTime(solution.getSolvedDateTime()))
 			.content(solution.getContent())
-			.result(solution.getResult())
+			.result(convertToCustomResult(solution.getResult()))
 			.memoryUsage(solution.getMemoryUsage())
 			.executionTime(solution.getExecutionTime())
 			.language(solution.getLanguage())
 			.codeLength(solution.getCodeLength())
 			.commentCount(commentCount)
 			.build();
+	}
+
+	private static String convertToCustomResult(String result) {
+		if (result.endsWith("점"))
+			return BOJResultConstants.CORRECT;
+		else if (result.equals(BOJResultConstants.WRONG_OUTPUT_FORMAT))
+			return BOJResultConstants.WRONG_OUTPUT_FORMAT_CUSTOM;
+		else
+			return result.contains("(") ? result.substring(0, result.indexOf("(")).trim() : result;
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/solution/repository/querydsl/CustomSolutionRepositoryImpl.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/repository/querydsl/CustomSolutionRepositoryImpl.java
@@ -45,10 +45,10 @@ public class CustomSolutionRepositoryImpl implements CustomSolutionRepository {
 			if (result.equals(CORRECT))
 				query.where(solution.result.eq(result)
 					.or(solution.result.endsWith("점")));
-			else if (result.equals(RUNTIME_ERROR))
-				query.where(solution.result.startsWith(RUNTIME_ERROR));
+			else if (result.equals(WRONG_OUTPUT_FORMAT_CUSTOM))
+				query.where(solution.result.eq(WRONG_OUTPUT_FORMAT));
 			else
-				query.where(solution.result.eq(result));
+				query.where(solution.result.startsWith(result));
 		}
 	}
 

--- a/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
@@ -155,7 +155,7 @@ class SolutionServiceTest {
 		}
 		for (int i = 5; i < 10; i++) {
 			assertThat(correctResult.getContent().get(i).content()).isEqualTo("content" + (i + 10));
-			assertThat(correctResult.getContent().get(i).result()).isEqualTo((i + 10) + "점");
+			assertThat(correctResult.getContent().get(i).result()).isEqualTo("맞았습니다!!");
 			assertThat(correctResult.getContent().get(i).memoryUsage()).isEqualTo(i + 10);
 			assertThat(correctResult.getContent().get(i).executionTime()).isEqualTo(i + 10);
 			assertThat(correctResult.getContent().get(i).nickname()).isEqualTo("nickname2");
@@ -349,7 +349,7 @@ class SolutionServiceTest {
 				.user(user)
 				.memoryUsage(i)
 				.executionTime(i)
-				.result("컴파일 에러")
+				.result("컴파일 에러 (IndexError)")
 				.language("Java 11")
 				.codeLength(i)
 				.solvedDateTime(fixedDateTime)


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
https://github.com/GAMZA-BAT/algohub-server/issues/136

## 🚀 Description
<!-- 작업 내용 -->
- 문제 풀이 결과 형태를 아래의 케이스들로만 나오도록 수정했습니다.
`맞았습니다!!`,
`출력 에러`,
`틀렸습니다`,
`시간초과`,
`메모리 초과`,
`출력 초과`,
`런타임 에러`,
`컴파일 에러`
- DB에서 결과는 백준 그대로 갖고 있고, 요청 및 응답을 처리할 때만 가공되도록 수정했습니다.
- 풀이 조회 시, request를 처리할 때 `출력 에러`로 오면 `출력 형태가 잘못되었습니다`를 검색 하도록 필터링을 수정했습니다.
- 점수 형태의 경우도 `맞았습니다!!`로 수정되어 응답됩니다.
- 기존 런타임 에러에서는 IndexError나 RecursionError 등 옆에 괄호로 에러 원인이 써있었는데, DTO에서 이를 제거하는 private 메서드를 추가했습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->