### PR TITLE
feat : 나의 풀이 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/solution/controller/SolutionController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/controller/SolutionController.java
@@ -27,12 +27,12 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/solution")
+@RequestMapping("/api")
 @Tag(name = "풀이 API", description = "문제 풀이 관련 API")
 public class SolutionController {
 	private final SolutionService solutionService;
 
-	@GetMapping
+	@GetMapping("/solutions")
 	@Operation(summary = "풀이 목록 조회 API", description = "특정 문제에 대한 풀이를 모두 조회하는 API")
 	public ResponseEntity<Page<GetSolutionResponse>> getSolutionList(@AuthedUser User user,
 		@RequestParam Long problemId,
@@ -47,7 +47,7 @@ public class SolutionController {
 		return ResponseEntity.ok().body(response);
 	}
 
-	@GetMapping("/{solutionId}")
+	@GetMapping("/solution/{solutionId}")
 	@Operation(summary = "풀이 하나 조회 API", description = "특정 풀이 하나를 조회하는 API")
 	public ResponseEntity<GetSolutionResponse> getSolution(@AuthedUser User user,
 		@PathVariable Long solutionId) {
@@ -55,7 +55,7 @@ public class SolutionController {
 		return ResponseEntity.ok().body(response);
 	}
 
-	@PostMapping
+	@PostMapping("/solution")
 	@Operation(summary = "풀이 생성 API")
 	public ResponseEntity<Void> createSolution(@Valid @RequestBody CreateSolutionRequest request, Errors errors) {
 		if (errors.hasErrors())
@@ -64,4 +64,17 @@ public class SolutionController {
 		return ResponseEntity.ok().build();
 	}
 
+	@GetMapping("/my-solutions")
+	@Operation(summary = "나의 풀이 목록 조회 API", description = "나의 풀이를 모두 조회하는 API")
+	public ResponseEntity<Page<GetSolutionResponse>> getSolutionList(@AuthedUser User user,
+		@RequestParam Long problemId,
+		@RequestParam(required = false) String language,
+		@RequestParam(required = false) String result,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "20") int size) {
+		Pageable pageable = PageRequest.of(page, size);
+		Page<GetSolutionResponse> response = solutionService.getSolutionList(user, problemId, user.getNickname(),
+			language, result, pageable);
+		return ResponseEntity.ok().body(response);
+	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/solution/controller/SolutionController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/controller/SolutionController.java
@@ -47,7 +47,7 @@ public class SolutionController {
 		return ResponseEntity.ok().body(response);
 	}
 
-	@GetMapping("/solution/{solutionId}")
+	@GetMapping("/solutions/{solutionId}")
 	@Operation(summary = "풀이 하나 조회 API", description = "특정 풀이 하나를 조회하는 API")
 	public ResponseEntity<GetSolutionResponse> getSolution(@AuthedUser User user,
 		@PathVariable Long solutionId) {
@@ -55,7 +55,7 @@ public class SolutionController {
 		return ResponseEntity.ok().body(response);
 	}
 
-	@PostMapping("/solution")
+	@PostMapping("/solutions")
 	@Operation(summary = "풀이 생성 API")
 	public ResponseEntity<Void> createSolution(@Valid @RequestBody CreateSolutionRequest request, Errors errors) {
 		if (errors.hasErrors())

--- a/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
@@ -23,7 +23,6 @@ import com.gamzabat.algohub.feature.group.studygroup.exception.GroupMemberValida
 import com.gamzabat.algohub.feature.group.studygroup.repository.GroupMemberRepository;
 import com.gamzabat.algohub.feature.group.studygroup.repository.StudyGroupRepository;
 import com.gamzabat.algohub.feature.notification.enums.NotificationCategory;
-import com.gamzabat.algohub.feature.notification.repository.NotificationSettingRepository;
 import com.gamzabat.algohub.feature.notification.service.NotificationService;
 import com.gamzabat.algohub.feature.problem.domain.Problem;
 import com.gamzabat.algohub.feature.problem.repository.ProblemRepository;
@@ -54,7 +53,6 @@ public class SolutionService {
 	private final SolutionCommentRepository commentRepository;
 	private final RankingService rankingService;
 	private final RankingUpdateService rankingUpdateService;
-	private final NotificationSettingRepository notificationSettingRepository;
 
 	public Page<GetSolutionResponse> getSolutionList(User user, Long problemId, String nickname,
 		String language, String result, Pageable pageable) {

--- a/src/test/java/com/gamzabat/algohub/feature/solution/controller/SolutionControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/solution/controller/SolutionControllerTest.java
@@ -90,7 +90,7 @@ class SolutionControllerTest {
 		when(solutionService.getSolutionList(any(User.class), anyLong(), isNull(), isNull(), isNull(),
 			any(Pageable.class))).thenReturn(pagedResponse);
 		// when, then
-		mockMvc.perform(get("/api/solution")
+		mockMvc.perform(get("/api/solutions")
 				.header("Authorization", token)
 				.param("problemId", String.valueOf(problemId)))
 			.andExpect(status().isOk())
@@ -107,7 +107,7 @@ class SolutionControllerTest {
 			any(Pageable.class)))
 			.thenThrow(new ProblemValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 문제 입니다."));
 		// when, then
-		mockMvc.perform(get("/api/solution")
+		mockMvc.perform(get("/api/solutions")
 				.header("Authorization", token)
 				.param("problemId", String.valueOf(problemId)))
 			.andExpect(status().isNotFound())
@@ -124,7 +124,7 @@ class SolutionControllerTest {
 			any(Pageable.class)))
 			.thenThrow(new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다."));
 		// when, then
-		mockMvc.perform(get("/api/solution")
+		mockMvc.perform(get("/api/solutions")
 				.header("Authorization", token)
 				.param("problemId", String.valueOf(problemId)))
 			.andExpect(status().isNotFound())
@@ -141,7 +141,7 @@ class SolutionControllerTest {
 			any(Pageable.class)))
 			.thenThrow(new GroupMemberValidationException(HttpStatus.FORBIDDEN.value(), "참여하지 않은 그룹 입니다."));
 		// when, then
-		mockMvc.perform(get("/api/solution")
+		mockMvc.perform(get("/api/solutions")
 				.header("Authorization", token)
 				.param("problemId", String.valueOf(problemId)))
 			.andExpect(status().isForbidden())
@@ -156,7 +156,7 @@ class SolutionControllerTest {
 		GetSolutionResponse response = GetSolutionResponse.builder().build();
 		when(solutionService.getSolution(any(User.class), anyLong())).thenReturn(response);
 		// when, then
-		mockMvc.perform(get("/api/solution/{solutionId}", solutionId)
+		mockMvc.perform(get("/api/solutions/{solutionId}", solutionId)
 				.header("Authorization", token))
 			.andExpect(status().isOk())
 			.andExpect(content().string(objectMapper.writeValueAsString(response)));
@@ -170,7 +170,7 @@ class SolutionControllerTest {
 		when(solutionService.getSolution(any(User.class), eq(solutionId)))
 			.thenThrow(new CannotFoundSolutionException("존재하지 않는 풀이 입니다."));
 		// when, then
-		mockMvc.perform(get("/api/solution/{solutionId}", solutionId)
+		mockMvc.perform(get("/api/solutions/{solutionId}", solutionId)
 				.header("Authorization", token))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.error").value("존재하지 않는 풀이 입니다."));
@@ -184,7 +184,7 @@ class SolutionControllerTest {
 		when(solutionService.getSolution(any(User.class), eq(solutionId)))
 			.thenThrow(new CannotFoundSolutionException("존재하지 않는 풀이 입니다."));
 		// when, then
-		mockMvc.perform(get("/api/solution/{solutionId}", solutionId)
+		mockMvc.perform(get("/api/solutions/{solutionId}", solutionId)
 				.header("Authorization", token))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.error").value("존재하지 않는 풀이 입니다."));
@@ -198,7 +198,7 @@ class SolutionControllerTest {
 		when(solutionService.getSolution(any(User.class), eq(solutionId)))
 			.thenThrow(new UserValidationException("해당 풀이를 확인 할 권한이 없습니다."));
 		// when, then
-		mockMvc.perform(get("/api/solution/{solutionId}", solutionId)
+		mockMvc.perform(get("/api/solutions/{solutionId}", solutionId)
 				.header("Authorization", token))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.error").value("해당 풀이를 확인 할 권한이 없습니다."));


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://github.com/GAMZA-BAT/algohub-server/issues/155

## 🚀 Description
<!-- 작업 내용 -->
- 나의 풀이 목록을 조회하는 API를 추가했습니다.
- service 계층은 추가된 사항 없습니다. 기존에 풀이 목록 조회하던 service 메소드에 request로 닉네임만 현재 유저로 박아넣으면 재활용이 가능합니다.
- controller단에서 내 풀이 목록 조회 API 추가와 함께 다른 API들 엔드포인트들을 좀 수정했습니다. (`/api/solution/my-solutions`은 좀 에바같아서)
- 곧 API들 엔드포인트 대거 수정이 발생할 수 있을 것 같아서 지금은 임의로 이렇게 만들었고, 추후에 한 번에 제대로 수정하지 않을까 싶습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->
- 좋은 API 엔드포인트 설계 예시 중 하나가 이런게 있더라구요.
```
DB 상에서 book이라는 테이블을 사용한다고 가정해보자.
- 특정 책 하나를 가져오는 요청은 여러 책 중에서 하나를 가져오는 것 이므로, GET /books:id
- 책 전체를 가져오는 요청은 여러 책들의 리스트를 가져오는 것 이므로, GET /books
- 책 한권을 등록하는 요청은 여러 책 안에 한 권의 책을 임의의 ID를 부여하면서 추가하는 것 이므로, POST /books
- 특정 책의 내용을 변경하는 요청은 여러 책 안에 있는 한 권의 책을 변경하는 것 이므로, PUT /books:id
```
- 좋은 예시같긴 한데 stackoverflow 보니 모두가 동의하는 사항은 아닌가봅니다. 하지만 단수형이든 복수형이든 하나로 통일해서 사용 해야 한다는게 공통 의견인 것 같아요.
- 추후에 엔드포인트 설계를 하게 된다면 같이 고민해 볼 사항이 될 것 같습니다. 엔드포인트가 제일 어렵네요 :(