### PR TITLE
refactor : 이미지 저장 시 이름 형태 수정

### DIFF
--- a/src/main/java/com/gamzabat/algohub/enums/ImageType.java
+++ b/src/main/java/com/gamzabat/algohub/enums/ImageType.java
@@ -1,0 +1,16 @@
+package com.gamzabat.algohub.enums;
+
+public enum ImageType {
+	USER("user"),
+	GROUP("group");
+
+	private final String value;
+
+	ImageType(String value) {
+		this.value = value;
+	}
+
+	public String getValue() {
+		return value;
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/gamzabat/algohub/exception/CustomExceptionHandler.java
@@ -12,6 +12,7 @@ import com.gamzabat.algohub.feature.group.studygroup.exception.CannotFoundProble
 import com.gamzabat.algohub.feature.group.studygroup.exception.CannotFoundUserException;
 import com.gamzabat.algohub.feature.group.studygroup.exception.GroupMemberValidationException;
 import com.gamzabat.algohub.feature.group.studygroup.exception.InvalidRoleException;
+import com.gamzabat.algohub.feature.image.exception.AwsS3Exception;
 import com.gamzabat.algohub.feature.notice.exception.NoticeValidationException;
 import com.gamzabat.algohub.feature.notification.exception.CannotFoundNotificationException;
 import com.gamzabat.algohub.feature.notification.exception.CannotFoundNotificationSettingException;
@@ -147,5 +148,11 @@ public class CustomExceptionHandler {
 	protected ResponseEntity<ErrorResponse> handler(CannotFoundUserException e) {
 		return ResponseEntity.status(e.getCode())
 			.body(new ErrorResponse(e.getCode(), e.getError(), null));
+	}
+
+	@ExceptionHandler(AwsS3Exception.class)
+	protected ResponseEntity<ErrorResponse> handler(AwsS3Exception e) {
+		return ResponseEntity.internalServerError()
+			.body(new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getError(), null));
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/domain/StudyGroup.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/domain/StudyGroup.java
@@ -3,6 +3,7 @@ package com.gamzabat.algohub.feature.group.studygroup.domain;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -19,6 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @SQLRestriction("deleted_at IS NULL")
 @SQLDelete(sql = "UPDATE study_group SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@DynamicUpdate
 public class StudyGroup {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
@@ -2,6 +2,8 @@ package com.gamzabat.algohub.feature.group.studygroup.service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -16,6 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.aventrix.jnanoid.jnanoid.NanoIdUtils;
 import com.gamzabat.algohub.constants.BOJResultConstants;
+import com.gamzabat.algohub.enums.ImageType;
 import com.gamzabat.algohub.exception.StudyGroupValidationException;
 import com.gamzabat.algohub.exception.UserValidationException;
 import com.gamzabat.algohub.feature.group.ranking.domain.Ranking;
@@ -87,18 +90,15 @@ public class StudyGroupService {
 
 	@Transactional
 	public GroupCodeResponse createGroup(User user, CreateGroupRequest request, MultipartFile profileImage) {
-		String imageUrl = imageService.saveImage(profileImage);
 		String inviteCode = NanoIdUtils.randomNanoId();
 
-		StudyGroup group = StudyGroup.builder()
+		StudyGroup group = groupRepository.save(StudyGroup.builder()
 			.name(request.name())
 			.startDate(request.startDate())
 			.endDate(request.endDate())
 			.introduction(request.introduction())
-			.groupImage(imageUrl)
 			.groupCode(inviteCode)
-			.build();
-		groupRepository.save(group);
+			.build());
 
 		GroupMember member = GroupMember.builder()
 			.studyGroup(group)
@@ -118,6 +118,8 @@ public class StudyGroupService {
 		notificationSettingRepository.save(
 			NotificationSetting.builder().member(member).build()
 		);
+
+		saveGroupImage(profileImage, group);
 		log.info("success to save study group");
 		return new GroupCodeResponse(inviteCode);
 	}
@@ -305,12 +307,7 @@ public class StudyGroupService {
 		if (!RoleOfGroupMember.isOwner(groupMember))
 			throw new StudyGroupValidationException(HttpStatus.FORBIDDEN.value(), "그룹 정보 수정에 대한 권한이 없습니다.");
 
-		if (groupImage != null) {
-			if (group.getGroupImage() != null)
-				imageService.deleteImage(group.getGroupImage());
-			String imageUrl = imageService.saveImage(groupImage);
-			group.editGroupImage(imageUrl);
-		}
+		editGroupImage(groupImage, group);
 		group.editGroupInfo(
 			request.name(),
 			request.startDate(),
@@ -318,6 +315,42 @@ public class StudyGroupService {
 			request.introduction()
 		);
 		log.info("success to edit group info");
+	}
+
+	private void editGroupImage(MultipartFile inputImage, StudyGroup group) {
+		if (inputImage == null || inputImage.isEmpty()) {
+			handleNullInputImage(group);
+			return;
+		}
+
+		if (group.getGroupImage() != null) {
+			if (isEqualToGroupImage(group, inputImage)) {
+				return;
+			}
+			imageService.deleteImage(group.getGroupImage());
+		}
+
+		saveGroupImage(inputImage, group);
+		log.info("success to edit group image");
+	}
+
+	private void saveGroupImage(MultipartFile inputImage, StudyGroup group) {
+		String imageUrl = imageService.saveImage(ImageType.GROUP, String.valueOf(group.getId()), inputImage);
+		group.editGroupImage(imageUrl);
+	}
+
+	private void handleNullInputImage(StudyGroup group) {
+		if (group.getGroupImage() != null) {
+			imageService.deleteImage(group.getGroupImage());
+			group.editGroupImage(null);
+		}
+	}
+
+	private boolean isEqualToGroupImage(StudyGroup group, MultipartFile inputImage) {
+		String inputImageUrl = imageService.getImageName(ImageType.GROUP, String.valueOf(group.getId()), inputImage);
+		String groupImageUrl = URLDecoder.decode(imageService.parseImageName(group.getGroupImage()),
+			StandardCharsets.UTF_8);
+		return inputImageUrl.equals(groupImageUrl);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/gamzabat/algohub/feature/image/exception/AwsS3Exception.java
+++ b/src/main/java/com/gamzabat/algohub/feature/image/exception/AwsS3Exception.java
@@ -1,0 +1,12 @@
+package com.gamzabat.algohub.feature.image.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AwsS3Exception extends RuntimeException {
+	private final String error;
+
+	public AwsS3Exception(String error) {
+		this.error = error;
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/feature/image/service/ImageService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/image/service/ImageService.java
@@ -73,7 +73,7 @@ public class ImageService {
 		return null;
 	}
 
-	public String createProfileImagePrefix(Long userId, String userEmail) {
-		return userId + DELIMITER + userEmail;
+	public String createImagePrefix(Long id, String identifier) {
+		return id + DELIMITER + identifier;
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/image/service/ImageService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/image/service/ImageService.java
@@ -5,7 +5,6 @@ import java.io.InputStream;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
-import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -13,6 +12,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.gamzabat.algohub.enums.ImageType;
+import com.gamzabat.algohub.feature.image.exception.AwsS3Exception;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -24,29 +25,55 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class ImageService {
 	private final AmazonS3 amazonS3;
+	private final String DELIMITER = "_";
 	@Value("${aws_bucket_name}")
 	private String bucket;
+	@Value("${aws_bucket_url}")
+	private String bucketUrl;
 
-	public String saveImage(MultipartFile multipartFile) {
+	public String saveImage(ImageType type, String prefix, MultipartFile multipartFile) {
 		if (multipartFile == null)
 			return null;
-		String originalFilename = multipartFile.getOriginalFilename();
-		String filename = UUID.randomUUID().toString().concat(Objects.requireNonNull(originalFilename));
+
+		String filename = getImageName(type, prefix, multipartFile);
 		ObjectMetadata metadata = new ObjectMetadata();
 		metadata.setContentType(multipartFile.getContentType());
 		metadata.setContentLength(multipartFile.getSize());
 		try (InputStream inputStream = multipartFile.getInputStream()) {
 			amazonS3.putObject(bucket, filename, inputStream, metadata);
 		} catch (IOException e) {
-			throw new RuntimeException(e);
+			throw new AwsS3Exception("AWS S3 이미지 저장 중 에러가 발생했습니다.");
 		}
-		return amazonS3.getUrl(bucket, filename).toString();
+
+		String imageUrl = amazonS3.getUrl(bucket, filename).toString();
+		log.info("success to save image. image url : {}", imageUrl);
+		return imageUrl;
+	}
+
+	public String getImageName(ImageType type, String prefix, MultipartFile multipartFile) {
+		String originalFilename = multipartFile.getOriginalFilename();
+		return createImagePrefix(type, prefix).concat(DELIMITER)
+			.concat(Objects.requireNonNull(originalFilename));
+	}
+
+	private String createImagePrefix(ImageType imageType, String prefix) {
+		return imageType.getValue() + DELIMITER + prefix;
 	}
 
 	public void deleteImage(String imageUrl) {
-		String splitStr = ".com/";
-		String fileName = imageUrl.substring(imageUrl.lastIndexOf(splitStr) + splitStr.length());
+		String fileName = parseImageName(imageUrl);
 		String file = URLDecoder.decode(fileName, StandardCharsets.UTF_8);
 		amazonS3.deleteObject(bucket, file);
+		log.info("delete image from S3 bucket. image url : {}", imageUrl);
+	}
+
+	public String parseImageName(String imageUrl) {
+		if (imageUrl.startsWith(bucketUrl))
+			return imageUrl.substring(bucketUrl.length());
+		return null;
+	}
+
+	public String createProfileImagePrefix(Long userId, String userEmail) {
+		return userId + DELIMITER + userEmail;
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/domain/User.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/domain/User.java
@@ -2,6 +2,7 @@ package com.gamzabat.algohub.feature.user.domain;
 
 import java.time.LocalDateTime;
 
+import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -24,6 +25,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @SQLRestriction("deleted_at IS NULL")
 @SQLDelete(sql = "UPDATE user SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@DynamicUpdate
 public class User {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -2,7 +2,7 @@ package com.gamzabat.algohub.feature.user.service;
 
 import static com.gamzabat.algohub.constants.ApiConstants.*;
 
-import java.net.URLEncoder;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.regex.Pattern;
@@ -80,7 +80,7 @@ public class UserService {
 	}
 
 	private void saveProfileImage(MultipartFile profileImage, User user) {
-		String imagePrefix = imageService.createProfileImagePrefix(user.getId(), user.getEmail());
+		String imagePrefix = imageService.createImagePrefix(user.getId(), user.getEmail());
 		String imageUrl = imageService.saveImage(ImageType.USER, imagePrefix, profileImage);
 		user.editProfileImage(imageUrl);
 	}
@@ -147,10 +147,11 @@ public class UserService {
 	}
 
 	private boolean isEqualToProfileImage(User user, MultipartFile profileImage) {
-		String prefix = imageService.createProfileImagePrefix(user.getId(), user.getEmail());
-		String inputImageUrl = URLEncoder.encode(imageService.getImageName(ImageType.USER, prefix,
-			profileImage), StandardCharsets.UTF_8);
-		String userProfileImageUrl = imageService.parseImageName(user.getProfileImage());
+		String prefix = imageService.createImagePrefix(user.getId(), user.getEmail());
+		String inputImageUrl = imageService.getImageName(ImageType.USER, prefix,
+			profileImage);
+		String userProfileImageUrl = URLDecoder.decode(imageService.parseImageName(user.getProfileImage()),
+			StandardCharsets.UTF_8);
 		return inputImageUrl.equals(userProfileImageUrl);
 	}
 

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -2,6 +2,8 @@ package com.gamzabat.algohub.feature.user.service;
 
 import static com.gamzabat.algohub.constants.ApiConstants.*;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.regex.Pattern;
 
@@ -24,6 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.gamzabat.algohub.common.jwt.TokenProvider;
 import com.gamzabat.algohub.common.jwt.dto.JwtDTO;
 import com.gamzabat.algohub.common.redis.RedisService;
+import com.gamzabat.algohub.enums.ImageType;
 import com.gamzabat.algohub.enums.Role;
 import com.gamzabat.algohub.exception.JwtRequestException;
 import com.gamzabat.algohub.exception.UserValidationException;
@@ -62,17 +65,24 @@ public class UserService {
 	@Transactional
 	public void register(RegisterRequest request, MultipartFile profileImage) {
 		checkEmailDuplication(request.email());
-		String imageUrl = imageService.saveImage(profileImage);
 		String encodedPassword = passwordEncoder.encode(request.password());
-		userRepository.save(User.builder()
+
+		User user = userRepository.save(User.builder()
 			.email(request.email())
 			.password(encodedPassword)
 			.nickname(request.nickname())
 			.bjNickname(request.bjNickname())
-			.profileImage(imageUrl)
 			.role(Role.USER)
 			.build());
+
+		saveProfileImage(profileImage, user);
 		log.info("success to register");
+	}
+
+	private void saveProfileImage(MultipartFile profileImage, User user) {
+		String imagePrefix = imageService.createProfileImagePrefix(user.getId(), user.getEmail());
+		String imageUrl = imageService.saveImage(ImageType.USER, imagePrefix, profileImage);
+		user.editProfileImage(imageUrl);
 	}
 
 	@Transactional(readOnly = true)
@@ -97,24 +107,51 @@ public class UserService {
 
 	@Transactional
 	public void userUpdate(User user, UpdateUserRequest updateUserRequest, MultipartFile profileImage) {
-		if (profileImage != null && !profileImage.isEmpty()) {
-			if (user.getProfileImage() != null && !user.getProfileImage().isEmpty()) {
-				imageService.deleteImage(user.getProfileImage());
-			}
-			String imageUrl = imageService.saveImage(profileImage);
-			user.editProfileImage(imageUrl);
-		}
-		if (updateUserRequest.getNickname() != null && !updateUserRequest.getNickname().isEmpty()) {
+		editUserProfileImage(user, profileImage);
+
+		if (!updateUserRequest.getNickname().isEmpty()) {
 			user.editNickname(updateUserRequest.getNickname());
 		}
-		if (updateUserRequest.getBjNickname() != null && !updateUserRequest.getBjNickname().isEmpty()) {
+		if (!updateUserRequest.getBjNickname().isEmpty()) {
 			user.editBjNickname(updateUserRequest.getBjNickname());
 		}
-		if (updateUserRequest.getDescription() != null && !updateUserRequest.getDescription().isEmpty()) {
+		if (!updateUserRequest.getDescription().isEmpty()) {
 			user.editDescription(updateUserRequest.getDescription());
 		}
 
 		userRepository.save(user);
+		log.info("success to update user");
+	}
+
+	private void editUserProfileImage(User user, MultipartFile inputImage) {
+		if (inputImage == null || inputImage.isEmpty()) {
+			handleNullInputImage(user);
+			return;
+		}
+
+		if (user.getProfileImage() != null) {
+			if (isEqualToProfileImage(user, inputImage))
+				return;
+			imageService.deleteImage(user.getProfileImage());
+		}
+
+		saveProfileImage(inputImage, user);
+		log.info("success to edit user profile image. profile image : {}", user.getProfileImage());
+	}
+
+	private void handleNullInputImage(User user) {
+		if (user.getProfileImage() != null) {
+			imageService.deleteImage(user.getProfileImage());
+			user.editProfileImage(null);
+		}
+	}
+
+	private boolean isEqualToProfileImage(User user, MultipartFile profileImage) {
+		String prefix = imageService.createProfileImagePrefix(user.getId(), user.getEmail());
+		String inputImageUrl = URLEncoder.encode(imageService.getImageName(ImageType.USER, prefix,
+			profileImage), StandardCharsets.UTF_8);
+		String userProfileImageUrl = imageService.parseImageName(user.getProfileImage());
+		return inputImageUrl.equals(userProfileImageUrl);
 	}
 
 	@Transactional

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -3,6 +3,7 @@ package com.gamzabat.algohub.feature.user.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,10 +33,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.gamzabat.algohub.common.jwt.TokenProvider;
 import com.gamzabat.algohub.common.jwt.dto.JwtDTO;
 import com.gamzabat.algohub.common.redis.RedisService;
+import com.gamzabat.algohub.enums.ImageType;
 import com.gamzabat.algohub.enums.Role;
 import com.gamzabat.algohub.exception.JwtRequestException;
 import com.gamzabat.algohub.exception.UserValidationException;
@@ -82,12 +85,12 @@ class UserServiceTest {
 	private final String password = "password";
 	private final String nickname = "nickname";
 	private final String encoded = "encoded";
-	private final String imageUrl = "imageUrl";
+	private final String imageUrl = "1_test@email.com_image.jpg";
 	private final String bjNickname = "bjNickname";
 	private User user;
 
 	@BeforeEach
-	void setUp() {
+	void setUp() throws NoSuchFieldException, IllegalAccessException {
 		user = User.builder()
 			.email(email)
 			.password(encoded)
@@ -96,15 +99,23 @@ class UserServiceTest {
 			.profileImage(imageUrl)
 			.role(Role.USER)
 			.build();
+
+		Field userId = User.class.getDeclaredField("id");
+		userId.setAccessible(true);
+		userId.set(user, 1L);
 	}
 
 	@Test
 	@DisplayName("회원가입 성공")
 	void register() {
 		// given
+		String prefix = "1_test@email.com";
 		RegisterRequest request = new RegisterRequest(email, password, nickname, bjNickname);
 		MockMultipartFile profileImage = new MockMultipartFile("image", "image.jpg", "image/jpeg", "test".getBytes());
-		when(imageService.saveImage(profileImage)).thenReturn(imageUrl);
+		when(userRepository.save(any(User.class))).thenReturn(user);
+		when(imageService.createProfileImagePrefix(user.getId(), user.getEmail())).thenReturn(prefix);
+		when(imageService.saveImage(ImageType.USER, prefix,
+			profileImage)).thenReturn(imageUrl);
 		when(passwordEncoder.encode(password)).thenReturn(encoded);
 		// when
 		userService.register(request, profileImage);
@@ -112,11 +123,10 @@ class UserServiceTest {
 		verify(userRepository, times(1)).save(userCaptor.capture());
 		User user = userCaptor.getValue();
 		assertThat(user.getEmail()).isEqualTo(email);
-		assertThat(user.getNickname()).isEqualTo(nickname);
-		assertThat(user.getProfileImage()).isEqualTo(imageUrl);
 		assertThat(user.getRole()).isEqualTo(Role.USER);
-		assertThat(user.getBjNickname()).isEqualTo(bjNickname);
 		assertThat(user.getDescription()).isEqualTo("");
+		verify(imageService, times(1)).createProfileImagePrefix(anyLong(), anyString());
+		verify(imageService, times(1)).saveImage(ImageType.USER, prefix, profileImage);
 	}
 
 	@Test
@@ -196,13 +206,17 @@ class UserServiceTest {
 	}
 
 	@Test
-	@DisplayName("회원 정보 수정 성공")
+	@DisplayName("회원 정보 수정 성공 : 프로필 이미지 존재")
 	void userUpdate() {
 		// given
+		String prefix = "1_test@email.com";
 		UpdateUserRequest request = new UpdateUserRequest("newNickname", "newBjNickname", "I am Batman");
 		MockMultipartFile newProfileImage = new MockMultipartFile("newImage", "image.jpg", "image/jpeg",
 			"test".getBytes());
-		when(imageService.saveImage(newProfileImage)).thenReturn("newProfileImageUrl");
+		when(imageService.getImageName(any(ImageType.class), anyString(), any(MultipartFile.class))).thenReturn(
+			"originalProfileImage");
+		when(imageService.createProfileImagePrefix(user.getId(), user.getEmail())).thenReturn(prefix);
+		when(imageService.saveImage(ImageType.USER, prefix, newProfileImage)).thenReturn("newProfileImageUrl");
 		doNothing().when(imageService).deleteImage(imageUrl);
 		// when
 		userService.userUpdate(user, request, newProfileImage);
@@ -211,6 +225,22 @@ class UserServiceTest {
 		assertThat(user.getBjNickname()).isEqualTo("newBjNickname");
 		assertThat(user.getProfileImage()).isEqualTo("newProfileImageUrl");
 		assertThat(user.getDescription()).isEqualTo("I am Batman");
+	}
+
+	@Test
+	@DisplayName("회원 정보 수정 : 프로필 이미지를 null로 설정")
+	void userUpdateWithoutImage() {
+		// given
+		UpdateUserRequest request = new UpdateUserRequest("newNickname", "newBjNickname", "I am Batman");
+		doNothing().when(imageService).deleteImage(imageUrl);
+		// when
+		userService.userUpdate(user, request, null);
+		// then
+		assertThat(user.getNickname()).isEqualTo("newNickname");
+		assertThat(user.getBjNickname()).isEqualTo("newBjNickname");
+		assertThat(user.getDescription()).isEqualTo("I am Batman");
+		assertThat(user.getProfileImage()).isNull();
+		verify(imageService, times(1)).deleteImage(imageUrl);
 	}
 
 	@Test
@@ -314,7 +344,6 @@ class UserServiceTest {
 		when(passwordEncoder.matches(request.currentPassword(), user.getPassword())).thenReturn(true);
 		//when
 		userService.editPassword(user, request);
-
 		//then
 		verify(userRepository).save(user);
 	}

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -113,7 +113,7 @@ class UserServiceTest {
 		RegisterRequest request = new RegisterRequest(email, password, nickname, bjNickname);
 		MockMultipartFile profileImage = new MockMultipartFile("image", "image.jpg", "image/jpeg", "test".getBytes());
 		when(userRepository.save(any(User.class))).thenReturn(user);
-		when(imageService.createProfileImagePrefix(user.getId(), user.getEmail())).thenReturn(prefix);
+		when(imageService.createImagePrefix(user.getId(), user.getEmail())).thenReturn(prefix);
 		when(imageService.saveImage(ImageType.USER, prefix,
 			profileImage)).thenReturn(imageUrl);
 		when(passwordEncoder.encode(password)).thenReturn(encoded);
@@ -125,7 +125,7 @@ class UserServiceTest {
 		assertThat(user.getEmail()).isEqualTo(email);
 		assertThat(user.getRole()).isEqualTo(Role.USER);
 		assertThat(user.getDescription()).isEqualTo("");
-		verify(imageService, times(1)).createProfileImagePrefix(anyLong(), anyString());
+		verify(imageService, times(1)).createImagePrefix(anyLong(), anyString());
 		verify(imageService, times(1)).saveImage(ImageType.USER, prefix, profileImage);
 	}
 
@@ -215,7 +215,7 @@ class UserServiceTest {
 			"test".getBytes());
 		when(imageService.getImageName(any(ImageType.class), anyString(), any(MultipartFile.class))).thenReturn(
 			"originalProfileImage");
-		when(imageService.createProfileImagePrefix(user.getId(), user.getEmail())).thenReturn(prefix);
+		when(imageService.createImagePrefix(user.getId(), user.getEmail())).thenReturn(prefix);
 		when(imageService.saveImage(ImageType.USER, prefix, newProfileImage)).thenReturn("newProfileImageUrl");
 		doNothing().when(imageService).deleteImage(imageUrl);
 		// when

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -33,7 +33,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.gamzabat.algohub.common.jwt.TokenProvider;
 import com.gamzabat.algohub.common.jwt.dto.JwtDTO;
@@ -203,28 +202,6 @@ class UserServiceTest {
 		assertThat(response.getProfileImage()).isEqualTo(imageUrl);
 		assertThat(response.getBjNickname()).isEqualTo(bjNickname);
 		assertThat(response.getDescription()).isEqualTo("");
-	}
-
-	@Test
-	@DisplayName("회원 정보 수정 성공 : 프로필 이미지 존재")
-	void userUpdate() {
-		// given
-		String prefix = "1_test@email.com";
-		UpdateUserRequest request = new UpdateUserRequest("newNickname", "newBjNickname", "I am Batman");
-		MockMultipartFile newProfileImage = new MockMultipartFile("newImage", "image.jpg", "image/jpeg",
-			"test".getBytes());
-		when(imageService.getImageName(any(ImageType.class), anyString(), any(MultipartFile.class))).thenReturn(
-			"originalProfileImage");
-		when(imageService.createImagePrefix(user.getId(), user.getEmail())).thenReturn(prefix);
-		when(imageService.saveImage(ImageType.USER, prefix, newProfileImage)).thenReturn("newProfileImageUrl");
-		doNothing().when(imageService).deleteImage(imageUrl);
-		// when
-		userService.userUpdate(user, request, newProfileImage);
-		// then
-		assertThat(user.getNickname()).isEqualTo("newNickname");
-		assertThat(user.getBjNickname()).isEqualTo("newBjNickname");
-		assertThat(user.getProfileImage()).isEqualTo("newProfileImageUrl");
-		assertThat(user.getDescription()).isEqualTo("I am Batman");
 	}
 
 	@Test

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -105,7 +105,7 @@ class UserServiceTest {
 	}
 
 	@Test
-	@DisplayName("회원가입 성공")
+	@DisplayName("회원가입 성공 : 이미지 포함")
 	void register() {
 		// given
 		String prefix = "1_test@email.com";

--- a/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockMultipartFile;
 
 import com.gamzabat.algohub.common.DateFormatUtil;
+import com.gamzabat.algohub.enums.ImageType;
 import com.gamzabat.algohub.enums.Role;
 import com.gamzabat.algohub.exception.StudyGroupValidationException;
 import com.gamzabat.algohub.exception.UserValidationException;
@@ -208,7 +209,8 @@ class StudyGroupServiceTest {
 		MockMultipartFile profileImage = new MockMultipartFile("image", new byte[] {1, 2, 3});
 		CreateGroupRequest request = new CreateGroupRequest(name, LocalDate.now(), LocalDate.now().plusDays(5),
 			"introduction");
-		when(imageService.saveImage(profileImage)).thenReturn(imageUrl);
+		when(imageService.saveImage(ImageType.GROUP, String.valueOf(groupId), profileImage)).thenReturn(imageUrl);
+		when(studyGroupRepository.save(any(StudyGroup.class))).thenReturn(group);
 		// when
 		studyGroupService.createGroup(user, request, profileImage);
 		// then
@@ -218,7 +220,6 @@ class StudyGroupServiceTest {
 		assertThat(result.getStartDate()).isEqualTo(LocalDate.now());
 		assertThat(result.getEndDate()).isEqualTo(LocalDate.now().plusDays(5));
 		assertThat(result.getIntroduction()).isEqualTo("introduction");
-		assertThat(result.getGroupImage()).isEqualTo(imageUrl);
 		verify(groupMemberRepository, times(1)).save(any(GroupMember.class));
 		verify(notificationSettingRepository, times(1)).save(any(NotificationSetting.class));
 	}
@@ -454,14 +455,13 @@ class StudyGroupServiceTest {
 		EditGroupRequest request = new EditGroupRequest("editName", LocalDate.now().plusDays(10),
 			LocalDate.now().plusDays(10), "editIntroduction");
 		MockMultipartFile editImage = new MockMultipartFile("editImage", new byte[] {1, 2, 3});
-		when(imageService.saveImage(editImage)).thenReturn("editImage");
 		when(studyGroupRepository.findById(anyLong())).thenReturn(Optional.ofNullable(group));
 		when(groupMemberRepository.findByUserAndStudyGroup(user, group)).thenReturn(Optional.ofNullable(groupMember1));
 		// when
-		studyGroupService.editGroup(user, 10L, request, editImage);
+		studyGroupService.editGroup(user, 10L, request, null);
 		// then
 		assertThat(group.getName()).isEqualTo("editName");
-		assertThat(group.getGroupImage()).isEqualTo("editImage");
+		assertThat(group.getGroupImage()).isNull();
 		assertThat(group.getStartDate()).isEqualTo(LocalDate.now().plusDays(10));
 		assertThat(group.getEndDate()).isEqualTo(LocalDate.now().plusDays(10));
 		assertThat(group.getIntroduction()).isEqualTo("editIntroduction");


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://github.com/GAMZA-BAT/algohub-server/issues/224

## 🚀 Description
- user 프로필 사진과 group 사진 저장 시, 각각의 고유 정보를 포함하도록 수정했습니다.
- 원래 있던 이미지와 동일하면 불필요한 s3 이미지 추가/삭제를 하지 않기 위해 이미지명으로 비교합니다.
- UTF-8 encoding으로 해보니 s3에서 진행하는 encoding과 형식이 조금 달라, 기존에 갖고 있던 이미지를 decoding해서 비교하는 방식으로 진행했습니다.
- 사진 요청에 null로 입력이 들어오면 프로필 사진은 null로 설정됩니다.
- 테스트 환경의 s3와 실제 서버 s3가 분리되지 않아서 userId만으로는 구분이 안될 것 같아 user Email 정보를 포함한 상태입니다.
- 하지만 이는 테스트로 인해 로직이 수정되기에 좋지 못한 설계입니다.
- 이건 추후에 이미지 이름에 test prefix를 추가해서 테스트용 사진과 실제 사진을 구분할 수 있도록 수정해야하지 않을까 싶습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->