### PR TITLE
fix : 타 회원 정보 조회 시 오류 수정 및 인증 정보 제거

### DIFF
--- a/src/main/java/com/gamzabat/algohub/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/gamzabat/algohub/exception/CustomExceptionHandler.java
@@ -9,6 +9,7 @@ import com.gamzabat.algohub.feature.comment.exception.CommentValidationException
 import com.gamzabat.algohub.feature.group.ranking.exception.CannotFoundRankingException;
 import com.gamzabat.algohub.feature.group.studygroup.exception.CannotFoundGroupException;
 import com.gamzabat.algohub.feature.group.studygroup.exception.CannotFoundProblemException;
+import com.gamzabat.algohub.feature.group.studygroup.exception.CannotFoundUserException;
 import com.gamzabat.algohub.feature.group.studygroup.exception.GroupMemberValidationException;
 import com.gamzabat.algohub.feature.group.studygroup.exception.InvalidRoleException;
 import com.gamzabat.algohub.feature.notice.exception.NoticeValidationException;
@@ -140,5 +141,11 @@ public class CustomExceptionHandler {
 	@ExceptionHandler(NotificationValidationException.class)
 	protected ResponseEntity<ErrorResponse> handler(NotificationValidationException e) {
 		return ResponseEntity.status(e.getCode()).body(new ErrorResponse(e.getCode(), e.getError(), null));
+	}
+
+	@ExceptionHandler(CannotFoundUserException.class)
+	protected ResponseEntity<ErrorResponse> handler(CannotFoundUserException e) {
+		return ResponseEntity.status(e.getCode())
+			.body(new ErrorResponse(e.getCode(), e.getError(), null));
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/controller/StudyGroupController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/controller/StudyGroupController.java
@@ -180,7 +180,7 @@ public class StudyGroupController {
 
 	@GetMapping(value = "/users/{userNickname}/groups")
 	@Operation(summary = "타 유저 그룹 목록 조회 API", description = "유저가 보이도록 설정해놓은 유저가 참여하고 있는 그룹 모두 조회")
-	public ResponseEntity<GetStudyGroupListsResponse> getOtherUserStudyGroupList(@AuthedUser User user,
+	public ResponseEntity<GetStudyGroupListsResponse> getOtherUserStudyGroupList(
 		@PathVariable String userNickname) {
 		GetStudyGroupListsResponse response = studyGroupService.getOtherStudyGroupList(userNickname);
 		return ResponseEntity.ok().body(response);

--- a/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
@@ -131,9 +131,9 @@ public class UserController {
 
 	@GetMapping(value = "/{userNickname}")
 	@Operation(summary = "타 회원 정보 조회 API")
-	public ResponseEntity<UserInfoResponse> getOtherUserInfo(@AuthedUser User user,
-		@RequestParam @PathVariable String userNickname) {
-		UserInfoResponse userInfo = userService.otherUserInfo(user, userNickname);
+	public ResponseEntity<UserInfoResponse> getOtherUserInfo(
+		@PathVariable String userNickname) {
+		UserInfoResponse userInfo = userService.otherUserInfo(userNickname);
 		return ResponseEntity.ok().body(userInfo);
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/repository/UserRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/repository/UserRepository.java
@@ -21,5 +21,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 	boolean existsByNickname(String nickname);
 
-	Optional<User> findByNickname(String userNickname);
+	Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -191,7 +191,7 @@ public class UserService {
 	}
 
 	@Transactional(readOnly = true)
-	public UserInfoResponse otherUserInfo(User user, String userNickname) {
+	public UserInfoResponse otherUserInfo(String userNickname) {
 		User targetUser = userRepository.findByNickname(userNickname)
 			.orElseThrow(() -> new CannotFoundUserException(HttpStatus.NOT_FOUND.value(), "해당 유저는 존재하지 않습니다."));
 

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -401,7 +401,7 @@ class UserServiceTest {
 			.build();
 		// when
 		when(userRepository.findByNickname(user2.getNickname())).thenReturn(Optional.of(user2));
-		UserInfoResponse response = userService.otherUserInfo(user, user2.getNickname());
+		UserInfoResponse response = userService.otherUserInfo(user2.getNickname());
 		// then
 		assertThat(response.getEmail()).isEqualTo("otherUserEmail");
 		assertThat(response.getNickname()).isEqualTo("otherUserNickname");
@@ -417,7 +417,7 @@ class UserServiceTest {
 		when(userRepository.findByNickname("nickname2")).thenReturn(Optional.empty());
 
 		// then
-		assertThatThrownBy(() -> userService.otherUserInfo(user, "nickname2"))
+		assertThatThrownBy(() -> userService.otherUserInfo("nickname2"))
 			.isInstanceOf(CannotFoundUserException.class)
 			.satisfies(exception -> {
 				CannotFoundUserException ex = (CannotFoundUserException)exception;


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://github.com/GAMZA-BAT/algohub-server/issues/211

## 🚀 Description
<!-- 작업 내용 -->
- 타 회원 정보 조회할 때 `@RequestParam` 빼야 하는데 안뺐었네요 제거했습니다.
- `CannotFoundUserException` 클래스가 예외 핸들러에 없어서 추가했습니다.
- 로그인 없이도 접근 가능하다길래 `@AuthedUser` 모두 제거했습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->