### PR TITLE
feat : 나의 풀이 전체 목록 조회 API / 그룹 내 나의 풀이 목록 조회 API 생성

### DIFF
--- a/src/main/java/com/gamzabat/algohub/common/DateFormatUtil.java
+++ b/src/main/java/com/gamzabat/algohub/common/DateFormatUtil.java
@@ -17,7 +17,7 @@ public final class DateFormatUtil {
 	}
 
 	public static String formatDateTimeForNotice(LocalDateTime dateTime) {
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yy/MM/dd HH:mm a", Locale.ENGLISH);
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yy/MM/dd hh:mm a", Locale.ENGLISH);
 		return dateTime.format(formatter);
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/solution/controller/SolutionController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/controller/SolutionController.java
@@ -64,17 +64,19 @@ public class SolutionController {
 		return ResponseEntity.ok().build();
 	}
 
-	@GetMapping("/my-solutions")
-	@Operation(summary = "나의 풀이 목록 조회 API", description = "나의 풀이를 모두 조회하는 API")
-	public ResponseEntity<Page<GetSolutionResponse>> getSolutionList(@AuthedUser User user,
-		@RequestParam Long problemId,
+	@GetMapping("/groups/{groupId}/my-solutions")
+	@Operation(summary = "그룹 내 나의 풀이 전체 조회 API", description = "특정 그룹 내에서 제출한 나의 풀이를 모두 조회하는 API")
+	public ResponseEntity<Page<GetSolutionResponse>> getMySolutionsInGroup(@AuthedUser User user,
+		@PathVariable Long groupId,
+		@RequestParam(required = false) Integer problemNumber,
 		@RequestParam(required = false) String language,
 		@RequestParam(required = false) String result,
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "20") int size) {
 		Pageable pageable = PageRequest.of(page, size);
-		Page<GetSolutionResponse> response = solutionService.getSolutionList(user, problemId, user.getNickname(),
-			language, result, pageable);
+		Page<GetSolutionResponse> response = solutionService.getMySolutionsInGroup(user,
+			groupId, problemNumber, language, result, pageable);
 		return ResponseEntity.ok().body(response);
 	}
+
 }

--- a/src/main/java/com/gamzabat/algohub/feature/solution/controller/SolutionController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/controller/SolutionController.java
@@ -79,4 +79,17 @@ public class SolutionController {
 		return ResponseEntity.ok().body(response);
 	}
 
+	@GetMapping("/users/my-solutions")
+	@Operation(summary = "내 풀이 전체 조회 API", description = "그룹 상관 없이 나의 풀이 전체를 조회하는 API")
+	public ResponseEntity<Page<GetSolutionResponse>> getMySolutions(@AuthedUser User user,
+		@RequestParam(required = false) Integer problemNumber,
+		@RequestParam(required = false) String language,
+		@RequestParam(required = false) String result,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "20") int size) {
+		Pageable pageable = PageRequest.of(page, size);
+		Page<GetSolutionResponse> response = solutionService.getMySolutions(user,
+			problemNumber, language, result, pageable);
+		return ResponseEntity.ok().body(response);
+	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/solution/controller/SolutionController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/controller/SolutionController.java
@@ -17,6 +17,7 @@ import com.gamzabat.algohub.common.annotation.AuthedUser;
 import com.gamzabat.algohub.exception.RequestException;
 import com.gamzabat.algohub.feature.solution.dto.CreateSolutionRequest;
 import com.gamzabat.algohub.feature.solution.dto.GetSolutionResponse;
+import com.gamzabat.algohub.feature.solution.dto.GetSolutionWithGroupIdResponse;
 import com.gamzabat.algohub.feature.solution.service.SolutionService;
 import com.gamzabat.algohub.feature.user.domain.User;
 
@@ -81,14 +82,14 @@ public class SolutionController {
 
 	@GetMapping("/users/my-solutions")
 	@Operation(summary = "내 풀이 전체 조회 API", description = "그룹 상관 없이 나의 풀이 전체를 조회하는 API")
-	public ResponseEntity<Page<GetSolutionResponse>> getMySolutions(@AuthedUser User user,
+	public ResponseEntity<Page<GetSolutionWithGroupIdResponse>> getMySolutions(@AuthedUser User user,
 		@RequestParam(required = false) Integer problemNumber,
 		@RequestParam(required = false) String language,
 		@RequestParam(required = false) String result,
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "20") int size) {
 		Pageable pageable = PageRequest.of(page, size);
-		Page<GetSolutionResponse> response = solutionService.getMySolutions(user,
+		Page<GetSolutionWithGroupIdResponse> response = solutionService.getMySolutions(user,
 			problemNumber, language, result, pageable);
 		return ResponseEntity.ok().body(response);
 	}

--- a/src/main/java/com/gamzabat/algohub/feature/solution/dto/GetSolutionResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/dto/GetSolutionResponse.java
@@ -5,21 +5,24 @@ import com.gamzabat.algohub.constants.BOJResultConstants;
 import com.gamzabat.algohub.feature.solution.domain.Solution;
 
 import lombok.Builder;
+import lombok.Getter;
 
 @Builder
-public record GetSolutionResponse(Long solutionId,
-								  String problemTitle,
-								  Integer problemLevel,
-								  String nickname,
-								  String profileImage,
-								  String solvedDateTime,
-								  String content,
-								  String result,
-								  Integer memoryUsage,
-								  Integer executionTime,
-								  String language,
-								  Integer codeLength,
-								  Long commentCount) {
+@Getter
+public class GetSolutionResponse {
+	private Long solutionId;
+	private String problemTitle;
+	private Integer problemLevel;
+	private String nickname;
+	private String profileImage;
+	private String solvedDateTime;
+	private String content;
+	private String result;
+	private Integer memoryUsage;
+	private Integer executionTime;
+	private String language;
+	private Integer codeLength;
+	private Long commentCount;
 
 	public static GetSolutionResponse toDTO(Solution solution, Long commentCount) {
 		return GetSolutionResponse.builder()
@@ -39,7 +42,7 @@ public record GetSolutionResponse(Long solutionId,
 			.build();
 	}
 
-	private static String convertToCustomResult(String result) {
+	protected static String convertToCustomResult(String result) {
 		if (result.endsWith("점"))
 			return BOJResultConstants.CORRECT;
 		else if (result.equals(BOJResultConstants.WRONG_OUTPUT_FORMAT))

--- a/src/main/java/com/gamzabat/algohub/feature/solution/dto/GetSolutionResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/dto/GetSolutionResponse.java
@@ -4,10 +4,10 @@ import com.gamzabat.algohub.common.DateFormatUtil;
 import com.gamzabat.algohub.constants.BOJResultConstants;
 import com.gamzabat.algohub.feature.solution.domain.Solution;
 
-import lombok.Builder;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 
-@Builder
+@SuperBuilder
 @Getter
 public class GetSolutionResponse {
 	private Long solutionId;

--- a/src/main/java/com/gamzabat/algohub/feature/solution/dto/GetSolutionWithGroupIdResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/dto/GetSolutionWithGroupIdResponse.java
@@ -1,0 +1,40 @@
+package com.gamzabat.algohub.feature.solution.dto;
+
+import com.gamzabat.algohub.common.DateFormatUtil;
+import com.gamzabat.algohub.feature.solution.domain.Solution;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class GetSolutionWithGroupIdResponse extends GetSolutionResponse {
+	private final Long groupId;
+
+	@Builder
+	GetSolutionWithGroupIdResponse(Long solutionId, String problemTitle, Integer problemLevel, String nickname,
+		String profileImage, String solvedDateTime, String content, String result, Integer memoryUsage,
+		Integer executionTime, String language, Integer codeLength, Long commentCount, Long groupId) {
+		super(solutionId, problemTitle, problemLevel, nickname, profileImage, solvedDateTime, content, result,
+			memoryUsage, executionTime, language, codeLength, commentCount);
+		this.groupId = groupId;
+	}
+
+	public static GetSolutionWithGroupIdResponse toDTO(Solution solution, Long commentCount) {
+		return GetSolutionWithGroupIdResponse.builder()
+			.solutionId(solution.getId())
+			.problemTitle(solution.getProblem().getTitle())
+			.problemLevel(solution.getProblem().getLevel())
+			.nickname(solution.getUser().getNickname())
+			.profileImage(solution.getUser().getProfileImage())
+			.solvedDateTime(DateFormatUtil.formatDateTime(solution.getSolvedDateTime()))
+			.content(solution.getContent())
+			.result(convertToCustomResult(solution.getResult()))
+			.memoryUsage(solution.getMemoryUsage())
+			.executionTime(solution.getExecutionTime())
+			.language(solution.getLanguage())
+			.codeLength(solution.getCodeLength())
+			.commentCount(commentCount)
+			.groupId(solution.getProblem().getStudyGroup().getId())
+			.build();
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/feature/solution/dto/GetSolutionWithGroupIdResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/dto/GetSolutionWithGroupIdResponse.java
@@ -3,21 +3,13 @@ package com.gamzabat.algohub.feature.solution.dto;
 import com.gamzabat.algohub.common.DateFormatUtil;
 import com.gamzabat.algohub.feature.solution.domain.Solution;
 
-import lombok.Builder;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 
+@SuperBuilder
 @Getter
 public class GetSolutionWithGroupIdResponse extends GetSolutionResponse {
 	private final Long groupId;
-
-	@Builder
-	GetSolutionWithGroupIdResponse(Long solutionId, String problemTitle, Integer problemLevel, String nickname,
-		String profileImage, String solvedDateTime, String content, String result, Integer memoryUsage,
-		Integer executionTime, String language, Integer codeLength, Long commentCount, Long groupId) {
-		super(solutionId, problemTitle, problemLevel, nickname, profileImage, solvedDateTime, content, result,
-			memoryUsage, executionTime, language, codeLength, commentCount);
-		this.groupId = groupId;
-	}
 
 	public static GetSolutionWithGroupIdResponse toDTO(Solution solution, Long commentCount) {
 		return GetSolutionWithGroupIdResponse.builder()

--- a/src/main/java/com/gamzabat/algohub/feature/solution/repository/querydsl/CustomSolutionRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/repository/querydsl/CustomSolutionRepository.java
@@ -3,6 +3,7 @@ package com.gamzabat.algohub.feature.solution.repository.querydsl;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import com.gamzabat.algohub.feature.group.studygroup.domain.StudyGroup;
 import com.gamzabat.algohub.feature.problem.domain.Problem;
 import com.gamzabat.algohub.feature.solution.domain.Solution;
 import com.gamzabat.algohub.feature.user.domain.User;
@@ -11,6 +12,14 @@ public interface CustomSolutionRepository {
 	Page<Solution> findAllFilteredSolutions(
 		Problem problem,
 		String nickname,
+		String language,
+		String result,
+		Pageable pageable);
+
+	Page<Solution> findAllFilteredMySolutions(
+		User user,
+		StudyGroup group,
+		Integer problemNumber,
 		String language,
 		String result,
 		Pageable pageable);

--- a/src/main/java/com/gamzabat/algohub/feature/solution/repository/querydsl/CustomSolutionRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/repository/querydsl/CustomSolutionRepository.java
@@ -16,7 +16,7 @@ public interface CustomSolutionRepository {
 		String result,
 		Pageable pageable);
 
-	Page<Solution> findAllFilteredMySolutions(
+	Page<Solution> findAllFilteredMySolutionsInGroup(
 		User user,
 		StudyGroup group,
 		Integer problemNumber,

--- a/src/main/java/com/gamzabat/algohub/feature/solution/repository/querydsl/CustomSolutionRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/repository/querydsl/CustomSolutionRepository.java
@@ -24,5 +24,12 @@ public interface CustomSolutionRepository {
 		String result,
 		Pageable pageable);
 
+	Page<Solution> findAllFilteredMySolutions(
+		User user,
+		Integer problemNumber,
+		String language,
+		String result,
+		Pageable pageable);
+
 	boolean existsByUserAndProblemAndResult(User user, Problem problem, String result);
 }

--- a/src/main/java/com/gamzabat/algohub/feature/solution/repository/querydsl/CustomSolutionRepositoryImpl.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/repository/querydsl/CustomSolutionRepositoryImpl.java
@@ -56,7 +56,7 @@ public class CustomSolutionRepositoryImpl implements CustomSolutionRepository {
 	}
 
 	@Override
-	public Page<Solution> findAllFilteredMySolutions(User user, StudyGroup group, Integer problemNumber,
+	public Page<Solution> findAllFilteredMySolutionsInGroup(User user, StudyGroup group, Integer problemNumber,
 		String language,
 		String result, Pageable pageable) {
 		JPAQuery<Solution> query = queryFactory.selectFrom(solution)

--- a/src/main/java/com/gamzabat/algohub/feature/solution/repository/querydsl/CustomSolutionRepositoryImpl.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/repository/querydsl/CustomSolutionRepositoryImpl.java
@@ -1,6 +1,8 @@
 package com.gamzabat.algohub.feature.solution.repository.querydsl;
 
 import static com.gamzabat.algohub.constants.BOJResultConstants.*;
+import static com.gamzabat.algohub.feature.group.studygroup.domain.QStudyGroup.*;
+import static com.gamzabat.algohub.feature.problem.domain.QProblem.*;
 import static com.gamzabat.algohub.feature.solution.domain.QSolution.*;
 
 import org.springframework.data.domain.Page;
@@ -9,6 +11,7 @@ import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 import com.gamzabat.algohub.constants.LanguageConstants;
+import com.gamzabat.algohub.feature.group.studygroup.domain.StudyGroup;
 import com.gamzabat.algohub.feature.problem.domain.Problem;
 import com.gamzabat.algohub.feature.solution.domain.Solution;
 import com.gamzabat.algohub.feature.user.domain.User;
@@ -52,6 +55,24 @@ public class CustomSolutionRepositoryImpl implements CustomSolutionRepository {
 		return PageableExecutionUtils.getPage(query.fetch(), pageable, countQuery::fetchOne);
 	}
 
+	@Override
+	public Page<Solution> findAllFilteredMySolutions(User user, StudyGroup group, Integer problemNumber,
+		String language,
+		String result, Pageable pageable) {
+		JPAQuery<Solution> query = queryFactory.selectFrom(solution)
+			.join(solution.problem, problem).fetchJoin()
+			.join(problem.studyGroup, studyGroup).fetchJoin()
+			.where(solution.problem.studyGroup.eq(group)
+				.and(solution.user.eq(user)));
+
+		addProblemFilter(problemNumber, query);
+		addLanguageFilter(language, query);
+		addResultFilter(result, query);
+
+		JPAQuery<Long> countQuery = solutionCountQuery(query);
+		return PageableExecutionUtils.getPage(query.fetch(), pageable, countQuery::fetchOne);
+	}
+
 	private void addResultFilter(String result, JPAQuery<Solution> query) {
 		if (result != null && !result.isBlank()) {
 			if (result.equals(CORRECT))
@@ -72,6 +93,11 @@ public class CustomSolutionRepositoryImpl implements CustomSolutionRepository {
 	private void addLanguageFilter(String language, JPAQuery<Solution> query) {
 		if (language != null && !language.isBlank())
 			languageFilter(query, language);
+	}
+
+	private void addProblemFilter(Integer problemNumber, JPAQuery<Solution> query) {
+		if (problemNumber != null)
+			query.where(solution.problem.number.eq(problemNumber));
 	}
 
 	private void languageFilter(JPAQuery<Solution> query, String language) {

--- a/src/main/java/com/gamzabat/algohub/feature/solution/repository/querydsl/CustomSolutionRepositoryImpl.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/repository/querydsl/CustomSolutionRepositoryImpl.java
@@ -73,6 +73,21 @@ public class CustomSolutionRepositoryImpl implements CustomSolutionRepository {
 		return PageableExecutionUtils.getPage(query.fetch(), pageable, countQuery::fetchOne);
 	}
 
+	@Override
+	public Page<Solution> findAllFilteredMySolutions(User user, Integer problemNumber,
+		String language,
+		String result, Pageable pageable) {
+		JPAQuery<Solution> query = queryFactory.selectFrom(solution)
+			.where(solution.user.eq(user));
+
+		addProblemFilter(problemNumber, query);
+		addLanguageFilter(language, query);
+		addResultFilter(result, query);
+
+		JPAQuery<Long> countQuery = solutionCountQuery(query);
+		return PageableExecutionUtils.getPage(query.fetch(), pageable, countQuery::fetchOne);
+	}
+
 	private void addResultFilter(String result, JPAQuery<Solution> query) {
 		if (result != null && !result.isBlank()) {
 			if (result.equals(CORRECT))

--- a/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
@@ -99,7 +99,8 @@ public class SolutionService {
 			throw new GroupMemberValidationException(HttpStatus.FORBIDDEN.value(), "참여하지 않은 그룹입니다.");
 		}
 
-		Page<Solution> solutions = solutionRepository.findAllFilteredMySolutions(user, group, problemNumber, language,
+		Page<Solution> solutions = solutionRepository.findAllFilteredMySolutionsInGroup(user, group, problemNumber,
+			language,
 			result, pageable);
 
 		return solutions.map(solution -> {

--- a/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
@@ -19,6 +19,7 @@ import com.gamzabat.algohub.feature.group.ranking.service.RankingService;
 import com.gamzabat.algohub.feature.group.ranking.service.RankingUpdateService;
 import com.gamzabat.algohub.feature.group.studygroup.domain.GroupMember;
 import com.gamzabat.algohub.feature.group.studygroup.domain.StudyGroup;
+import com.gamzabat.algohub.feature.group.studygroup.exception.CannotFoundGroupException;
 import com.gamzabat.algohub.feature.group.studygroup.exception.GroupMemberValidationException;
 import com.gamzabat.algohub.feature.group.studygroup.repository.GroupMemberRepository;
 import com.gamzabat.algohub.feature.group.studygroup.repository.StudyGroupRepository;
@@ -87,6 +88,24 @@ public class SolutionService {
 		} else {
 			throw new UserValidationException("해당 풀이를 확인 할 권한이 없습니다.");
 		}
+	}
+
+	public Page<GetSolutionResponse> getMySolutionsInGroup(User user, Long groupId, Integer problemNumber,
+		String language,
+		String result, Pageable pageable) {
+		StudyGroup group = studyGroupRepository.findById(groupId)
+			.orElseThrow(() -> new CannotFoundGroupException("존재하지 않는 그룹입니다."));
+		if (!groupMemberRepository.existsByUserAndStudyGroup(user, group)) {
+			throw new GroupMemberValidationException(HttpStatus.FORBIDDEN.value(), "참여하지 않은 그룹입니다.");
+		}
+
+		Page<Solution> solutions = solutionRepository.findAllFilteredMySolutions(user, group, problemNumber, language,
+			result, pageable);
+
+		return solutions.map(solution -> {
+			long commentCount = commentRepository.countCommentsBySolutionId(solution.getId());
+			return GetSolutionResponse.toDTO(solution, commentCount);
+		});
 	}
 
 	public void createSolution(CreateSolutionRequest request) {

--- a/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
@@ -109,6 +109,18 @@ public class SolutionService {
 		});
 	}
 
+	public Page<GetSolutionResponse> getMySolutions(User user, Integer problemNumber, String language, String result,
+		Pageable pageable) {
+		Page<Solution> solutions = solutionRepository.findAllFilteredMySolutions(user, problemNumber,
+			language,
+			result, pageable);
+
+		return solutions.map(solution -> {
+			long commentCount = commentRepository.countCommentsBySolutionId(solution.getId());
+			return GetSolutionResponse.toDTO(solution, commentCount);
+		});
+	}
+
 	public void createSolution(CreateSolutionRequest request) {
 
 		List<Problem> problems = problemRepository.findAllByNumber(request.problemNumber());

--- a/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
@@ -30,6 +30,7 @@ import com.gamzabat.algohub.feature.problem.repository.ProblemRepository;
 import com.gamzabat.algohub.feature.solution.domain.Solution;
 import com.gamzabat.algohub.feature.solution.dto.CreateSolutionRequest;
 import com.gamzabat.algohub.feature.solution.dto.GetSolutionResponse;
+import com.gamzabat.algohub.feature.solution.dto.GetSolutionWithGroupIdResponse;
 import com.gamzabat.algohub.feature.solution.exception.CannotFoundSolutionException;
 import com.gamzabat.algohub.feature.solution.repository.SolutionCommentRepository;
 import com.gamzabat.algohub.feature.solution.repository.SolutionRepository;
@@ -109,7 +110,8 @@ public class SolutionService {
 		});
 	}
 
-	public Page<GetSolutionResponse> getMySolutions(User user, Integer problemNumber, String language, String result,
+	public Page<GetSolutionWithGroupIdResponse> getMySolutions(User user, Integer problemNumber, String language,
+		String result,
 		Pageable pageable) {
 		Page<Solution> solutions = solutionRepository.findAllFilteredMySolutions(user, problemNumber,
 			language,
@@ -117,7 +119,7 @@ public class SolutionService {
 
 		return solutions.map(solution -> {
 			long commentCount = commentRepository.countCommentsBySolutionId(solution.getId());
-			return GetSolutionResponse.toDTO(solution, commentCount);
+			return GetSolutionWithGroupIdResponse.toDTO(solution, commentCount);
 		});
 	}
 

--- a/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
@@ -66,8 +66,10 @@ class SolutionServiceTest {
 	@Mock
 	private UserRepository userRepository;
 	private User user, user2;
-	private Problem problem;
-	private StudyGroup group;
+	private Problem problem, problem1, problem2;
+	private StudyGroup group, group1;
+	private Long groupId = 30L;
+	private Integer problemNumber = 1010;
 	DateTimeFormatter formatter;
 
 	@BeforeEach
@@ -78,9 +80,28 @@ class SolutionServiceTest {
 		user2 = User.builder().email("email2").password("password").nickname("nickname2").bjNickname("bjNickname2")
 			.role(Role.USER).profileImage("profileImage").build();
 		group = StudyGroup.builder().name("name").groupImage("imageUrl").groupCode("code").build();
+		group1 = StudyGroup.builder().name("name1").groupImage("imageUrl1").groupCode("code1").build();
 		problem = Problem.builder()
 			.studyGroup(group)
 			.link("link")
+			.number(1010)
+			.level(100)
+			.startDate(LocalDate.now())
+			.endDate(LocalDate.now())
+			.build();
+		problem1 = Problem.builder()
+			.studyGroup(group)
+			.link("link1")
+			.number(1020)
+			.level(200)
+			.startDate(LocalDate.now())
+			.endDate(LocalDate.now())
+			.build();
+		problem2 = Problem.builder()
+			.studyGroup(group1)
+			.link("link2")
+			.number(1030)
+			.level(300)
 			.startDate(LocalDate.now())
 			.endDate(LocalDate.now())
 			.build();
@@ -446,5 +467,40 @@ class SolutionServiceTest {
 		// then
 		verify(solutionRepository, times(1)).save(any(Solution.class));
 		verify(notificationService, times(1)).sendNotificationToMembers(any(), any(), any(), any());
+	}
+
+	@Test
+	@DisplayName("그룹 내 나의 풀이 전체 조회 성공 : 문제 필터링")
+	void getMySolutionsInGroup() {
+		// given
+		Pageable pageable = PageRequest.of(0, 10);
+		List<Solution> solutions = new ArrayList<>();
+		LocalDateTime fixedDateTime = LocalDateTime.now();
+
+		for (int i = 0; i < 5; i++) {
+			solutions.add(Solution.builder()
+				.problem(problem)
+				.user(user)
+				.codeLength(i)
+				.result("맞았습니다!!")
+				.language("Java 11")
+				.solvedDateTime(fixedDateTime)
+				.build());
+		}
+
+		Page<Solution> mySolutions = new PageImpl<>(solutions, pageable, 10);
+		when(studyGroupRepository.findById(groupId)).thenReturn(Optional.ofNullable(group));
+		when(groupMemberRepository.existsByUserAndStudyGroup(user, group)).thenReturn(true);
+		when(solutionRepository.findAllFilteredMySolutions(user, group, problemNumber, null, null,
+			pageable)).thenReturn(mySolutions);
+		// when
+		Page<GetSolutionResponse> responses = solutionService.getMySolutionsInGroup(user, groupId, problemNumber, null,
+			null,
+			pageable);
+		// then
+		for (int i = 0; i < 5; i++) {
+			assertThat(responses.getContent().get(i).nickname()).isEqualTo("nickname1");
+			assertThat(responses.getContent().get(i).problemLevel()).isEqualTo(problem.getLevel());
+		}
 	}
 }

--- a/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
@@ -40,6 +40,7 @@ import com.gamzabat.algohub.feature.problem.repository.ProblemRepository;
 import com.gamzabat.algohub.feature.solution.domain.Solution;
 import com.gamzabat.algohub.feature.solution.dto.CreateSolutionRequest;
 import com.gamzabat.algohub.feature.solution.dto.GetSolutionResponse;
+import com.gamzabat.algohub.feature.solution.dto.GetSolutionWithGroupIdResponse;
 import com.gamzabat.algohub.feature.solution.exception.CannotFoundSolutionException;
 import com.gamzabat.algohub.feature.solution.repository.SolutionCommentRepository;
 import com.gamzabat.algohub.feature.solution.repository.SolutionRepository;
@@ -150,46 +151,46 @@ class SolutionServiceTest {
 		assertThat(compileErrorResult.getContent().size()).isEqualTo(10);
 		assertThat(compileErrorResult.getTotalElements()).isEqualTo(10);
 		for (int i = 0; i < 5; i++) {
-			assertThat(compileErrorResult.getContent().get(i).content()).isEqualTo("content" + i);
-			assertThat(compileErrorResult.getContent().get(i).result()).isEqualTo("컴파일 에러");
-			assertThat(compileErrorResult.getContent().get(i).memoryUsage()).isEqualTo(i);
-			assertThat(compileErrorResult.getContent().get(i).executionTime()).isEqualTo(i);
-			assertThat(compileErrorResult.getContent().get(i).nickname()).isEqualTo("nickname1");
-			assertThat(compileErrorResult.getContent().get(i).language()).isEqualTo("Java 11");
-			assertThat(compileErrorResult.getContent().get(i).solvedDateTime()).isEqualTo(
+			assertThat(compileErrorResult.getContent().get(i).getContent()).isEqualTo("content" + i);
+			assertThat(compileErrorResult.getContent().get(i).getResult()).isEqualTo("컴파일 에러");
+			assertThat(compileErrorResult.getContent().get(i).getMemoryUsage()).isEqualTo(i);
+			assertThat(compileErrorResult.getContent().get(i).getExecutionTime()).isEqualTo(i);
+			assertThat(compileErrorResult.getContent().get(i).getNickname()).isEqualTo("nickname1");
+			assertThat(compileErrorResult.getContent().get(i).getLanguage()).isEqualTo("Java 11");
+			assertThat(compileErrorResult.getContent().get(i).getSolvedDateTime()).isEqualTo(
 				DateFormatUtil.formatDateTime(fixedDateTime));
 		}
 		for (int i = 5; i < 10; i++) {
-			assertThat(compileErrorResult.getContent().get(i).content()).isEqualTo("content" + i);
-			assertThat(compileErrorResult.getContent().get(i).result()).isEqualTo("컴파일 에러");
-			assertThat(compileErrorResult.getContent().get(i).memoryUsage()).isEqualTo(i);
-			assertThat(compileErrorResult.getContent().get(i).executionTime()).isEqualTo(i);
-			assertThat(compileErrorResult.getContent().get(i).nickname()).isEqualTo("nickname2");
-			assertThat(compileErrorResult.getContent().get(i).language()).isEqualTo("C++17");
-			assertThat(compileErrorResult.getContent().get(i).solvedDateTime()).isEqualTo(
+			assertThat(compileErrorResult.getContent().get(i).getContent()).isEqualTo("content" + i);
+			assertThat(compileErrorResult.getContent().get(i).getResult()).isEqualTo("컴파일 에러");
+			assertThat(compileErrorResult.getContent().get(i).getMemoryUsage()).isEqualTo(i);
+			assertThat(compileErrorResult.getContent().get(i).getExecutionTime()).isEqualTo(i);
+			assertThat(compileErrorResult.getContent().get(i).getNickname()).isEqualTo("nickname2");
+			assertThat(compileErrorResult.getContent().get(i).getLanguage()).isEqualTo("C++17");
+			assertThat(compileErrorResult.getContent().get(i).getSolvedDateTime()).isEqualTo(
 				DateFormatUtil.formatDateTime(fixedDateTime));
 		}
 		// 2) 맞았습니다!! 풀이 목록 조회
 		assertThat(correctResult.getContent().size()).isEqualTo(10);
 		assertThat(correctResult.getTotalElements()).isEqualTo(10);
 		for (int i = 0; i < 5; i++) {
-			assertThat(correctResult.getContent().get(i).content()).isEqualTo("content" + (i + 10));
-			assertThat(correctResult.getContent().get(i).result()).isEqualTo("맞았습니다!!");
-			assertThat(correctResult.getContent().get(i).memoryUsage()).isEqualTo(i + 10);
-			assertThat(correctResult.getContent().get(i).executionTime()).isEqualTo(i + 10);
-			assertThat(correctResult.getContent().get(i).nickname()).isEqualTo("nickname1");
-			assertThat(correctResult.getContent().get(i).language()).isEqualTo("Java 11");
-			assertThat(correctResult.getContent().get(i).solvedDateTime()).isEqualTo(
+			assertThat(correctResult.getContent().get(i).getContent()).isEqualTo("content" + (i + 10));
+			assertThat(correctResult.getContent().get(i).getResult()).isEqualTo("맞았습니다!!");
+			assertThat(correctResult.getContent().get(i).getMemoryUsage()).isEqualTo(i + 10);
+			assertThat(correctResult.getContent().get(i).getExecutionTime()).isEqualTo(i + 10);
+			assertThat(correctResult.getContent().get(i).getNickname()).isEqualTo("nickname1");
+			assertThat(correctResult.getContent().get(i).getLanguage()).isEqualTo("Java 11");
+			assertThat(correctResult.getContent().get(i).getSolvedDateTime()).isEqualTo(
 				DateFormatUtil.formatDateTime(fixedDateTime));
 		}
 		for (int i = 5; i < 10; i++) {
-			assertThat(correctResult.getContent().get(i).content()).isEqualTo("content" + (i + 10));
-			assertThat(correctResult.getContent().get(i).result()).isEqualTo("맞았습니다!!");
-			assertThat(correctResult.getContent().get(i).memoryUsage()).isEqualTo(i + 10);
-			assertThat(correctResult.getContent().get(i).executionTime()).isEqualTo(i + 10);
-			assertThat(correctResult.getContent().get(i).nickname()).isEqualTo("nickname2");
-			assertThat(correctResult.getContent().get(i).language()).isEqualTo("PyPy3");
-			assertThat(correctResult.getContent().get(i).solvedDateTime()).isEqualTo(
+			assertThat(correctResult.getContent().get(i).getContent()).isEqualTo("content" + (i + 10));
+			assertThat(correctResult.getContent().get(i).getResult()).isEqualTo("맞았습니다!!");
+			assertThat(correctResult.getContent().get(i).getMemoryUsage()).isEqualTo(i + 10);
+			assertThat(correctResult.getContent().get(i).getExecutionTime()).isEqualTo(i + 10);
+			assertThat(correctResult.getContent().get(i).getNickname()).isEqualTo("nickname2");
+			assertThat(correctResult.getContent().get(i).getLanguage()).isEqualTo("PyPy3");
+			assertThat(correctResult.getContent().get(i).getSolvedDateTime()).isEqualTo(
 				DateFormatUtil.formatDateTime(fixedDateTime));
 		}
 	}
@@ -219,13 +220,13 @@ class SolutionServiceTest {
 		assertThat(result.getContent().size()).isEqualTo(5);
 		assertThat(result.getTotalElements()).isEqualTo(5);
 		for (int i = 0; i < 5; i++) {
-			assertThat(result.getContent().get(i).content()).isEqualTo("content" + (i + 10));
-			assertThat(result.getContent().get(i).result()).isEqualTo("맞았습니다!!");
-			assertThat(result.getContent().get(i).memoryUsage()).isEqualTo(i + 10);
-			assertThat(result.getContent().get(i).executionTime()).isEqualTo(i + 10);
-			assertThat(result.getContent().get(i).nickname()).isEqualTo("nickname1");
-			assertThat(result.getContent().get(i).language()).isEqualTo("Java 11");
-			assertThat(result.getContent().get(i).solvedDateTime()).isEqualTo(
+			assertThat(result.getContent().get(i).getContent()).isEqualTo("content" + (i + 10));
+			assertThat(result.getContent().get(i).getResult()).isEqualTo("맞았습니다!!");
+			assertThat(result.getContent().get(i).getMemoryUsage()).isEqualTo(i + 10);
+			assertThat(result.getContent().get(i).getExecutionTime()).isEqualTo(i + 10);
+			assertThat(result.getContent().get(i).getNickname()).isEqualTo("nickname1");
+			assertThat(result.getContent().get(i).getLanguage()).isEqualTo("Java 11");
+			assertThat(result.getContent().get(i).getSolvedDateTime()).isEqualTo(
 				DateFormatUtil.formatDateTime(fixedDateTime));
 		}
 	}
@@ -292,16 +293,16 @@ class SolutionServiceTest {
 		// when
 		GetSolutionResponse response = solutionService.getSolution(user, 10L);
 		// then
-		assertThat(response.content()).isEqualTo("content");
-		assertThat(response.result()).isEqualTo("맞았습니다!!");
-		assertThat(response.memoryUsage()).isEqualTo(10);
-		assertThat(response.executionTime()).isEqualTo(10);
-		assertThat(response.nickname()).isEqualTo("nickname1");
-		assertThat(response.profileImage()).isEqualTo("profileImage");
-		assertThat(response.language()).isEqualTo("Java");
-		assertThat(response.codeLength()).isEqualTo(10);
-		assertThat(response.commentCount()).isEqualTo(0);
-		assertThat(response.solvedDateTime()).isEqualTo(DateFormatUtil.formatDateTime(LocalDateTime.now()));
+		assertThat(response.getContent()).isEqualTo("content");
+		assertThat(response.getResult()).isEqualTo("맞았습니다!!");
+		assertThat(response.getMemoryUsage()).isEqualTo(10);
+		assertThat(response.getExecutionTime()).isEqualTo(10);
+		assertThat(response.getNickname()).isEqualTo("nickname1");
+		assertThat(response.getProfileImage()).isEqualTo("profileImage");
+		assertThat(response.getLanguage()).isEqualTo("Java");
+		assertThat(response.getCodeLength()).isEqualTo(10);
+		assertThat(response.getCommentCount()).isEqualTo(0);
+		assertThat(response.getSolvedDateTime()).isEqualTo(DateFormatUtil.formatDateTime(LocalDateTime.now()));
 	}
 
 	@Test
@@ -324,16 +325,16 @@ class SolutionServiceTest {
 		// when
 		GetSolutionResponse response = solutionService.getSolution(user2, 10L);
 		// then
-		assertThat(response.content()).isEqualTo("content");
-		assertThat(response.result()).isEqualTo("맞았습니다!!");
-		assertThat(response.memoryUsage()).isEqualTo(10);
-		assertThat(response.executionTime()).isEqualTo(10);
-		assertThat(response.nickname()).isEqualTo("nickname1");
-		assertThat(response.profileImage()).isEqualTo("profileImage");
-		assertThat(response.language()).isEqualTo("Java");
-		assertThat(response.codeLength()).isEqualTo(10);
-		assertThat(response.commentCount()).isEqualTo(0);
-		assertThat(response.solvedDateTime()).isEqualTo(DateFormatUtil.formatDateTime(LocalDateTime.now()));
+		assertThat(response.getContent()).isEqualTo("content");
+		assertThat(response.getResult()).isEqualTo("맞았습니다!!");
+		assertThat(response.getMemoryUsage()).isEqualTo(10);
+		assertThat(response.getExecutionTime()).isEqualTo(10);
+		assertThat(response.getNickname()).isEqualTo("nickname1");
+		assertThat(response.getProfileImage()).isEqualTo("profileImage");
+		assertThat(response.getLanguage()).isEqualTo("Java");
+		assertThat(response.getCodeLength()).isEqualTo(10);
+		assertThat(response.getCommentCount()).isEqualTo(0);
+		assertThat(response.getSolvedDateTime()).isEqualTo(DateFormatUtil.formatDateTime(LocalDateTime.now()));
 	}
 
 	@Test
@@ -499,8 +500,64 @@ class SolutionServiceTest {
 			pageable);
 		// then
 		for (int i = 0; i < 5; i++) {
-			assertThat(responses.getContent().get(i).nickname()).isEqualTo("nickname1");
-			assertThat(responses.getContent().get(i).problemLevel()).isEqualTo(problem.getLevel());
+			assertThat(responses.getContent().get(i).getNickname()).isEqualTo("nickname1");
+			assertThat(responses.getContent().get(i).getProblemLevel()).isEqualTo(problem.getLevel());
+		}
+	}
+
+	@Test
+	@DisplayName("나의 풀이 전체 조회 성공")
+	void getMySolutions() {
+		// given
+		Pageable pageable = PageRequest.of(0, 10);
+		List<Solution> solutions = new ArrayList<>();
+		LocalDateTime fixedDateTime = LocalDateTime.now();
+
+		for (int i = 0; i < 5; i++) {
+			solutions.add(Solution.builder()
+				.problem(problem)
+				.user(user)
+				.codeLength(i)
+				.result("맞았습니다!!")
+				.language("Java 11")
+				.solvedDateTime(fixedDateTime)
+				.build());
+		}
+		for (int i = 5; i < 10; i++) {
+			solutions.add(Solution.builder()
+				.problem(problem)
+				.user(user)
+				.codeLength(i)
+				.result("틀렸습니다")
+				.language("Java 11")
+				.solvedDateTime(fixedDateTime)
+				.build());
+		}
+		for (int i = 10; i < 15; i++) {
+			solutions.add(Solution.builder()
+				.problem(problem2)
+				.user(user)
+				.codeLength(i)
+				.result("컴파일 에러")
+				.language("Java 11")
+				.solvedDateTime(fixedDateTime)
+				.build());
+		}
+
+		Page<Solution> mySolutions = new PageImpl<>(solutions, pageable, 10);
+		when(solutionRepository.findAllFilteredMySolutions(user, null, null, null,
+			pageable)).thenReturn(mySolutions);
+		// when
+		Page<GetSolutionWithGroupIdResponse> responses = solutionService.getMySolutions(user, null, null,
+			null, pageable);
+		// then
+		for (int i = 0; i < 10; i++) {
+			assertThat(responses.getContent().get(i).getNickname()).isEqualTo("nickname1");
+			assertThat(responses.getContent().get(i).getGroupId()).isEqualTo(problem.getStudyGroup().getId());
+		}
+		for (int i = 10; i < 15; i++) {
+			assertThat(responses.getContent().get(i).getNickname()).isEqualTo("nickname1");
+			assertThat(responses.getContent().get(i).getGroupId()).isEqualTo(problem2.getStudyGroup().getId());
 		}
 	}
 }

--- a/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
@@ -491,7 +491,7 @@ class SolutionServiceTest {
 		Page<Solution> mySolutions = new PageImpl<>(solutions, pageable, 10);
 		when(studyGroupRepository.findById(groupId)).thenReturn(Optional.ofNullable(group));
 		when(groupMemberRepository.existsByUserAndStudyGroup(user, group)).thenReturn(true);
-		when(solutionRepository.findAllFilteredMySolutions(user, group, problemNumber, null, null,
+		when(solutionRepository.findAllFilteredMySolutionsInGroup(user, group, problemNumber, null, null,
 			pageable)).thenReturn(mySolutions);
 		// when
 		Page<GetSolutionResponse> responses = solutionService.getMySolutionsInGroup(user, groupId, problemNumber, null,


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://github.com/GAMZA-BAT/algohub-server/issues/193

## 🚀 Description
<!-- 작업 내용 -->
1. 그룹 내에서 나의 풀이 목록을 조회하는 API를 추가했습니다.
2. 그룹 상관 없이 나의 풀이 목록 전체를 조회하는 API를 추가했습니다.
    -  이건 DTO에 `groupId`도 필요하다 하더라구요. 그래서 DTO를 상속해서 `groupId`도 받을 수 있도록 만들었습니다.
    -  저도 처음 알았는데, 상속해서 상위 클래스에 대한 필드들도 모두 담는 builder 패턴을 사용할거면 기존의 `@Builder`로는 안되고, `@SuperBuilder`를 사용해야한다고 합니다.

- 두 API 공통으로, `문제 번호에 대한 필터링`이 추가되었습니다.

- + ) 추가로, 공지 조회 시 포맷팅하면 실제 시간과 다르게 나오는 오류가 있었어서 이 부분도 해결했습니다. (시간 부분을 24시간제인 `HH`에서 12시간제인 `hh`로 수정했습니다.)

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->