### PR TITLE
fix : JwtAuthenticationFilter 제외 endpoint 수정

### DIFF
--- a/src/main/java/com/gamzabat/algohub/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/JwtAuthenticationFilter.java
@@ -21,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private final TokenProvider tokenProvider;
-	private final List<String> excludedPaths = Arrays.asList("/api/user/sign-in", "/api/user/register");
+	private final List<String> excludedPaths = Arrays.asList("/api/users/sign-in", "/api/users/sign-up");
 
 	@Override
 	protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://github.com/GAMZA-BAT/algohub-server/issues/183

## 🚀 Description
<!-- 작업 내용 -->
- `JwtAuthenticationFilter`에서 토큰 검증을 제외하는 엔드포인트를 `/api/users/sign-in`과 `/api/users/sign-up`으로 수정했습니다.
- 그냥 기존의 회원가입, 로그인 엔드포인트 수정된거 적용한겁니다.
- 위 엔드포인트로 들어오는 API 요청은 JWT에 대한 유효성 검증을 진행하지 않는다고 보심 됩니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->