### PR TITLE
feat : 그룹 탈퇴 및 그룹 삭제 API 분리

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/group/ranking/repository/querydsl/CustomRankingRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/ranking/repository/querydsl/CustomRankingRepository.java
@@ -7,4 +7,6 @@ import com.gamzabat.algohub.feature.group.studygroup.domain.StudyGroup;
 
 public interface CustomRankingRepository {
 	List<Ranking> findAllByStudyGroup(StudyGroup studyGroup);
+
+	void deleteAllByStudyGroup(StudyGroup studyGroup);
 }

--- a/src/main/java/com/gamzabat/algohub/feature/group/ranking/repository/querydsl/CustomRankingRepositoryImpl.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/ranking/repository/querydsl/CustomRankingRepositoryImpl.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 
 import com.gamzabat.algohub.feature.group.ranking.domain.Ranking;
 import com.gamzabat.algohub.feature.group.studygroup.domain.StudyGroup;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.AllArgsConstructor;
@@ -26,5 +27,15 @@ public class CustomRankingRepositoryImpl implements CustomRankingRepository {
 			.join(groupMember.user, user).fetchJoin()
 			.where(ranking.member.studyGroup.eq(studyGroup))
 			.fetch();
+	}
+
+	@Override
+	public void deleteAllByStudyGroup(StudyGroup group) {
+		queryFactory.delete(ranking)
+			.where(ranking.member.in(
+				JPAExpressions.selectFrom(groupMember)
+					.where(groupMember.studyGroup.eq(group))
+			))
+			.execute();
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/controller/StudyGroupController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/controller/StudyGroupController.java
@@ -71,7 +71,14 @@ public class StudyGroupController {
 	}
 
 	@DeleteMapping(value = "/groups/{groupId}/members/me")
-	@Operation(summary = "그룹 탈퇴 API", description = "방장,멤버 상관 없이 해당 그룹을 삭제,탈퇴하는 API")
+	@Operation(summary = "그룹 탈퇴 API", description = "방장,멤버 상관 없이 해당 그룹을 탈퇴하는 API")
+	public ResponseEntity<Void> exitGroup(@AuthedUser User user, @PathVariable Long groupId) {
+		studyGroupService.exitGroup(user, groupId);
+		return ResponseEntity.ok().build();
+	}
+
+	@DeleteMapping(value = "/groups/{groupId}")
+	@Operation(summary = "그룹 삭제 API", description = "방장 권한으로 그룹을 삭제하는 API")
 	public ResponseEntity<Void> deleteGroup(@AuthedUser User user, @PathVariable Long groupId) {
 		studyGroupService.deleteGroup(user, groupId);
 		return ResponseEntity.ok().build();

--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/repository/BookmarkedStudyGroupRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/repository/BookmarkedStudyGroupRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import com.gamzabat.algohub.feature.group.studygroup.domain.BookmarkedStudyGroup;
 import com.gamzabat.algohub.feature.group.studygroup.domain.StudyGroup;
@@ -17,4 +19,8 @@ public interface BookmarkedStudyGroupRepository extends JpaRepository<Bookmarked
 	List<BookmarkedStudyGroup> findAllByStudyGroup(StudyGroup studyGroup);
 
 	boolean existsByUserAndStudyGroup(User user, StudyGroup group);
+
+	@Modifying
+	@Query("delete from BookmarkedStudyGroup bms where bms.studyGroup = :studyGroup")
+	void deleteAllByStudyGroup(StudyGroup studyGroup);
 }

--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/repository/GroupMemberRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/repository/GroupMemberRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -29,4 +30,8 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
 	GroupMember findByStudyGroupAndRole(StudyGroup group, RoleOfGroupMember role);
 
 	int countByStudyGroup(StudyGroup studyGroup);
+
+	@Modifying
+	@Query("delete from GroupMember gm where gm.studyGroup = :studyGroup")
+	void deleteAllByStudyGroup(StudyGroup studyGroup);
 }

--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
@@ -148,6 +148,33 @@ public class StudyGroupService {
 
 	@Transactional
 	public void deleteGroup(User user, Long groupId) {
+		StudyGroup group = groupRepository.findById(groupId)
+			.orElseThrow(() -> new CannotFoundGroupException("존재하지 않는 그룹입니다."));
+
+		GroupMember owner = groupMemberRepository.findByUserAndStudyGroup(user, group)
+			.orElseThrow(
+				() -> new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "참여하지 않은 그룹입니다."));
+
+		if (!RoleOfGroupMember.isOwner(owner)) {
+			throw new GroupMemberValidationException(HttpStatus.FORBIDDEN.value(), "스터디 그룹 삭제는 방장만 가능합니다.");
+		}
+
+		// bookmarkedStudyGroupRepository.deleteAllInBatch(bookmarkedStudyGroupRepository.findAllByStudyGroup(group));
+		// rankingRepository.deleteAllInBatch(rankingRepository.findAllByStudyGroup(group));
+		// notificationSettingRepository.deleteAllInBatch(notificationSettingRepository.findAllByStudyGroup(group));
+		// groupMemberRepository.deleteAllInBatch(groupMemberRepository.findAllByStudyGroup(group));
+		// groupRepository.delete(group);
+		bookmarkedStudyGroupRepository.deleteAllByStudyGroup(group);
+		rankingRepository.deleteAllByStudyGroup(group);
+		notificationSettingRepository.deleteAllByStudyGroup(group);
+		groupMemberRepository.deleteAllByStudyGroup(group);
+		groupRepository.delete(group);
+
+		log.info("success to delete study group");
+	}
+
+	@Transactional
+	public void exitGroup(User user, Long groupId) {
 		StudyGroup studyGroup = groupRepository.findById(groupId)
 			.orElseThrow(() -> new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다."));
 

--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
@@ -47,6 +47,7 @@ import com.gamzabat.algohub.feature.group.studygroup.repository.StudyGroupReposi
 import com.gamzabat.algohub.feature.image.service.ImageService;
 import com.gamzabat.algohub.feature.notification.domain.NotificationSetting;
 import com.gamzabat.algohub.feature.notification.enums.NotificationCategory;
+import com.gamzabat.algohub.feature.notification.repository.NotificationRepository;
 import com.gamzabat.algohub.feature.notification.repository.NotificationSettingRepository;
 import com.gamzabat.algohub.feature.notification.service.NotificationService;
 import com.gamzabat.algohub.feature.problem.domain.Problem;
@@ -71,6 +72,7 @@ public class StudyGroupService {
 	private final StudyGroupRepository studyGroupRepository;
 	private final BookmarkedStudyGroupRepository bookmarkedStudyGroupRepository;
 	private final RankingRepository rankingRepository;
+	private final NotificationRepository notificationRepository;
 
 	private final ObjectProvider<StudyGroupService> studyGroupServiceProvider;
 	private final NotificationSettingRepository notificationSettingRepository;
@@ -162,6 +164,7 @@ public class StudyGroupService {
 		bookmarkedStudyGroupRepository.deleteAllByStudyGroup(group);
 		rankingRepository.deleteAllByStudyGroup(group);
 		notificationSettingRepository.deleteAllByStudyGroup(group);
+		notificationRepository.deleteAllByStudyGroup(group);
 		groupMemberRepository.deleteAllByStudyGroup(group);
 		groupRepository.delete(group);
 
@@ -171,22 +174,23 @@ public class StudyGroupService {
 	@Transactional
 	public void exitGroup(User user, Long groupId) {
 		StudyGroup studyGroup = groupRepository.findById(groupId)
-			.orElseThrow(() -> new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다."));
+			.orElseThrow(() -> new CannotFoundGroupException("존재하지 않는 그룹입니다."));
 
 		GroupMember groupMember = groupMemberRepository.findByUserAndStudyGroup(user, studyGroup)
 			.orElseThrow(
-				() -> new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "이미 참여하지 않은 그룹 입니다."));
+				() -> new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "참여하지 않은 그룹입니다."));
 
-		if (RoleOfGroupMember.isOwner(groupMember)) { // owner
-			bookmarkedStudyGroupRepository.deleteAll(bookmarkedStudyGroupRepository.findAllByStudyGroup(studyGroup));
-			rankingRepository.deleteAll(rankingRepository.findAllByStudyGroup(studyGroup));
-			notificationSettingRepository.deleteAll(notificationSettingRepository.findAllByStudyGroup(studyGroup));
-			groupMemberRepository.deleteAll(groupMemberRepository.findAllByStudyGroup(studyGroup));
-			groupRepository.delete(studyGroup);
-		} else { // member
-			studyGroupServiceProvider.getObject().deleteMemberFromStudyGroup(user, groupMember, studyGroup);
+		studyGroupServiceProvider.getObject().deleteMemberFromStudyGroup(user, groupMember, studyGroup);
+
+		if (RoleOfGroupMember.isOwner(groupMember)) {
+			GroupMember member = groupMemberRepository.findAllByStudyGroup(studyGroup)
+				.stream()
+				.sorted(Comparator.comparing(GroupMember::getRole).thenComparing(GroupMember::getJoinDate))
+				.toList().getFirst();
+			member.updateRole(RoleOfGroupMember.OWNER);
 		}
-		log.info("success to delete(exit) study group");
+
+		log.info("success to exit study group");
 	}
 
 	@Transactional
@@ -217,6 +221,7 @@ public class StudyGroupService {
 			.ifPresent(bookmarkedStudyGroupRepository::delete);
 		rankingRepository.deleteByMember(groupMember);
 		notificationSettingRepository.deleteByMember(groupMember);
+		notificationRepository.deleteAllByStudyGroup(groupMember.getStudyGroup());
 		groupMemberRepository.delete(groupMember);
 		log.info("success to delete group member");
 	}

--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
@@ -159,11 +159,6 @@ public class StudyGroupService {
 			throw new GroupMemberValidationException(HttpStatus.FORBIDDEN.value(), "스터디 그룹 삭제는 방장만 가능합니다.");
 		}
 
-		// bookmarkedStudyGroupRepository.deleteAllInBatch(bookmarkedStudyGroupRepository.findAllByStudyGroup(group));
-		// rankingRepository.deleteAllInBatch(rankingRepository.findAllByStudyGroup(group));
-		// notificationSettingRepository.deleteAllInBatch(notificationSettingRepository.findAllByStudyGroup(group));
-		// groupMemberRepository.deleteAllInBatch(groupMemberRepository.findAllByStudyGroup(group));
-		// groupRepository.delete(group);
 		bookmarkedStudyGroupRepository.deleteAllByStudyGroup(group);
 		rankingRepository.deleteAllByStudyGroup(group);
 		notificationSettingRepository.deleteAllByStudyGroup(group);

--- a/src/main/java/com/gamzabat/algohub/feature/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notification/repository/NotificationRepository.java
@@ -3,7 +3,10 @@ package com.gamzabat.algohub.feature.notification.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
+import com.gamzabat.algohub.feature.group.studygroup.domain.StudyGroup;
 import com.gamzabat.algohub.feature.notification.domain.Notification;
 import com.gamzabat.algohub.feature.user.domain.User;
 
@@ -11,4 +14,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 	List<Notification> findAllByUser(User user);
 
 	List<Notification> findAllByUserAndIsRead(User user, boolean isRead);
+
+	@Modifying
+	@Query("delete from Notification n where n.studyGroup = :studyGroup")
+	void deleteAllByStudyGroup(StudyGroup studyGroup);
 }

--- a/src/main/java/com/gamzabat/algohub/feature/notification/repository/querydsl/CustomNotificationSettingRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notification/repository/querydsl/CustomNotificationSettingRepository.java
@@ -10,4 +10,6 @@ public interface CustomNotificationSettingRepository {
 	List<NotificationSetting> findAllByUser(User user);
 
 	List<NotificationSetting> findAllByStudyGroup(StudyGroup studyGroup);
+
+	void deleteAllByStudyGroup(StudyGroup studyGroup);
 }

--- a/src/main/java/com/gamzabat/algohub/feature/notification/repository/querydsl/CustomNotificationSettingRepositoryImpl.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notification/repository/querydsl/CustomNotificationSettingRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.gamzabat.algohub.feature.notification.repository.querydsl;
 
+import static com.gamzabat.algohub.feature.group.studygroup.domain.QGroupMember.*;
 import static com.gamzabat.algohub.feature.notification.domain.QNotificationSetting.*;
 
 import java.util.List;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Repository;
 import com.gamzabat.algohub.feature.group.studygroup.domain.StudyGroup;
 import com.gamzabat.algohub.feature.notification.domain.NotificationSetting;
 import com.gamzabat.algohub.feature.user.domain.User;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.AllArgsConstructor;
@@ -30,5 +32,15 @@ public class CustomNotificationSettingRepositoryImpl implements CustomNotificati
 		return query.selectFrom(notificationSetting)
 			.where(notificationSetting.member.studyGroup.eq(studyGroup))
 			.fetch();
+	}
+
+	@Override
+	public void deleteAllByStudyGroup(StudyGroup studyGroup) {
+		query.delete(notificationSetting)
+			.where(notificationSetting.member.in(
+				JPAExpressions.selectFrom(groupMember)
+					.where(groupMember.studyGroup.eq(studyGroup))
+			))
+			.execute();
 	}
 }

--- a/src/test/java/com/gamzabat/algohub/feature/group/ranking/service/RankingUpdateServiceAOPTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/group/ranking/service/RankingUpdateServiceAOPTest.java
@@ -117,7 +117,7 @@ public class RankingUpdateServiceAOPTest {
 		when(groupMemberRepository.findByUserAndStudyGroup(user2, group)).thenReturn(Optional.of(groupMember2));
 		doNothing().when(rankingUpdateService).updateRanking(group);
 		// when
-		studyGroupService.deleteGroup(user2, groupId);
+		studyGroupService.exitGroup(user2, groupId);
 		// then
 		verify(rankingUpdateService, times(1)).updateRanking(group);
 	}

--- a/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
@@ -254,6 +254,52 @@ class StudyGroupControllerTest {
 	}
 
 	@Test
+	@DisplayName("그룹 삭제 성공")
+	void deleteGroup() throws Exception {
+		// given
+		doNothing().when(studyGroupService).deleteGroup(user, groupId);
+		// when, then
+		mockMvc.perform(delete("/api/groups/{groupId}", groupId)
+				.header("Authorization", token)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk());
+
+		verify(studyGroupService, times(1)).deleteGroup(user, groupId);
+	}
+
+	@Test
+	@DisplayName("그룹 삭제 실패 : 이미 참여 안한 그룹")
+	void deleteGroupFailed_1() throws Exception {
+		// given
+		doThrow(new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "참여하지 않은 그룹 입니다.")).when(
+			studyGroupService).deleteGroup(user, groupId);
+		// when, then
+		mockMvc.perform(delete("/api/groups/{groupId}", groupId)
+				.header("Authorization", token)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.error").value("참여하지 않은 그룹 입니다."));
+
+		verify(studyGroupService, times(1)).deleteGroup(any(User.class), anyLong());
+	}
+
+	@Test
+	@DisplayName("그룹 삭제 실패 : 존재하지 않는 그룹")
+	void deleteGroupFailed_2() throws Exception {
+		// given
+		doThrow(new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹입니다.")).when(
+			studyGroupService).deleteGroup(user, groupId);
+		// when, then
+		mockMvc.perform(delete("/api/groups/{groupId}", groupId)
+				.header("Authorization", token)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.error").value("존재하지 않는 그룹입니다."));
+
+		verify(studyGroupService, times(1)).deleteGroup(any(User.class), anyLong());
+	}
+
+	@Test
 	@DisplayName("그룹 탈퇴 성공")
 	void leaveGroup() throws Exception {
 		// given

--- a/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
@@ -257,14 +257,14 @@ class StudyGroupControllerTest {
 	@DisplayName("그룹 탈퇴 성공")
 	void leaveGroup() throws Exception {
 		// given
-		doNothing().when(studyGroupService).deleteGroup(user, groupId);
+		doNothing().when(studyGroupService).exitGroup(user, groupId);
 		// when, then
 		mockMvc.perform(delete("/api/groups/{groupId}/members/me", groupId)
 				.header("Authorization", token)
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk());
 
-		verify(studyGroupService, times(1)).deleteGroup(any(User.class), anyLong());
+		verify(studyGroupService, times(1)).exitGroup(any(User.class), anyLong());
 	}
 
 	@Test
@@ -272,7 +272,7 @@ class StudyGroupControllerTest {
 	void leaveGroupFailed_1() throws Exception {
 		// given
 		doThrow(new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다.")).when(
-			studyGroupService).deleteGroup(user, groupId);
+			studyGroupService).exitGroup(user, groupId);
 		// when, then
 		mockMvc.perform(delete("/api/groups/{groupId}/members/me", groupId)
 				.header("Authorization", token)
@@ -280,7 +280,7 @@ class StudyGroupControllerTest {
 			.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.error").value("존재하지 않는 그룹 입니다."));
 
-		verify(studyGroupService, times(1)).deleteGroup(any(User.class), anyLong());
+		verify(studyGroupService, times(1)).exitGroup(any(User.class), anyLong());
 	}
 
 	@Test
@@ -288,7 +288,7 @@ class StudyGroupControllerTest {
 	void leaveGroupFailed_2() throws Exception {
 		// given
 		doThrow(new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "이미 참여하지 않은 그룹 입니다.")).when(
-			studyGroupService).deleteGroup(user, groupId);
+			studyGroupService).exitGroup(user, groupId);
 		// when, then
 		mockMvc.perform(delete("/api/groups/{groupId}/members/me", groupId)
 				.header("Authorization", token)
@@ -296,7 +296,7 @@ class StudyGroupControllerTest {
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.error").value("이미 참여하지 않은 그룹 입니다."));
 
-		verify(studyGroupService, times(1)).deleteGroup(any(User.class), anyLong());
+		verify(studyGroupService, times(1)).exitGroup(any(User.class), anyLong());
 	}
 
 	@Test
@@ -318,7 +318,7 @@ class StudyGroupControllerTest {
 		// given
 		doThrow(new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(),
 			"멤버 삭제 권한이 없습니다. : 참여하지 않은 그룹 입니다.")).when(
-			studyGroupService).deleteGroup(user, groupId);
+			studyGroupService).exitGroup(user, groupId);
 		// when, then
 		mockMvc.perform(delete("/api/groups/{groupId}/members/me", groupId)
 				.header("Authorization", token)
@@ -332,7 +332,7 @@ class StudyGroupControllerTest {
 	void deleteMemberFailed_2() throws Exception {
 		// given
 		doThrow(new UserValidationException("멤버를 삭제 할 권한이 없습니다.")).when(
-			studyGroupService).deleteGroup(user, groupId);
+			studyGroupService).exitGroup(user, groupId);
 		// when, then
 		mockMvc.perform(delete("/api/groups/{groupId}/members/me", groupId)
 				.header("Authorization", token)

--- a/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
@@ -301,7 +301,7 @@ class StudyGroupControllerTest {
 
 	@Test
 	@DisplayName("그룹 탈퇴 성공")
-	void leaveGroup() throws Exception {
+	void exitGroup() throws Exception {
 		// given
 		doNothing().when(studyGroupService).exitGroup(user, groupId);
 		// when, then
@@ -315,32 +315,32 @@ class StudyGroupControllerTest {
 
 	@Test
 	@DisplayName("그룹 탈퇴 실패 : 존재하지 않는 그룹")
-	void leaveGroupFailed_1() throws Exception {
+	void exitGroupFailed_1() throws Exception {
 		// given
-		doThrow(new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다.")).when(
+		doThrow(new CannotFoundGroupException("존재하지 않는 그룹입니다.")).when(
 			studyGroupService).exitGroup(user, groupId);
 		// when, then
 		mockMvc.perform(delete("/api/groups/{groupId}/members/me", groupId)
 				.header("Authorization", token)
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isNotFound())
-			.andExpect(jsonPath("$.error").value("존재하지 않는 그룹 입니다."));
+			.andExpect(jsonPath("$.error").value("존재하지 않는 그룹입니다."));
 
 		verify(studyGroupService, times(1)).exitGroup(any(User.class), anyLong());
 	}
 
 	@Test
 	@DisplayName("그룹 탈퇴 실패 : 이미 참여 안한 그룹")
-	void leaveGroupFailed_2() throws Exception {
+	void exitGroupFailed_2() throws Exception {
 		// given
-		doThrow(new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "이미 참여하지 않은 그룹 입니다.")).when(
+		doThrow(new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "참여하지 않은 그룹 입니다.")).when(
 			studyGroupService).exitGroup(user, groupId);
 		// when, then
 		mockMvc.perform(delete("/api/groups/{groupId}/members/me", groupId)
 				.header("Authorization", token)
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.error").value("이미 참여하지 않은 그룹 입니다."));
+			.andExpect(jsonPath("$.error").value("참여하지 않은 그룹 입니다."));
 
 		verify(studyGroupService, times(1)).exitGroup(any(User.class), anyLong());
 	}
@@ -359,7 +359,7 @@ class StudyGroupControllerTest {
 	}
 
 	@Test
-	@DisplayName("그룹 탈퇴 실패 : 참여하지 않은 그룹")
+	@DisplayName("멤버 삭제 실패 : 참여하지 않은 그룹")
 	void deleteMemberFailed_1() throws Exception {
 		// given
 		doThrow(new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(),
@@ -374,7 +374,7 @@ class StudyGroupControllerTest {
 	}
 
 	@Test
-	@DisplayName("그룹 탈퇴 실패 : 권한 없음")
+	@DisplayName("멤버 삭제 실패 : 권한 없음")
 	void deleteMemberFailed_2() throws Exception {
 		// given
 		doThrow(new UserValidationException("멤버를 삭제 할 권한이 없습니다.")).when(

--- a/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
@@ -264,7 +264,7 @@ class StudyGroupServiceTest {
 		when(groupMemberRepository.findByUserAndStudyGroup(user, group)).thenReturn(Optional.ofNullable(groupMember1));
 		when(groupMemberRepository.findAllByStudyGroup(group)).thenReturn(List.of(groupMember1));
 		// when
-		studyGroupService.deleteGroup(user, 10L);
+		studyGroupService.exitGroup(user, 10L);
 		// then
 		verify(studyGroupRepository, times(1)).delete(group);
 		verify(groupMemberRepository, times(1)).deleteAll(List.of(groupMember1));
@@ -296,7 +296,7 @@ class StudyGroupServiceTest {
 		}).when(groupService).deleteMemberFromStudyGroup(user2, groupMember, group);
 
 		// when
-		studyGroupService.deleteGroup(user2, groupId);
+		studyGroupService.exitGroup(user2, groupId);
 		// then
 		verify(groupMemberRepository, times(1)).delete(groupMember);
 		verify(bookmarkedStudyGroupRepository, times(1)).delete(Objects.requireNonNull(bookmark));
@@ -310,7 +310,7 @@ class StudyGroupServiceTest {
 		// given
 		when(studyGroupRepository.findById(10L)).thenReturn(Optional.empty());
 		// when, then
-		assertThatThrownBy(() -> studyGroupService.deleteGroup(user, 10L))
+		assertThatThrownBy(() -> studyGroupService.exitGroup(user, 10L))
 			.isInstanceOf(StudyGroupValidationException.class)
 			.hasFieldOrPropertyWithValue("code", HttpStatus.NOT_FOUND.value())
 			.hasFieldOrPropertyWithValue("error", "존재하지 않는 그룹 입니다.");
@@ -323,7 +323,7 @@ class StudyGroupServiceTest {
 		when(studyGroupRepository.findById(10L)).thenReturn(Optional.ofNullable(group));
 		when(groupMemberRepository.findByUserAndStudyGroup(user2, group)).thenReturn(Optional.empty());
 		// when, then
-		assertThatThrownBy(() -> studyGroupService.deleteGroup(user2, 10L))
+		assertThatThrownBy(() -> studyGroupService.exitGroup(user2, 10L))
 			.isInstanceOf(GroupMemberValidationException.class)
 			.hasFieldOrPropertyWithValue("code", HttpStatus.BAD_REQUEST.value())
 			.hasFieldOrPropertyWithValue("error", "이미 참여하지 않은 그룹 입니다.");

--- a/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
@@ -49,6 +49,7 @@ import com.gamzabat.algohub.feature.group.studygroup.repository.StudyGroupReposi
 import com.gamzabat.algohub.feature.group.studygroup.service.StudyGroupService;
 import com.gamzabat.algohub.feature.image.service.ImageService;
 import com.gamzabat.algohub.feature.notification.domain.NotificationSetting;
+import com.gamzabat.algohub.feature.notification.repository.NotificationRepository;
 import com.gamzabat.algohub.feature.notification.repository.NotificationSettingRepository;
 import com.gamzabat.algohub.feature.notification.service.NotificationService;
 import com.gamzabat.algohub.feature.problem.domain.Problem;
@@ -76,6 +77,8 @@ class StudyGroupServiceTest {
 	private ProblemRepository problemRepository;
 	@Mock
 	private UserRepository userRepository;
+	@Mock
+	private NotificationRepository notificationRepository;
 	@Mock
 	private NotificationSettingRepository notificationSettingRepository;
 	@Mock
@@ -263,6 +266,7 @@ class StudyGroupServiceTest {
 		verify(rankingRepository, times(1)).deleteAllByStudyGroup(group);
 		verify(notificationSettingRepository, times(1)).deleteAllByStudyGroup(group);
 		verify(groupMemberRepository, times(1)).deleteAllByStudyGroup(group);
+		verify(notificationRepository, times(1)).deleteAllByStudyGroup(group);
 		verify(studyGroupRepository, times(1)).delete(group);
 	}
 
@@ -285,6 +289,49 @@ class StudyGroupServiceTest {
 		when(groupMemberRepository.findByUserAndStudyGroup(user2, group)).thenReturn(Optional.empty());
 		// when, then
 		assertThatThrownBy(() -> studyGroupService.deleteGroup(user2, 10L))
+			.isInstanceOf(GroupMemberValidationException.class)
+			.hasFieldOrPropertyWithValue("code", HttpStatus.BAD_REQUEST.value())
+			.hasFieldOrPropertyWithValue("error", "참여하지 않은 그룹입니다.");
+	}
+
+	@Test
+	@DisplayName("그룹 탈퇴 성공 (방장)")
+	void exitGroup() {
+		// given
+		when(studyGroupRepository.findById(10L)).thenReturn(Optional.of(group));
+		when(groupMemberRepository.findByUserAndStudyGroup(user, group)).thenReturn(Optional.ofNullable(groupMember1));
+		when(groupMemberRepository.findAllByStudyGroup(group)).thenReturn(
+			List.of(groupMember2, groupMember3));
+		when(studyGroupServiceObjectProvider.getObject()).thenReturn(studyGroupService);
+		// when
+		studyGroupService.exitGroup(user, 10L);
+		// then
+		verify(rankingRepository, times(1)).deleteByMember(groupMember1);
+		verify(notificationSettingRepository, times(1)).deleteByMember(groupMember1);
+		verify(groupMemberRepository, times(1)).delete(groupMember1);
+		verify(notificationRepository, times(1)).deleteAllByStudyGroup(group);
+		assertThat(groupMember3.getRole()).isEqualTo(RoleOfGroupMember.OWNER);
+	}
+
+	@Test
+	@DisplayName("그룹 탈퇴 실패 : 존재하지 않는 그룹")
+	void exitGroupFailed_1() {
+		// given
+		when(studyGroupRepository.findById(groupId)).thenReturn(Optional.empty());
+		// when, then
+		assertThatThrownBy(() -> studyGroupService.exitGroup(user, groupId))
+			.isInstanceOf(CannotFoundGroupException.class)
+			.hasFieldOrPropertyWithValue("errors", "존재하지 않는 그룹입니다.");
+	}
+
+	@Test
+	@DisplayName("그룹 탈퇴 실패 : 이미 참여하지 않은 그룹")
+	void exitGroupFailed_2() {
+		// given
+		when(studyGroupRepository.findById(10L)).thenReturn(Optional.ofNullable(group));
+		when(groupMemberRepository.findByUserAndStudyGroup(user2, group)).thenReturn(Optional.empty());
+		// when, then
+		assertThatThrownBy(() -> studyGroupService.exitGroup(user2, 10L))
 			.isInstanceOf(GroupMemberValidationException.class)
 			.hasFieldOrPropertyWithValue("code", HttpStatus.BAD_REQUEST.value())
 			.hasFieldOrPropertyWithValue("error", "참여하지 않은 그룹입니다.");

--- a/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
@@ -8,7 +8,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -255,53 +254,16 @@ class StudyGroupServiceTest {
 	@DisplayName("그룹 삭제 성공 (주인)")
 	void deleteGroup() {
 		// given
-		List<BookmarkedStudyGroup> bookmarks = new ArrayList<>();
-		bookmarks.add(BookmarkedStudyGroup.builder().studyGroup(group).user(user).build());
-		bookmarks.add(BookmarkedStudyGroup.builder().studyGroup(group).user(user2).build());
-
 		when(studyGroupRepository.findById(10L)).thenReturn(Optional.of(group));
-		when(bookmarkedStudyGroupRepository.findAllByStudyGroup(group)).thenReturn(bookmarks);
 		when(groupMemberRepository.findByUserAndStudyGroup(user, group)).thenReturn(Optional.ofNullable(groupMember1));
-		when(groupMemberRepository.findAllByStudyGroup(group)).thenReturn(List.of(groupMember1));
 		// when
-		studyGroupService.exitGroup(user, 10L);
+		studyGroupService.deleteGroup(user, 10L);
 		// then
+		verify(bookmarkedStudyGroupRepository, times(1)).deleteAllByStudyGroup(group);
+		verify(rankingRepository, times(1)).deleteAllByStudyGroup(group);
+		verify(notificationSettingRepository, times(1)).deleteAllByStudyGroup(group);
+		verify(groupMemberRepository, times(1)).deleteAllByStudyGroup(group);
 		verify(studyGroupRepository, times(1)).delete(group);
-		verify(groupMemberRepository, times(1)).deleteAll(List.of(groupMember1));
-		verify(bookmarkedStudyGroupRepository, times(1)).deleteAll(bookmarks);
-	}
-
-	@Test
-	@DisplayName("그룹 삭제 성공 (멤버)")
-	void exitGroup() {
-		// given
-		BookmarkedStudyGroup bookmark = BookmarkedStudyGroup.builder().studyGroup(group).user(user2).build();
-
-		GroupMember groupMember = GroupMember.builder()
-			.studyGroup(group)
-			.user(user2)
-			.role(RoleOfGroupMember.ADMIN)
-			.joinDate(LocalDate.now())
-			.build();
-
-		when(studyGroupRepository.findById(groupId)).thenReturn(Optional.ofNullable(group));
-		when(groupMemberRepository.findByUserAndStudyGroup(user2, group)).thenReturn(Optional.of(groupMember));
-
-		when(studyGroupServiceObjectProvider.getObject()).thenReturn(groupService);
-		doNothing().when(groupService).deleteMemberFromStudyGroup(user2, groupMember, group);
-		doAnswer(invocation -> {
-			groupMemberRepository.delete(groupMember);
-			bookmarkedStudyGroupRepository.delete(bookmark);
-			return null;
-		}).when(groupService).deleteMemberFromStudyGroup(user2, groupMember, group);
-
-		// when
-		studyGroupService.exitGroup(user2, groupId);
-		// then
-		verify(groupMemberRepository, times(1)).delete(groupMember);
-		verify(bookmarkedStudyGroupRepository, times(1)).delete(Objects.requireNonNull(bookmark));
-		verify(groupService, times(1)).deleteMemberFromStudyGroup(user2, groupMember,
-			group);
 	}
 
 	@Test
@@ -310,10 +272,9 @@ class StudyGroupServiceTest {
 		// given
 		when(studyGroupRepository.findById(10L)).thenReturn(Optional.empty());
 		// when, then
-		assertThatThrownBy(() -> studyGroupService.exitGroup(user, 10L))
-			.isInstanceOf(StudyGroupValidationException.class)
-			.hasFieldOrPropertyWithValue("code", HttpStatus.NOT_FOUND.value())
-			.hasFieldOrPropertyWithValue("error", "존재하지 않는 그룹 입니다.");
+		assertThatThrownBy(() -> studyGroupService.deleteGroup(user, 10L))
+			.isInstanceOf(CannotFoundGroupException.class)
+			.hasFieldOrPropertyWithValue("errors", "존재하지 않는 그룹입니다.");
 	}
 
 	@Test
@@ -323,10 +284,10 @@ class StudyGroupServiceTest {
 		when(studyGroupRepository.findById(10L)).thenReturn(Optional.ofNullable(group));
 		when(groupMemberRepository.findByUserAndStudyGroup(user2, group)).thenReturn(Optional.empty());
 		// when, then
-		assertThatThrownBy(() -> studyGroupService.exitGroup(user2, 10L))
+		assertThatThrownBy(() -> studyGroupService.deleteGroup(user2, 10L))
 			.isInstanceOf(GroupMemberValidationException.class)
 			.hasFieldOrPropertyWithValue("code", HttpStatus.BAD_REQUEST.value())
-			.hasFieldOrPropertyWithValue("error", "이미 참여하지 않은 그룹 입니다.");
+			.hasFieldOrPropertyWithValue("error", "참여하지 않은 그룹입니다.");
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://github.com/GAMZA-BAT/algohub-server/issues/187

## 🚀 Description
<!-- 작업 내용 -->
- 기존 `deleteGroup` API가 그룹 탈퇴와 그룹 삭제를 겸했습니다.
- 이번에 그룹 탈퇴 전용 API와 그룹 삭제 전용 API로 분리했습니다.
- 알림도 삭제된 그룹에 대해서는 존재할 필요가 없다고 하셔서 알림 삭제 로직도 추가했습니다.
- 방장의 경우 그룹을 탈퇴하면 `OWNER` 권한을 위임해야 하는데, `ADMIN` 중 가장 먼저 가입한 사람으로 위임되는 로직을 추가했습니다. (`ADMIN`이 존재하지 않으면 가장 먼저 가입한 사람이 됩니다.)

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->