### PR TITLE
refactor : 공지 목록 조회 시 최신순 정렬

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/notice/controller/NoticeController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notice/controller/NoticeController.java
@@ -3,6 +3,7 @@ package com.gamzabat.algohub.feature.notice.controller;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -34,6 +35,7 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "공지 API", description = "공지 관련 API")
 
 public class NoticeController {
+	private final String NOTICE_SORT_BY = "createdAt";
 	private final NoticeService noticeService;
 
 	@PostMapping("/groups/{groupId}/notices")
@@ -61,7 +63,7 @@ public class NoticeController {
 		@PathVariable Long groupId,
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "20") int size) {
-		Pageable pageable = PageRequest.of(page, size);
+		Pageable pageable = PageRequest.of(page, size, Sort.by(NOTICE_SORT_BY).descending());
 		Page<GetNoticeResponse> response = noticeService.getNoticeList(user, groupId, pageable);
 		return ResponseEntity.ok().body(response);
 	}

--- a/src/test/java/com/gamzabat/algohub/service/NoticeServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/NoticeServiceTest.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 
 import com.gamzabat.algohub.common.DateFormatUtil;
@@ -224,7 +225,7 @@ public class NoticeServiceTest {
 	@DisplayName("공지 목록 조회 성공")
 	void getNoticeListSuccess_1() {
 		//given
-		Pageable pageable = PageRequest.of(0, 20);
+		Pageable pageable = PageRequest.of(0, 20, Sort.by("createdAt").descending());
 
 		List<Notice> noticeList = new ArrayList<>(10);
 		for (int i = 0; i < 10; i++)
@@ -234,7 +235,7 @@ public class NoticeServiceTest {
 					.content("content" + i)
 					.title("title" + i)
 					.category("category" + i)
-					.createdAt(LocalDateTime.now())
+					.createdAt(LocalDateTime.now().minusDays(i))
 					.studyGroup(studyGroup)
 					.build());
 		for (int i = 10; i < 20; i++)
@@ -244,7 +245,7 @@ public class NoticeServiceTest {
 					.content("content" + i)
 					.title("title" + i)
 					.category("category" + i)
-					.createdAt(LocalDateTime.now())
+					.createdAt(LocalDateTime.now().minusDays(i))
 					.studyGroup(studyGroup)
 					.build());
 		when(studyGroupRepository.findById(30L)).thenReturn(Optional.ofNullable(studyGroup));


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://github.com/GAMZA-BAT/algohub-server/issues/202

## 🚀 Description
<!-- 작업 내용 -->
- 공지 목록 조회 API에서 최신순으로 정렬합니다.
- `Pageable`에서 정렬할 기준을 넣어주면 JPA 사용해 정렬할 수 있다고 합니다.
- `Notice`의 `createdAt` 필드를 기준으로 내림차순 정렬하면 최신순으로 조회 가능합니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->