### PR TITLE
fix : 방장 혼자 있는 그룹 탈퇴 시 권한 이전 오류 해결 및 삭제 로직 추가

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
@@ -177,11 +177,11 @@ public class StudyGroupService {
 		rankingRepository.deleteAllByStudyGroup(group);
 		notificationSettingRepository.deleteAllByStudyGroup(group);
 		notificationRepository.deleteAllByStudyGroup(group);
-		noticeRepository.deleteAllByStudyGroup(group);
 		noticeCommentRepository.deleteAllByStudyGroup(group);
-		problemRepository.deleteAllByStudyGroup(group);
-		solutionRepository.deleteAllByStudyGroup(group);
+		noticeRepository.deleteAllByStudyGroup(group);
 		solutionCommentRepository.deleteAllByStudyGroup(group);
+		solutionRepository.deleteAllByStudyGroup(group);
+		problemRepository.deleteAllByStudyGroup(group);
 		groupMemberRepository.deleteAllByStudyGroup(group);
 		groupRepository.delete(group);
 	}

--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
@@ -45,6 +45,8 @@ import com.gamzabat.algohub.feature.group.studygroup.repository.BookmarkedStudyG
 import com.gamzabat.algohub.feature.group.studygroup.repository.GroupMemberRepository;
 import com.gamzabat.algohub.feature.group.studygroup.repository.StudyGroupRepository;
 import com.gamzabat.algohub.feature.image.service.ImageService;
+import com.gamzabat.algohub.feature.notice.repository.NoticeCommentRepository;
+import com.gamzabat.algohub.feature.notice.repository.NoticeRepository;
 import com.gamzabat.algohub.feature.notification.domain.NotificationSetting;
 import com.gamzabat.algohub.feature.notification.enums.NotificationCategory;
 import com.gamzabat.algohub.feature.notification.repository.NotificationRepository;
@@ -52,6 +54,7 @@ import com.gamzabat.algohub.feature.notification.repository.NotificationSettingR
 import com.gamzabat.algohub.feature.notification.service.NotificationService;
 import com.gamzabat.algohub.feature.problem.domain.Problem;
 import com.gamzabat.algohub.feature.problem.repository.ProblemRepository;
+import com.gamzabat.algohub.feature.solution.repository.SolutionCommentRepository;
 import com.gamzabat.algohub.feature.solution.repository.SolutionRepository;
 import com.gamzabat.algohub.feature.user.domain.User;
 import com.gamzabat.algohub.feature.user.repository.UserRepository;
@@ -72,6 +75,9 @@ public class StudyGroupService {
 	private final StudyGroupRepository studyGroupRepository;
 	private final BookmarkedStudyGroupRepository bookmarkedStudyGroupRepository;
 	private final RankingRepository rankingRepository;
+	private final NoticeRepository noticeRepository;
+	private final NoticeCommentRepository noticeCommentRepository;
+	private final SolutionCommentRepository solutionCommentRepository;
 	private final NotificationRepository notificationRepository;
 
 	private final ObjectProvider<StudyGroupService> studyGroupServiceProvider;
@@ -161,14 +167,23 @@ public class StudyGroupService {
 			throw new GroupMemberValidationException(HttpStatus.FORBIDDEN.value(), "스터디 그룹 삭제는 방장만 가능합니다.");
 		}
 
+		deleteAllAboutGroup(group);
+
+		log.info("success to delete study group");
+	}
+
+	private void deleteAllAboutGroup(StudyGroup group) {
 		bookmarkedStudyGroupRepository.deleteAllByStudyGroup(group);
 		rankingRepository.deleteAllByStudyGroup(group);
 		notificationSettingRepository.deleteAllByStudyGroup(group);
 		notificationRepository.deleteAllByStudyGroup(group);
+		noticeRepository.deleteAllByStudyGroup(group);
+		noticeCommentRepository.deleteAllByStudyGroup(group);
+		problemRepository.deleteAllByStudyGroup(group);
+		solutionRepository.deleteAllByStudyGroup(group);
+		solutionCommentRepository.deleteAllByStudyGroup(group);
 		groupMemberRepository.deleteAllByStudyGroup(group);
 		groupRepository.delete(group);
-
-		log.info("success to delete study group");
 	}
 
 	@Transactional
@@ -183,11 +198,16 @@ public class StudyGroupService {
 		studyGroupServiceProvider.getObject().deleteMemberFromStudyGroup(user, groupMember, studyGroup);
 
 		if (RoleOfGroupMember.isOwner(groupMember)) {
-			GroupMember member = groupMemberRepository.findAllByStudyGroup(studyGroup)
+			List<GroupMember> members = groupMemberRepository.findAllByStudyGroup(studyGroup)
 				.stream()
 				.sorted(Comparator.comparing(GroupMember::getRole).thenComparing(GroupMember::getJoinDate))
-				.toList().getFirst();
-			member.updateRole(RoleOfGroupMember.OWNER);
+				.toList();
+
+			if (members.isEmpty()) {
+				deleteAllAboutGroup(studyGroup);
+			} else {
+				members.getFirst().updateRole(RoleOfGroupMember.OWNER);
+			}
 		}
 
 		log.info("success to exit study group");

--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
@@ -241,7 +241,7 @@ public class StudyGroupService {
 			.ifPresent(bookmarkedStudyGroupRepository::delete);
 		rankingRepository.deleteByMember(groupMember);
 		notificationSettingRepository.deleteByMember(groupMember);
-		notificationRepository.deleteAllByStudyGroup(groupMember.getStudyGroup());
+		notificationRepository.deleteAllByUserAndStudyGroup(user, studyGroup);
 		groupMemberRepository.delete(groupMember);
 		log.info("success to delete group member");
 	}

--- a/src/main/java/com/gamzabat/algohub/feature/notice/repository/NoticeCommentRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notice/repository/NoticeCommentRepository.java
@@ -19,6 +19,6 @@ public interface NoticeCommentRepository extends JpaRepository<NoticeComment, Lo
 	void deleteAllCommentByNotice(Notice notice);
 
 	@Modifying
-	@Query("delete from NoticeComment nc join nc.notice where nc.notice.studyGroup = :group")
+	@Query("DELETE FROM NoticeComment nc WHERE nc.notice.studyGroup = :group")
 	void deleteAllByStudyGroup(StudyGroup group);
 }

--- a/src/main/java/com/gamzabat/algohub/feature/notice/repository/NoticeCommentRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notice/repository/NoticeCommentRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import com.gamzabat.algohub.feature.group.studygroup.domain.StudyGroup;
 import com.gamzabat.algohub.feature.notice.domain.Notice;
 import com.gamzabat.algohub.feature.notice.domain.NoticeComment;
 
@@ -16,4 +17,8 @@ public interface NoticeCommentRepository extends JpaRepository<NoticeComment, Lo
 	@Modifying
 	@Query("delete from NoticeComment c where c.notice = :notice")
 	void deleteAllCommentByNotice(Notice notice);
+
+	@Modifying
+	@Query("delete from NoticeComment nc join nc.notice where nc.notice.studyGroup = :group")
+	void deleteAllByStudyGroup(StudyGroup group);
 }

--- a/src/main/java/com/gamzabat/algohub/feature/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notice/repository/NoticeRepository.java
@@ -3,6 +3,8 @@ package com.gamzabat.algohub.feature.notice.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import com.gamzabat.algohub.feature.group.studygroup.domain.StudyGroup;
 import com.gamzabat.algohub.feature.notice.domain.Notice;
@@ -10,4 +12,7 @@ import com.gamzabat.algohub.feature.notice.domain.Notice;
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 	Page<Notice> findAllByStudyGroup(StudyGroup studyGroup, Pageable pageable);
 
+	@Modifying
+	@Query("delete from Notice n where n.studyGroup = :studyGroup")
+	void deleteAllByStudyGroup(StudyGroup studyGroup);
 }

--- a/src/main/java/com/gamzabat/algohub/feature/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notification/repository/NotificationRepository.java
@@ -18,4 +18,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 	@Modifying
 	@Query("delete from Notification n where n.studyGroup = :studyGroup")
 	void deleteAllByStudyGroup(StudyGroup studyGroup);
+
+	@Modifying
+	@Query("DELETE FROM Notification n WHERE n.user = :user AND n.studyGroup = :studyGroup")
+	void deleteAllByUserAndStudyGroup(User user, StudyGroup studyGroup);
 }

--- a/src/main/java/com/gamzabat/algohub/feature/problem/repository/ProblemRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/problem/repository/ProblemRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -27,4 +28,8 @@ public interface ProblemRepository extends JpaRepository<Problem, Long> {
 	Long countProblemsByGroupId(@Param("groupId") Long groupId);
 
 	List<Problem> findAllByEndDate(LocalDate endDate);
+
+	@Modifying
+	@Query("delete from Problem p where p.studyGroup = :studyGroup")
+	void deleteAllByStudyGroup(StudyGroup studyGroup);
 }

--- a/src/main/java/com/gamzabat/algohub/feature/solution/repository/SolutionCommentRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/repository/SolutionCommentRepository.java
@@ -3,9 +3,11 @@ package com.gamzabat.algohub.feature.solution.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.gamzabat.algohub.feature.group.studygroup.domain.StudyGroup;
 import com.gamzabat.algohub.feature.solution.domain.Solution;
 import com.gamzabat.algohub.feature.solution.domain.SolutionComment;
 
@@ -14,4 +16,8 @@ public interface SolutionCommentRepository extends JpaRepository<SolutionComment
 
 	@Query("SELECT COUNT(c) FROM SolutionComment c WHERE c.solution.id = :solutionId")
 	long countCommentsBySolutionId(@Param("solutionId") Long solutionId);
+
+	@Modifying
+	@Query("DELETE FROM SolutionComment sc WHERE sc.solution.problem.studyGroup = :studyGroup")
+	void deleteAllByStudyGroup(StudyGroup studyGroup);
 }

--- a/src/main/java/com/gamzabat/algohub/feature/solution/repository/SolutionRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/repository/SolutionRepository.java
@@ -1,9 +1,11 @@
 package com.gamzabat.algohub.feature.solution.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.gamzabat.algohub.feature.group.studygroup.domain.StudyGroup;
 import com.gamzabat.algohub.feature.problem.domain.Problem;
 import com.gamzabat.algohub.feature.solution.domain.Solution;
 import com.gamzabat.algohub.feature.solution.repository.querydsl.CustomSolutionRepository;
@@ -26,4 +28,8 @@ public interface SolutionRepository extends JpaRepository<Solution, Long>, Custo
 		"AND s.result = :correct")
 	Long countDistinctCorrectSolutionsByUserAndGroup(@Param("user") User user, @Param("groupId") Long groupId,
 		@Param("correct") String correct);
+
+	@Modifying
+	@Query("DELETE FROM Solution s WHERE s.problem.studyGroup = :studyGroup")
+	void deleteAllByStudyGroup(StudyGroup studyGroup);
 }

--- a/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
@@ -48,6 +48,8 @@ import com.gamzabat.algohub.feature.group.studygroup.repository.GroupMemberRepos
 import com.gamzabat.algohub.feature.group.studygroup.repository.StudyGroupRepository;
 import com.gamzabat.algohub.feature.group.studygroup.service.StudyGroupService;
 import com.gamzabat.algohub.feature.image.service.ImageService;
+import com.gamzabat.algohub.feature.notice.repository.NoticeCommentRepository;
+import com.gamzabat.algohub.feature.notice.repository.NoticeRepository;
 import com.gamzabat.algohub.feature.notification.domain.NotificationSetting;
 import com.gamzabat.algohub.feature.notification.repository.NotificationRepository;
 import com.gamzabat.algohub.feature.notification.repository.NotificationSettingRepository;
@@ -55,6 +57,7 @@ import com.gamzabat.algohub.feature.notification.service.NotificationService;
 import com.gamzabat.algohub.feature.problem.domain.Problem;
 import com.gamzabat.algohub.feature.problem.repository.ProblemRepository;
 import com.gamzabat.algohub.feature.solution.domain.Solution;
+import com.gamzabat.algohub.feature.solution.repository.SolutionCommentRepository;
 import com.gamzabat.algohub.feature.solution.repository.SolutionRepository;
 import com.gamzabat.algohub.feature.user.domain.User;
 import com.gamzabat.algohub.feature.user.repository.UserRepository;
@@ -81,6 +84,12 @@ class StudyGroupServiceTest {
 	private NotificationRepository notificationRepository;
 	@Mock
 	private NotificationSettingRepository notificationSettingRepository;
+	@Mock
+	private NoticeRepository noticeRepository;
+	@Mock
+	private NoticeCommentRepository noticeCommentRepository;
+	@Mock
+	private SolutionCommentRepository solutionCommentRepository;
 	@Mock
 	private RankingRepository rankingRepository;
 	@Mock
@@ -299,18 +308,18 @@ class StudyGroupServiceTest {
 	void exitGroup() {
 		// given
 		when(studyGroupRepository.findById(10L)).thenReturn(Optional.of(group));
-		when(groupMemberRepository.findByUserAndStudyGroup(user, group)).thenReturn(Optional.ofNullable(groupMember1));
-		when(groupMemberRepository.findAllByStudyGroup(group)).thenReturn(
-			List.of(groupMember2, groupMember3));
+		when(groupMemberRepository.findByUserAndStudyGroup(user2, group)).thenReturn(Optional.ofNullable(groupMember2));
+		// when(groupMemberRepository.findAllByStudyGroup(group)).thenReturn(
+		// 	List.of(groupMember2, groupMember3));
 		when(studyGroupServiceObjectProvider.getObject()).thenReturn(studyGroupService);
 		// when
-		studyGroupService.exitGroup(user, 10L);
+		studyGroupService.exitGroup(user2, 10L);
 		// then
-		verify(rankingRepository, times(1)).deleteByMember(groupMember1);
-		verify(notificationSettingRepository, times(1)).deleteByMember(groupMember1);
-		verify(groupMemberRepository, times(1)).delete(groupMember1);
-		verify(notificationRepository, times(1)).deleteAllByStudyGroup(group);
-		assertThat(groupMember3.getRole()).isEqualTo(RoleOfGroupMember.OWNER);
+		verify(rankingRepository, times(1)).deleteByMember(groupMember2);
+		verify(notificationSettingRepository, times(1)).deleteByMember(groupMember2);
+		verify(groupMemberRepository, times(1)).delete(groupMember2);
+		verify(notificationRepository, times(1)).deleteAllByUserAndStudyGroup(user2, group);
+		// assertThat(groupMember3.getRole()).isEqualTo(RoleOfGroupMember.OWNER);
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://github.com/GAMZA-BAT/algohub-server/issues/198

## 🚀 Description
<!-- 작업 내용 -->
- 방장이 혼자 있을 때 그룹을 탈퇴할 경우, 그룹이 삭제되도록 로직을 수정했습니다.
- 추가로, 그룹을 삭제할 때 공지부터 풀이 및 댓글까지 전체 삭제되는 로직을 추가했습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->