### PR TITLE
feat : 공지, 랭킹 목록 조회 페이징 적용 및 잡다한 것들

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/group/ranking/controller/RankingController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/ranking/controller/RankingController.java
@@ -1,11 +1,13 @@
 package com.gamzabat.algohub.feature.group.ranking.controller;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.gamzabat.algohub.common.annotation.AuthedUser;
@@ -26,8 +28,12 @@ public class RankingController {
 
 	@GetMapping(value = "/{groupId}/rankings")
 	@Operation(summary = "과제 진행도 전체순위 API")
-	public ResponseEntity<List<GetRankingResponse>> getAllRanking(@AuthedUser User user, @PathVariable Long groupId) {
-		List<GetRankingResponse> rankingResponse = rankingService.getAllRank(user, groupId);
+	public ResponseEntity<Page<GetRankingResponse>> getAllRanking(@AuthedUser User user, @PathVariable Long groupId,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "20") int size) {
+		Pageable pageable = PageRequest.of(page, size);
+
+		Page<GetRankingResponse> rankingResponse = rankingService.getAllRank(user, groupId, pageable);
 		return ResponseEntity.ok().body(rankingResponse);
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/group/ranking/dto/GetRankingResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/ranking/dto/GetRankingResponse.java
@@ -1,5 +1,7 @@
 package com.gamzabat.algohub.feature.group.ranking.dto;
 
+import com.gamzabat.algohub.feature.group.ranking.domain.Ranking;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -19,5 +21,15 @@ public class GetRankingResponse {
 		this.rank = rank;
 		this.solvedCount = solvedCount;
 		this.rankDiff = rankDiff;
+	}
+
+	public static GetRankingResponse toDTO(Ranking ranking) {
+		return new GetRankingResponse(
+			ranking.getMember().getUser().getNickname(),
+			ranking.getMember().getUser().getProfileImage(),
+			ranking.getCurrentRank(),
+			ranking.getSolvedCount(),
+			ranking.getRankDiff()
+		);
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/group/ranking/repository/querydsl/CustomRankingRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/ranking/repository/querydsl/CustomRankingRepository.java
@@ -2,9 +2,14 @@ package com.gamzabat.algohub.feature.group.ranking.repository.querydsl;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import com.gamzabat.algohub.feature.group.ranking.domain.Ranking;
 import com.gamzabat.algohub.feature.group.studygroup.domain.StudyGroup;
 
 public interface CustomRankingRepository {
+	Page<Ranking> findAllByStudyGroup(StudyGroup studyGroup, Pageable pageable);
+
 	List<Ranking> findAllByStudyGroup(StudyGroup studyGroup);
 }

--- a/src/main/java/com/gamzabat/algohub/feature/group/ranking/repository/querydsl/CustomRankingRepositoryImpl.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/ranking/repository/querydsl/CustomRankingRepositoryImpl.java
@@ -6,10 +6,14 @@ import static com.gamzabat.algohub.feature.user.domain.QUser.*;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 import com.gamzabat.algohub.feature.group.ranking.domain.Ranking;
 import com.gamzabat.algohub.feature.group.studygroup.domain.StudyGroup;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.AllArgsConstructor;
@@ -20,11 +24,30 @@ public class CustomRankingRepositoryImpl implements CustomRankingRepository {
 	private final JPAQueryFactory queryFactory;
 
 	@Override
+	public Page<Ranking> findAllByStudyGroup(StudyGroup studyGroup, Pageable pageable) {
+		JPAQuery<Ranking> query = getRankingsQuery(studyGroup)
+			.orderBy(ranking.currentRank.asc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize());
+		JPAQuery<Long> countQuery = rankingCountQuery();
+
+		return PageableExecutionUtils.getPage(query.fetch(), pageable, countQuery::fetchOne);
+	}
+
+	@Override
 	public List<Ranking> findAllByStudyGroup(StudyGroup studyGroup) {
+		return getRankingsQuery(studyGroup).fetch();
+	}
+
+	private JPAQuery<Ranking> getRankingsQuery(StudyGroup studyGroup) {
 		return queryFactory.selectFrom(ranking)
 			.join(ranking.member, groupMember).fetchJoin()
 			.join(groupMember.user, user).fetchJoin()
-			.where(ranking.member.studyGroup.eq(studyGroup))
-			.fetch();
+			.where(ranking.member.studyGroup.eq(studyGroup));
+	}
+
+	private JPAQuery<Long> rankingCountQuery() {
+		return queryFactory.select(ranking.count())
+			.from(ranking);
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/group/ranking/service/RankingService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/ranking/service/RankingService.java
@@ -7,6 +7,9 @@ import java.time.LocalTime;
 import java.util.Comparator;
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,7 +40,7 @@ public class RankingService {
 	public static final double SCORE_SCALING_FACTOR = 1e-4;
 
 	@Transactional(readOnly = true)
-	public List<GetRankingResponse> getAllRank(User user, Long groupId) {
+	public Page<GetRankingResponse> getAllRank(User user, Long groupId, Pageable pageable) {
 
 		StudyGroup group = groupRepository.findById(groupId)
 			.orElseThrow(() -> new CannotFoundGroupException("그룹을 찾을 수 없습니다."));
@@ -50,17 +53,23 @@ public class RankingService {
 			.stream()
 			.sorted(Comparator.comparing(Ranking::getCurrentRank))
 			.toList();
-		return getRankingResponse(ranking);
+		return getRankingResponse(ranking, pageable);
 	}
 
-	private List<GetRankingResponse> getRankingResponse(List<Ranking> ranking) {
-		return ranking.stream().map(r -> new GetRankingResponse(
+	private Page<GetRankingResponse> getRankingResponse(List<Ranking> ranking, Pageable pageable) {
+		List<GetRankingResponse> responses = ranking.stream().map(r -> new GetRankingResponse(
 				r.getMember().getUser().getNickname(),
 				r.getMember().getUser().getProfileImage(),
 				r.getCurrentRank(),
 				r.getSolvedCount(),
 				r.getRankDiff()))
 			.toList();
+
+		return new PageImpl<>(
+			responses,
+			pageable,
+			ranking.size()
+		);
 	}
 
 	@Transactional

--- a/src/main/java/com/gamzabat/algohub/feature/group/ranking/service/RankingService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/ranking/service/RankingService.java
@@ -4,11 +4,8 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.Comparator;
-import java.util.List;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -49,27 +46,8 @@ public class RankingService {
 			throw new GroupMemberValidationException(HttpStatus.FORBIDDEN.value(), "랭킹을 확인할 권한이 없습니다.");
 		}
 
-		List<Ranking> ranking = rankingRepository.findAllByStudyGroup(group)
-			.stream()
-			.sorted(Comparator.comparing(Ranking::getCurrentRank))
-			.toList();
-		return getRankingResponse(ranking, pageable);
-	}
-
-	private Page<GetRankingResponse> getRankingResponse(List<Ranking> ranking, Pageable pageable) {
-		List<GetRankingResponse> responses = ranking.stream().map(r -> new GetRankingResponse(
-				r.getMember().getUser().getNickname(),
-				r.getMember().getUser().getProfileImage(),
-				r.getCurrentRank(),
-				r.getSolvedCount(),
-				r.getRankDiff()))
-			.toList();
-
-		return new PageImpl<>(
-			responses,
-			pageable,
-			ranking.size()
-		);
+		return rankingRepository.findAllByStudyGroup(group, pageable)
+			.map(GetRankingResponse::toDTO);
 	}
 
 	@Transactional

--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/controller/StudyGroupController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/controller/StudyGroupController.java
@@ -49,10 +49,10 @@ public class StudyGroupController {
 	@Operation(summary = "그룹 생성 API")
 	public ResponseEntity<GroupCodeResponse> createGroup(@AuthedUser User user,
 		@Valid @RequestPart CreateGroupRequest request, Errors errors,
-		@RequestPart(required = false) MultipartFile profileImage) {
+		@RequestPart(required = false) MultipartFile groupImage) {
 		if (errors.hasErrors())
 			throw new RequestException("그룹 생성 요청이 올바르지 않습니다.", errors);
-		GroupCodeResponse inviteCode = studyGroupService.createGroup(user, request, profileImage);
+		GroupCodeResponse inviteCode = studyGroupService.createGroup(user, request, groupImage);
 		return ResponseEntity.ok().body(inviteCode);
 	}
 

--- a/src/main/java/com/gamzabat/algohub/feature/notice/controller/NoticeController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notice/controller/NoticeController.java
@@ -1,7 +1,8 @@
 package com.gamzabat.algohub.feature.notice.controller;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.gamzabat.algohub.common.annotation.AuthedUser;
@@ -55,9 +57,12 @@ public class NoticeController {
 
 	@GetMapping(value = "/groups/{groupId}/notices")
 	@Operation(summary = "공지 목록 조회 API")
-	public ResponseEntity<List<GetNoticeResponse>> getNoticeList(@AuthedUser User user,
-		@PathVariable Long groupId) {
-		List<GetNoticeResponse> response = noticeService.getNoticeList(user, groupId);
+	public ResponseEntity<Page<GetNoticeResponse>> getNoticeList(@AuthedUser User user,
+		@PathVariable Long groupId,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "20") int size) {
+		Pageable pageable = PageRequest.of(page, size);
+		Page<GetNoticeResponse> response = noticeService.getNoticeList(user, groupId, pageable);
 		return ResponseEntity.ok().body(response);
 	}
 

--- a/src/main/java/com/gamzabat/algohub/feature/notice/dto/GetNoticeResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notice/dto/GetNoticeResponse.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 
 @Builder
 public record GetNoticeResponse(String author,
+								String authorImage,
 								Long noticeId,
 								String content,
 								String title,
@@ -17,6 +18,7 @@ public record GetNoticeResponse(String author,
 	public static GetNoticeResponse toDTO(Notice notice, boolean isRead) {
 		return GetNoticeResponse.builder()
 			.author(notice.getAuthor().getNickname())
+			.authorImage(notice.getAuthor().getProfileImage())
 			.noticeId(notice.getId())
 			.title(notice.getTitle())
 			.content(notice.getContent())

--- a/src/main/java/com/gamzabat/algohub/feature/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notice/repository/NoticeRepository.java
@@ -1,13 +1,13 @@
 package com.gamzabat.algohub.feature.notice.repository;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.gamzabat.algohub.feature.group.studygroup.domain.StudyGroup;
 import com.gamzabat.algohub.feature.notice.domain.Notice;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
-	List<Notice> findAllByStudyGroup(StudyGroup studyGroup);
+	Page<Notice> findAllByStudyGroup(StudyGroup studyGroup, Pageable pageable);
 
 }

--- a/src/main/java/com/gamzabat/algohub/feature/notice/service/NoticeService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notice/service/NoticeService.java
@@ -1,8 +1,9 @@
 package com.gamzabat.algohub.feature.notice.service;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -86,18 +87,17 @@ public class NoticeService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<GetNoticeResponse> getNoticeList(@AuthedUser User user, Long studyGroupId) {
+	public Page<GetNoticeResponse> getNoticeList(@AuthedUser User user, Long studyGroupId, Pageable pageable) {
 		StudyGroup studyGroup = studyGroupRepository.findById(studyGroupId)
 			.orElseThrow(() -> new StudyGroupValidationException(HttpStatus.BAD_REQUEST.value(), "존재하지 않는 스터디 그룹입니다"));
 		if (!groupMemberRepository.existsByUserAndStudyGroup(user, studyGroup))
 			throw new GroupMemberValidationException(HttpStatus.FORBIDDEN.value(), "참여하지 않은 스터디 그룹입니다");
 
-		List<Notice> list = noticeRepository.findAllByStudyGroup(studyGroup);
-		List<GetNoticeResponse> result = list.stream().map(
-			notice -> GetNoticeResponse.toDTO(notice, noticeReadRepository.existsByNoticeAndUser(notice, user))
-		).toList();
+		Page<Notice> list = noticeRepository.findAllByStudyGroup(studyGroup, pageable);
+		Page<GetNoticeResponse> responses = list.map(
+			notice -> GetNoticeResponse.toDTO(notice, noticeReadRepository.existsByNoticeAndUser(notice, user)));
 		log.info("success to get notice list");
-		return result;
+		return responses;
 	}
 
 	@Transactional

--- a/src/test/java/com/gamzabat/algohub/feature/group/ranking/controller/RankingControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/group/ranking/controller/RankingControllerTest.java
@@ -7,7 +7,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -17,6 +16,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -60,43 +63,47 @@ class RankingControllerTest {
 	@DisplayName("전체 랭킹 조회 성공")
 	void getAllRank() throws Exception {
 		// given
-		List<GetRankingResponse> response = new ArrayList<>();
-		when(rankingService.getAllRank(user, groupId)).thenReturn(response);
+		Page<GetRankingResponse> response = new PageImpl<>(new ArrayList<>());
+		Pageable pageable = PageRequest.of(0, 20);
+		when(rankingService.getAllRank(user, groupId, pageable)).thenReturn(response);
 		// when, then
 		mockMvc.perform(get("/api/groups/{groupId}/rankings", groupId)
 				.header("Authorization", token))
 			.andExpect(status().isOk())
 			.andExpect(content().json(objectMapper.writeValueAsString(response)));
 
-		verify(rankingService, times(1)).getAllRank(any(User.class), anyLong());
+		verify(rankingService, times(1)).getAllRank(any(User.class), anyLong(), any(Pageable.class));
 	}
 
 	@Test
 	@DisplayName("전체 랭킹 조회 실패 : 그룹을 못 찾은 경우")
 	void getAllRankFailed_1() throws Exception {
 		// given
-		doThrow(new CannotFoundGroupException("그룹을 찾을 수 없습니다.")).when(rankingService).getAllRank(user, groupId);
+		Pageable pageable = PageRequest.of(0, 20);
+		doThrow(new CannotFoundGroupException("그룹을 찾을 수 없습니다.")).when(rankingService)
+			.getAllRank(user, groupId, pageable);
 		// when, then
 		mockMvc.perform(get("/api/groups/{groupId}/rankings", groupId)
 				.header("Authorization", token))
 			.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.error").value("그룹을 찾을 수 없습니다."));
 
-		verify(rankingService, times(1)).getAllRank(any(User.class), anyLong());
+		verify(rankingService, times(1)).getAllRank(any(User.class), anyLong(), any(Pageable.class));
 	}
 
 	@Test
 	@DisplayName("전체 랭킹 조회 실패 : 랭킹 확인 권한이 없는 경우")
 	void getAllRankFailed_2() throws Exception {
 		// given
+		Pageable pageable = PageRequest.of(0, 20);
 		doThrow(new GroupMemberValidationException(HttpStatus.FORBIDDEN.value(), "랭킹을 확인할 권한이 없습니다.")).when(
-			rankingService).getAllRank(user, groupId);
+			rankingService).getAllRank(user, groupId, pageable);
 		// when, then
 		mockMvc.perform(get("/api/groups/{groupId}/rankings", groupId)
 				.header("Authorization", token))
 			.andExpect(status().isForbidden())
 			.andExpect(jsonPath("$.error").value("랭킹을 확인할 권한이 없습니다."));
 
-		verify(rankingService, times(1)).getAllRank(any(User.class), anyLong());
+		verify(rankingService, times(1)).getAllRank(any(User.class), anyLong(), any(Pageable.class));
 	}
 }

--- a/src/test/java/com/gamzabat/algohub/feature/group/ranking/service/RankingServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/group/ranking/service/RankingServiceTest.java
@@ -21,6 +21,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -147,15 +148,16 @@ class RankingServiceTest {
 	@DisplayName("전체랭킹 조회 성공")
 	void getAllRank_SuccessByOwner() {
 		//given
-		Pageable pageable = PageRequest.of(0, 20);
+		Pageable pageable = PageRequest.of(0, 4);
 		when(studyGroupRepository.findById(10L)).thenReturn(Optional.of(group));
 		when(groupMemberRepository.existsByUserAndStudyGroup(user2, group)).thenReturn(true);
 		List<Ranking> ranking = new ArrayList<>();
+		ranking.add(ranking1);
 		ranking.add(ranking2);
 		ranking.add(ranking3);
-		ranking.add(ranking1);
 		ranking.add(ranking4);
-		when(rankingRepository.findAllByStudyGroup(group)).thenReturn(ranking);
+		Page<Ranking> page = new PageImpl<>(ranking, pageable, ranking.size());
+		when(rankingRepository.findAllByStudyGroup(group, pageable)).thenReturn(page);
 
 		//when
 		Page<GetRankingResponse> result = rankingService.getAllRank(user2, 10L, pageable);

--- a/src/test/java/com/gamzabat/algohub/feature/group/ranking/service/RankingServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/group/ranking/service/RankingServiceTest.java
@@ -20,6 +20,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 
 import com.gamzabat.algohub.enums.Role;
@@ -144,6 +147,7 @@ class RankingServiceTest {
 	@DisplayName("전체랭킹 조회 성공")
 	void getAllRank_SuccessByOwner() {
 		//given
+		Pageable pageable = PageRequest.of(0, 20);
 		when(studyGroupRepository.findById(10L)).thenReturn(Optional.of(group));
 		when(groupMemberRepository.existsByUserAndStudyGroup(user2, group)).thenReturn(true);
 		List<Ranking> ranking = new ArrayList<>();
@@ -154,16 +158,16 @@ class RankingServiceTest {
 		when(rankingRepository.findAllByStudyGroup(group)).thenReturn(ranking);
 
 		//when
-		List<GetRankingResponse> result = rankingService.getAllRank(user2, 10L);
+		Page<GetRankingResponse> result = rankingService.getAllRank(user2, 10L, pageable);
 
 		//then
-		assertThat(result.size()).isEqualTo(4);
+		assertThat(result.getTotalElements()).isEqualTo(4);
 
 		for (int i = 0; i < 4; i++) {
-			assertThat(result.get(i).getProfileImage()).isEqualTo("image" + (i + 1));
-			assertThat(result.get(i).getSolvedCount()).isEqualTo(3 - i);
-			assertThat(result.get(i).getUserNickname()).isEqualTo("nickname" + (i + 1));
-			assertThat(result.get(i).getRank()).isEqualTo(i + 1);
+			assertThat(result.getContent().get(i).getProfileImage()).isEqualTo("image" + (i + 1));
+			assertThat(result.getContent().get(i).getSolvedCount()).isEqualTo(3 - i);
+			assertThat(result.getContent().get(i).getUserNickname()).isEqualTo("nickname" + (i + 1));
+			assertThat(result.getContent().get(i).getRank()).isEqualTo(i + 1);
 		}
 	}
 
@@ -171,10 +175,11 @@ class RankingServiceTest {
 	@DisplayName("전체랭킹 조회 실패 : 그룹을 못 찾은 경우")
 	void getAllRank_FailedByCannotFoundGroup() {
 		//given
+		Pageable pageable = PageRequest.of(0, 20);
 		when(studyGroupRepository.findById(9L)).thenReturn(Optional.empty());
 
 		//then
-		assertThatThrownBy(() -> rankingService.getAllRank(user, 9L))
+		assertThatThrownBy(() -> rankingService.getAllRank(user, 9L, pageable))
 			.isInstanceOf(CannotFoundGroupException.class)
 			.hasFieldOrPropertyWithValue("errors", "그룹을 찾을 수 없습니다.");
 	}
@@ -183,11 +188,12 @@ class RankingServiceTest {
 	@DisplayName("전체랭킹 조회 실패 : 랭킹을 확인할 권한이 없는 경우")
 	void getAllRank_FailedByAccess() {
 		//given
+		Pageable pageable = PageRequest.of(0, 20);
 		when(studyGroupRepository.findById(groupId)).thenReturn(Optional.of(group));
 		when(groupMemberRepository.existsByUserAndStudyGroup(user2, group)).thenReturn(false);
 
 		//then
-		assertThatThrownBy(() -> rankingService.getAllRank(user2, groupId))
+		assertThatThrownBy(() -> rankingService.getAllRank(user2, groupId, pageable))
 			.isInstanceOf(GroupMemberValidationException.class)
 			.hasFieldOrPropertyWithValue("code", HttpStatus.FORBIDDEN.value())
 			.hasFieldOrPropertyWithValue("error", "랭킹을 확인할 권한이 없습니다.");

--- a/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
@@ -107,7 +107,7 @@ class StudyGroupControllerTest {
 		GroupCodeResponse response = new GroupCodeResponse("inviteCode");
 		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
 			objectMapper.writeValueAsString(request).getBytes());
-		MockMultipartFile profileImage = new MockMultipartFile("profileImage", "profile.jpg", "image/jpeg",
+		MockMultipartFile profileImage = new MockMultipartFile("groupImage", "profile.jpg", "image/jpeg",
 			"image".getBytes());
 		when(studyGroupService.createGroup(any(User.class), any(CreateGroupRequest.class),
 			any(MultipartFile.class))).thenReturn(response);

--- a/src/test/java/com/gamzabat/algohub/service/NoticeServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/NoticeServiceTest.java
@@ -19,6 +19,10 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 
 import com.gamzabat.algohub.common.DateFormatUtil;
@@ -220,6 +224,8 @@ public class NoticeServiceTest {
 	@DisplayName("공지 목록 조회 성공")
 	void getNoticeListSuccess_1() {
 		//given
+		Pageable pageable = PageRequest.of(0, 20);
+
 		List<Notice> noticeList = new ArrayList<>(10);
 		for (int i = 0; i < 10; i++)
 			noticeList.add(
@@ -243,16 +249,17 @@ public class NoticeServiceTest {
 					.build());
 		when(studyGroupRepository.findById(30L)).thenReturn(Optional.ofNullable(studyGroup));
 		when(groupMemberRepository.existsByUserAndStudyGroup(user, studyGroup)).thenReturn(true);
-		when(noticeRepository.findAllByStudyGroup(studyGroup)).thenReturn(noticeList);
+		when(noticeRepository.findAllByStudyGroup(studyGroup, pageable)).thenReturn(
+			new PageImpl<>(noticeList, pageable, noticeList.size()));
 		//when
-		List<GetNoticeResponse> result = noticeService.getNoticeList(user, 30L);
+		Page<GetNoticeResponse> result = noticeService.getNoticeList(user, 30L, pageable);
 		//then
-		assertThat(result.size()).isEqualTo(20);
+		assertThat(result.getTotalElements()).isEqualTo(20);
 		for (int i = 0; i < 20; i++) {
-			assertThat(result.get(i).content()).isEqualTo("content" + i);
-			assertThat(result.get(i).title()).isEqualTo("title" + i);
-			assertThat(result.get(i).category()).isEqualTo("category" + i);
-			assertThat(result.get(i).isRead()).isFalse();
+			assertThat(result.getContent().get(i).content()).isEqualTo("content" + i);
+			assertThat(result.getContent().get(i).title()).isEqualTo("title" + i);
+			assertThat(result.getContent().get(i).category()).isEqualTo("category" + i);
+			assertThat(result.getContent().get(i).isRead()).isFalse();
 		}
 	}
 
@@ -260,9 +267,11 @@ public class NoticeServiceTest {
 	@DisplayName("공지 목록 조회 실패 (존재하지 않는 스터디 그룹임)")
 	void getNoticeListFailed_1() {
 		//given
+		Pageable pageable = PageRequest.of(0, 20);
+
 		when(studyGroupRepository.findById(31L)).thenReturn(Optional.empty());
 		//when,then
-		assertThatThrownBy(() -> noticeService.getNoticeList(user, 31L))
+		assertThatThrownBy(() -> noticeService.getNoticeList(user, 31L, pageable))
 			.isInstanceOf(StudyGroupValidationException.class)
 			.hasFieldOrPropertyWithValue("code", HttpStatus.BAD_REQUEST.value())
 			.hasFieldOrPropertyWithValue("error", "존재하지 않는 스터디 그룹입니다");
@@ -272,10 +281,12 @@ public class NoticeServiceTest {
 	@DisplayName("공지 목록 조회 실패(참여하지 않은 스터디 그룹)")
 	void getNoticeListFailed_2() {
 		//given
+		Pageable pageable = PageRequest.of(0, 20);
+
 		when(studyGroupRepository.findById(30L)).thenReturn(Optional.ofNullable(studyGroup));
 		when(groupMemberRepository.existsByUserAndStudyGroup(user4, studyGroup)).thenReturn(false);
 		//when, then
-		assertThatThrownBy(() -> noticeService.getNoticeList(user4, 30L))
+		assertThatThrownBy(() -> noticeService.getNoticeList(user4, 30L, pageable))
 			.isInstanceOf(GroupMemberValidationException.class)
 			.hasFieldOrPropertyWithValue("code", HttpStatus.FORBIDDEN.value())
 			.hasFieldOrPropertyWithValue("error", "참여하지 않은 스터디 그룹입니다");


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://github.com/GAMZA-BAT/algohub-server/issues/185

## 🚀 Description
<!-- 작업 내용 -->
- 공지, 랭킹 목록 조회 시 페이징을 적용했습니다.
- 공지 조회 시 작성자의 프로필 이미지 정보를 DTO에 추가했습니다.
- 그룹 생성 시 `profileImage` 필드명도 `groupImage`로 변경해달란 요청이 있어서 했습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->