### PR TITLE
fix : 문제 삭제 시 soft delete 오류 해결

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/problem/domain/Problem.java
+++ b/src/main/java/com/gamzabat/algohub/feature/problem/domain/Problem.java
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @SQLRestriction("deleted_at IS NULL")
-@SQLDelete(sql = "UPDATE Problem SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@SQLDelete(sql = "UPDATE problem SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 public class Problem {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://github.com/GAMZA-BAT/algohub-server/issues/181

## 🚀 Description
<!-- 작업 내용 -->
- 찾아보니 저의 local DB와 RDS가 대소문자 구분하는 설정이 다르게 되어 있었습니다.
- MySql 가서 아래 쿼리 날려보시면 설정 확인 가능합니다.
```sql
show variables like 'lower%';
```
- local DB 값은 아래와 같았습니다.
<p align="center"><img src="https://github.com/user-attachments/assets/e052d1ce-a53a-4345-95f2-253a02f48fc6"></p>

- `lower_case_table_names`만 참고하시면 됩니다.
    - 0 : 테이블 생성 시 대소문자를 구분합니다.
    - 1 : 테이블 생성 시 대소문자를 구분하지 않습니다.
    - 2 : 테이블 생성 시에는 대소문자를 구분하지만, 테이블 관련 쿼리를 날릴 땐 대소문자를 구분하지 않습니다.

- 서버 RDS의 값은 아래와 같았습니다.
<p align="center"><img src="https://github.com/user-attachments/assets/90ebc84e-faa7-47d5-b500-5ca4da50dbc2"></p>

- `lower_case_table_names` 값이 0입니다. 즉, 대소문자를 구분합니다.
- 기존 문제 삭제 API에서 soft delete를 사용하는데, `@SQLDelete` 쿼리를 보니 아래와 같았습니다.
```sql
UPDATE Problem SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?;
```
- 우리 DB는 대소문자를 구분하지만, 쿼리에서는 `Problem` 테이블을 찾고있으므로 기존 `problem` 테이블과 매칭이 안되어 오류가 발생했을거라고 예상합니다.
- local에서 잘 돌아가는 이유도 아마 대소문자를 구분하지 않는 설정 때문이라고 예상 중입니다.
- 리뷰 하시는 분들도 각자 mysql에서 한 번씩 위 쿼리로 대소문자 구분 확인 해보시고, 대소문자 구분은.. 뭐가 맞을진 잘 모르겠네요 안하는게 좋을 것 같기도하고

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->
- 참고한 링크입니다-
https://codinghero.tistory.com/57