### PR TITLE
refactor:notice 날짜 포맷팅 수정

### DIFF
--- a/src/main/java/com/gamzabat/algohub/common/DateFormatUtil.java
+++ b/src/main/java/com/gamzabat/algohub/common/DateFormatUtil.java
@@ -14,4 +14,9 @@ public final class DateFormatUtil {
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm:ss");
 		return dateTime.format(formatter);
 	}
+
+	public static String formatDateTimeForNotice(LocalDateTime dateTime) {
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yy/MM.dd HH:mm");
+		return dateTime.format(formatter);
+	}
 }

--- a/src/main/java/com/gamzabat/algohub/common/DateFormatUtil.java
+++ b/src/main/java/com/gamzabat/algohub/common/DateFormatUtil.java
@@ -16,7 +16,7 @@ public final class DateFormatUtil {
 	}
 
 	public static String formatDateTimeForNotice(LocalDateTime dateTime) {
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yy/MM/dd HH:mm");
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yy/MM/dd HH:mm a");
 		return dateTime.format(formatter);
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/common/DateFormatUtil.java
+++ b/src/main/java/com/gamzabat/algohub/common/DateFormatUtil.java
@@ -16,7 +16,7 @@ public final class DateFormatUtil {
 	}
 
 	public static String formatDateTimeForNotice(LocalDateTime dateTime) {
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yy/MM.dd HH:mm");
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yy/MM/dd HH:mm");
 		return dateTime.format(formatter);
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/notice/dto/GetNoticeResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notice/dto/GetNoticeResponse.java
@@ -18,7 +18,7 @@ public record GetNoticeResponse(String author,
 			.noticeId(notice.getId())
 			.noticeTitle(notice.getTitle())
 			.noticeContent(notice.getContent())
-			.createAt(DateFormatUtil.formatDate(notice.getCreatedAt().toLocalDate()))
+			.createAt(DateFormatUtil.formatDateTimeForNotice(notice.getCreatedAt()))
 			.build();
 
 	}

--- a/src/main/java/com/gamzabat/algohub/feature/notice/service/NoticeService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notice/service/NoticeService.java
@@ -73,7 +73,7 @@ public class NoticeService {
 			.noticeId(notice.getId())
 			.noticeTitle(notice.getTitle())
 			.noticeContent(notice.getContent())
-			.createAt(DateFormatUtil.formatDate(notice.getCreatedAt().toLocalDate()))
+			.createAt(DateFormatUtil.formatDateTimeForNotice(notice.getCreatedAt()))
 			.build();
 	}
 

--- a/src/test/java/com/gamzabat/algohub/service/NoticeServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/NoticeServiceTest.java
@@ -181,7 +181,7 @@ public class NoticeServiceTest {
 		assertThat(response.content()).isEqualTo("content");
 		assertThat(response.title()).isEqualTo("title");
 		assertThat(response.category()).isEqualTo("category");
-		assertThat(response.createAt()).isEqualTo(DateFormatUtil.formatDate(LocalDateTime.now().toLocalDate()));
+		assertThat(response.createAt()).isEqualTo(DateFormatUtil.formatDateTimeForNotice(notice.getCreatedAt()));
 		assertThat(response.noticeId()).isEqualTo(1000L);
 	}
 


### PR DESCRIPTION
## 📌 Related Issue
#157 
## 🚀 Description
<!-- 작업 내용 -->
- 공지 날짜 포맷팅 수정했습니다

## 📢 Review Point
- 공지 날짜 포맷팅 수정했는데 DateFormatUtil에 공지를 위한 static 함수를 만들어서 했는데.. 잘 한게 맞을지 모르겠습니다


## 📚Etc (선택)
- 원래 DateFormatUtil의 함수 포맷만 변경하려 했는데 solution에서 쓰이고 있길래 공지로 따로 만들어서 했습니다 어렵네요..

- [Q] 이 흐름이 궁금합니다 Notice를 만들면 DB에 
```java
	noticeRepository.save(Notice.builder()
			.author(user)
			.studyGroup(studyGroup)
			.title(request.title())
			.content(request.content())
			.createdAt(LocalDateTime.now())
			.build());
```
이렇게 저장을 해놓는거잖아요? 저장 후에 클라에서 요청을 받으면
Response를 
```java
		return GetNoticeResponse.builder()
			.author(notice.getAuthor().getNickname())
			.noticeId(notice.getId())
			.noticeTitle(notice.getTitle())
			.noticeContent(notice.getContent())
			.createAt(DateFormatUtil.formatDateTimeForNotice(notice.getCreatedAt()))
			.build();
```
이렇게 보내 주는 흐름이 맞는지.. 궁금합니다