### PR TITLE
feat : refresh token 도입

### DIFF
--- a/src/main/java/com/gamzabat/algohub/common/jwt/TokenProvider.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/TokenProvider.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -223,5 +224,10 @@ public class TokenProvider {
 
 	private boolean logout(String token) {
 		return redisService.getValues(token).equals("logout");
+	}
+
+	@Scheduled(cron = "0 0 0 * * *")
+	private void clearExpiredRefreshTokens() {
+		refreshTokenRepository.deleteExpiredRefreshTokens();
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/common/jwt/TokenProvider.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/TokenProvider.java
@@ -4,6 +4,7 @@ import java.security.Key;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -17,9 +18,13 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 import com.amazonaws.util.StringUtils;
+import com.gamzabat.algohub.common.jwt.domain.RefreshToken;
 import com.gamzabat.algohub.common.jwt.dto.JwtDTO;
+import com.gamzabat.algohub.common.jwt.repository.RefreshTokenRepository;
 import com.gamzabat.algohub.common.redis.RedisService;
 import com.gamzabat.algohub.exception.JwtRequestException;
+import com.gamzabat.algohub.feature.group.studygroup.exception.CannotFoundUserException;
+import com.gamzabat.algohub.feature.user.repository.UserRepository;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -38,38 +43,75 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @Getter
 public class TokenProvider {
-	private final Key key;
+	private final Key accessTokenKey;
+	private final Key refreshTokenKey;
 	private final RedisService redisService;
+	private final RefreshTokenRepository refreshTokenRepository;
+	private final UserRepository userRepository;
 	@Value("${jwt_expiration_time}")
-	private long tokenExpiration;
+	private long accessTokenExpirationTime;
 	@Value("${refresh_token_expiration_time}")
 	private long refreshTokenExpirationTime;
 
-	public TokenProvider(@Value("${jwt_secret_key}") String secretKey, RedisService redisService) {
-		byte[] keyBytes = Decoders.BASE64URL.decode(secretKey);
-		this.key = Keys.hmacShaKeyFor(keyBytes);
+	public TokenProvider(@Value("${jwt_secret_key}") String accessTokenKey,
+		@Value("${jwt_refresh_secret_key}") String refreshTokenKey,
+		RedisService redisService, RefreshTokenRepository refreshTokenRepository,
+		UserRepository userRepository) {
+		byte[] accessKeyBytes = Decoders.BASE64URL.decode(accessTokenKey);
+		byte[] refreshKeyBytes = Decoders.BASE64URL.decode(refreshTokenKey);
+		this.accessTokenKey = Keys.hmacShaKeyFor(accessKeyBytes);
+		this.refreshTokenKey = Keys.hmacShaKeyFor(refreshKeyBytes);
 		this.redisService = redisService;
+		this.refreshTokenRepository = refreshTokenRepository;
+		this.userRepository = userRepository;
 	}
 
-	public JwtDTO generateToken(Authentication authentication) {
+	public JwtDTO generateTokens(Authentication authentication) {
+		String loginId = UUID.randomUUID().toString();
+		return JwtDTO.builder()
+			.grantType("Bearer")
+			.accessToken(generateAccessToken(loginId, authentication))
+			.refreshToken(generateRefreshToken(loginId, authentication))
+			.build();
+	}
+
+	public String generateAccessToken(String loginId, Authentication authentication) {
 		String authorities = authentication.getAuthorities().stream()
 			.map(GrantedAuthority::getAuthority)
 			.collect(Collectors.joining(","));
 
 		long now = (new Date().getTime());
 
-		Date tokenExpireDate = new Date(now + this.tokenExpiration);
-		String token = Jwts.builder()
+		Date tokenExpireDate = new Date(now + this.accessTokenExpirationTime);
+		return Jwts.builder()
 			.setSubject(authentication.getName())
 			.claim("auth", authorities)
+			.claim("loginId", loginId)
 			.setExpiration(tokenExpireDate)
-			.signWith(key, SignatureAlgorithm.HS256)
+			.signWith(accessTokenKey, SignatureAlgorithm.HS256)
+			.compact();
+	}
+
+	public String generateRefreshToken(String loginId, Authentication authentication) {
+		long now = (new Date().getTime());
+		Date expirationTime = new Date(now + this.refreshTokenExpirationTime);
+		String refreshToken = Jwts.builder()
+			.setSubject(authentication.getName())
+			.signWith(refreshTokenKey, SignatureAlgorithm.HS256)
 			.compact();
 
-		return JwtDTO.builder()
-			.grantType("Bearer")
-			.token(token)
-			.build();
+		com.gamzabat.algohub.feature.user.domain.User user = userRepository.findByEmail(authentication.getName())
+			.orElseThrow(() -> new CannotFoundUserException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 유저입니다."));
+
+		refreshTokenRepository.save(
+			RefreshToken.builder()
+				.refreshToken(refreshToken)
+				.user(user)
+				.loginId(loginId)
+				.expirationDateTime(expirationTime)
+				.build()
+		);
+		return refreshToken;
 	}
 
 	public Authentication getAuthentication(String token) {
@@ -90,7 +132,7 @@ public class TokenProvider {
 			if (logout(token))
 				throw new JwtRequestException(HttpStatus.FORBIDDEN.value(), "FORBIDDEN", "로그아웃 된 토큰입니다.");
 			Jwts.parserBuilder()
-				.setSigningKey(key)
+				.setSigningKey(accessTokenKey)
 				.build().parseClaimsJws(token);
 			return true;
 		} catch (SecurityException | MalformedJwtException e) {
@@ -106,7 +148,7 @@ public class TokenProvider {
 
 	private Claims parseClaims(String token) {
 		return Jwts.parserBuilder()
-			.setSigningKey(key)
+			.setSigningKey(accessTokenKey)
 			.build()
 			.parseClaimsJws(token)
 			.getBody();
@@ -114,7 +156,7 @@ public class TokenProvider {
 
 	public String getUserEmail(String authToken) {
 		String token = authToken.replace("Bearer", "").trim();
-		Jws<Claims> claimsJws = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+		Jws<Claims> claimsJws = Jwts.parserBuilder().setSigningKey(accessTokenKey).build().parseClaimsJws(token);
 		return claimsJws.getBody().getSubject();
 	}
 

--- a/src/main/java/com/gamzabat/algohub/common/jwt/TokenProvider.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/TokenProvider.java
@@ -42,6 +42,8 @@ public class TokenProvider {
 	private final RedisService redisService;
 	@Value("${jwt_expiration_time}")
 	private long tokenExpiration;
+	@Value("${refresh_token_expiration_time}")
+	private long refreshTokenExpirationTime;
 
 	public TokenProvider(@Value("${jwt_secret_key}") String secretKey, RedisService redisService) {
 		byte[] keyBytes = Decoders.BASE64URL.decode(secretKey);
@@ -86,13 +88,13 @@ public class TokenProvider {
 	public boolean validateToken(String token) {
 		try {
 			if (logout(token))
-				throw new JwtRequestException(HttpStatus.UNAUTHORIZED.value(), "UNAUTHORIZED", "로그아웃 되었습니다.");
+				throw new JwtRequestException(HttpStatus.FORBIDDEN.value(), "FORBIDDEN", "로그아웃 된 토큰입니다.");
 			Jwts.parserBuilder()
 				.setSigningKey(key)
 				.build().parseClaimsJws(token);
 			return true;
 		} catch (SecurityException | MalformedJwtException e) {
-			throw new JwtRequestException(HttpStatus.UNAUTHORIZED.value(), "UNAUTHORIZED", "검증되지 않은 토큰입니다.");
+			throw new JwtRequestException(HttpStatus.BAD_REQUEST.value(), "BAD_REQUEST", "검증되지 않은 토큰입니다.");
 		} catch (ExpiredJwtException e) {
 			throw new JwtRequestException(HttpStatus.UNAUTHORIZED.value(), "UNAUTHORIZED", "만료된 토큰 입니다.");
 		} catch (UnsupportedJwtException e) {

--- a/src/main/java/com/gamzabat/algohub/common/jwt/TokenProvider.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/TokenProvider.java
@@ -16,19 +16,23 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.amazonaws.util.StringUtils;
 import com.gamzabat.algohub.common.jwt.domain.RefreshToken;
 import com.gamzabat.algohub.common.jwt.dto.JwtDTO;
+import com.gamzabat.algohub.common.jwt.exception.ExpiredTokenException;
+import com.gamzabat.algohub.common.jwt.exception.TokenException;
 import com.gamzabat.algohub.common.jwt.repository.RefreshTokenRepository;
 import com.gamzabat.algohub.common.redis.RedisService;
 import com.gamzabat.algohub.exception.JwtRequestException;
 import com.gamzabat.algohub.feature.group.studygroup.exception.CannotFoundUserException;
+import com.gamzabat.algohub.feature.user.dto.TokenResponse;
 import com.gamzabat.algohub.feature.user.repository.UserRepository;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -81,24 +85,14 @@ public class TokenProvider {
 			.collect(Collectors.joining(","));
 
 		long now = (new Date().getTime());
-
 		Date tokenExpireDate = new Date(now + this.accessTokenExpirationTime);
-		return Jwts.builder()
-			.setSubject(authentication.getName())
-			.claim("auth", authorities)
-			.claim("loginId", loginId)
-			.setExpiration(tokenExpireDate)
-			.signWith(accessTokenKey, SignatureAlgorithm.HS256)
-			.compact();
+		return createNewAccessToken(authentication.getName(), authorities, loginId, tokenExpireDate);
 	}
 
 	public String generateRefreshToken(String loginId, Authentication authentication) {
 		long now = (new Date().getTime());
 		Date expirationTime = new Date(now + this.refreshTokenExpirationTime);
-		String refreshToken = Jwts.builder()
-			.setSubject(authentication.getName())
-			.signWith(refreshTokenKey, SignatureAlgorithm.HS256)
-			.compact();
+		String refreshToken = createNewRefreshToken(authentication.getName());
 
 		com.gamzabat.algohub.feature.user.domain.User user = userRepository.findByEmail(authentication.getName())
 			.orElseThrow(() -> new CannotFoundUserException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 유저입니다."));
@@ -155,9 +149,7 @@ public class TokenProvider {
 	}
 
 	public String getUserEmail(String authToken) {
-		String token = authToken.replace("Bearer", "").trim();
-		Jws<Claims> claimsJws = Jwts.parserBuilder().setSigningKey(accessTokenKey).build().parseClaimsJws(token);
-		return claimsJws.getBody().getSubject();
+		return getClaims(authToken).getSubject();
 	}
 
 	public String resolveToken(HttpServletRequest request) {
@@ -165,6 +157,68 @@ public class TokenProvider {
 		if (StringUtils.hasValue(token) && token.startsWith("Bearer"))
 			return token.substring(7);
 		return null;
+	}
+
+	private Claims getClaims(String expiredToken) {
+		String token = expiredToken.replace("Bearer", "").trim();
+		return parseClaims(token);
+	}
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW, noRollbackFor = ExpiredTokenException.class)
+	public TokenResponse reissueTokens(String expiredToken, String inputRefreshToken) {
+		Claims claims = getClaims(expiredToken);
+		String subject = claims.getSubject();
+		com.gamzabat.algohub.feature.user.domain.User user = userRepository.findByEmail(subject)
+			.orElseThrow(() -> new CannotFoundUserException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 유저입니다."));
+
+		String loginId = (String)claims.get("loginId");
+		RefreshToken refreshToken = refreshTokenRepository.findByLoginIdAndUser(loginId, user)
+			.orElseThrow(() -> new TokenException(HttpStatus.UNAUTHORIZED.value(), "유효하지 않은 리프레시 토큰입니다. 재로그인이 필요합니다."));
+
+		validateTokenPair(inputRefreshToken, loginId, refreshToken);
+
+		long now = (new Date().getTime());
+		Date accessTokenExpireDate = new Date(now + this.accessTokenExpirationTime);
+		String newAccessToken = createNewAccessToken(
+			subject, claims.get("auth").toString(), loginId, accessTokenExpireDate
+		);
+
+		Date refreshTokenExpireDate = new Date(now + this.refreshTokenExpirationTime);
+		String newRefreshToken = createNewRefreshToken(subject);
+		refreshToken.updateRefreshToken(newRefreshToken, refreshTokenExpireDate);
+
+		return new TokenResponse(newAccessToken, newRefreshToken);
+	}
+
+	private void validateTokenPair(String inputRefreshToken, String loginId, RefreshToken refreshToken) {
+		if (!loginId.equals(refreshToken.getLoginId()) || !inputRefreshToken.equals(refreshToken.getRefreshToken())) {
+			throw new TokenException(HttpStatus.FORBIDDEN.value(), "토큰의 로그인 정보가 일치하지 않습니다.");
+		}
+
+		if (refreshToken.getExpirationDateTime().before(new Date())) {
+			refreshTokenRepository.delete(refreshToken);
+			log.info("success to delete refresh token");
+			throw new ExpiredTokenException(HttpStatus.UNAUTHORIZED.value(), "리프레시 토큰의 유효기간이 만료되었습니다. 재로그인이 필요합니다.");
+		}
+	}
+
+	private String createNewAccessToken(String subject, String authorities, String loginId, Date expirationDateTime) {
+		return Jwts.builder()
+			.setSubject(subject)
+			.setIssuedAt(new Date())
+			.claim("auth", authorities)
+			.claim("loginId", loginId)
+			.setExpiration(expirationDateTime)
+			.signWith(accessTokenKey, SignatureAlgorithm.HS256)
+			.compact();
+	}
+
+	private String createNewRefreshToken(String subject) {
+		return Jwts.builder()
+			.setSubject(subject)
+			.setIssuedAt(new Date())
+			.signWith(refreshTokenKey, SignatureAlgorithm.HS256)
+			.compact();
 	}
 
 	private boolean logout(String token) {

--- a/src/main/java/com/gamzabat/algohub/common/jwt/domain/RefreshToken.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/domain/RefreshToken.java
@@ -2,6 +2,8 @@ package com.gamzabat.algohub.common.jwt.domain;
 
 import java.util.Date;
 
+import org.hibernate.annotations.DynamicUpdate;
+
 import com.gamzabat.algohub.feature.user.domain.User;
 
 import jakarta.persistence.Entity;
@@ -18,12 +20,13 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
+@DynamicUpdate
 public class RefreshToken {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id")
+	@JoinColumn(name = "user_id", unique = false)
 	private User user;
 	private String refreshToken;
 	private String loginId;
@@ -34,6 +37,11 @@ public class RefreshToken {
 		this.user = user;
 		this.refreshToken = refreshToken;
 		this.loginId = loginId;
+		this.expirationDateTime = expirationDateTime;
+	}
+
+	public void updateRefreshToken(String refreshToken, Date expirationDateTime) {
+		this.refreshToken = refreshToken;
 		this.expirationDateTime = expirationDateTime;
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/common/jwt/domain/RefreshToken.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/domain/RefreshToken.java
@@ -26,7 +26,7 @@ public class RefreshToken {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id", unique = false)
+	@JoinColumn(name = "user_id")
 	private User user;
 	private String refreshToken;
 	private String loginId;

--- a/src/main/java/com/gamzabat/algohub/common/jwt/domain/RefreshToken.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/domain/RefreshToken.java
@@ -1,0 +1,39 @@
+package com.gamzabat.algohub.common.jwt.domain;
+
+import java.util.Date;
+
+import com.gamzabat.algohub.feature.user.domain.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class RefreshToken {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+	private String refreshToken;
+	private String loginId;
+	private Date expirationDateTime;
+
+	@Builder
+	public RefreshToken(User user, String refreshToken, Date expirationDateTime, String loginId) {
+		this.user = user;
+		this.refreshToken = refreshToken;
+		this.loginId = loginId;
+		this.expirationDateTime = expirationDateTime;
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/common/jwt/dto/JwtDTO.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/dto/JwtDTO.java
@@ -9,5 +9,6 @@ import lombok.Data;
 @AllArgsConstructor
 public class JwtDTO {
 	private String grantType;
-	private String token;
+	private String accessToken;
+	private String refreshToken;
 }

--- a/src/main/java/com/gamzabat/algohub/common/jwt/dto/ReissueTokenRequest.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/dto/ReissueTokenRequest.java
@@ -1,0 +1,4 @@
+package com.gamzabat.algohub.common.jwt.dto;
+
+public record ReissueTokenRequest(String expiredAccessToken, String refreshToken) {
+}

--- a/src/main/java/com/gamzabat/algohub/common/jwt/exception/ExpiredTokenException.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/exception/ExpiredTokenException.java
@@ -1,0 +1,11 @@
+package com.gamzabat.algohub.common.jwt.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ExpiredTokenException extends TokenException {
+	public ExpiredTokenException(int code, String error) {
+		super(code, error);
+	}
+}
+

--- a/src/main/java/com/gamzabat/algohub/common/jwt/exception/TokenException.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/exception/TokenException.java
@@ -1,0 +1,14 @@
+package com.gamzabat.algohub.common.jwt.exception;
+
+import lombok.Getter;
+
+@Getter
+public class TokenException extends RuntimeException {
+	private final int code;
+	private final String error;
+
+	public TokenException(int code, String error) {
+		this.code = code;
+		this.error = error;
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/common/jwt/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/repository/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package com.gamzabat.algohub.common.jwt.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.gamzabat.algohub.common.jwt.domain.RefreshToken;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+}

--- a/src/main/java/com/gamzabat/algohub/common/jwt/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/repository/RefreshTokenRepository.java
@@ -1,8 +1,12 @@
 package com.gamzabat.algohub.common.jwt.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.gamzabat.algohub.common.jwt.domain.RefreshToken;
+import com.gamzabat.algohub.feature.user.domain.User;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+	Optional<RefreshToken> findByLoginIdAndUser(String loginId, User user);
 }

--- a/src/main/java/com/gamzabat/algohub/common/jwt/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/repository/RefreshTokenRepository.java
@@ -3,10 +3,16 @@ package com.gamzabat.algohub.common.jwt.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import com.gamzabat.algohub.common.jwt.domain.RefreshToken;
 import com.gamzabat.algohub.feature.user.domain.User;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 	Optional<RefreshToken> findByLoginIdAndUser(String loginId, User user);
+
+	@Modifying
+	@Query("DELETE FROM RefreshToken rt WHERE rt.expirationDateTime < NOW()")
+	void deleteExpiredRefreshTokens();
 }

--- a/src/main/java/com/gamzabat/algohub/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/gamzabat/algohub/exception/CustomExceptionHandler.java
@@ -5,6 +5,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import com.gamzabat.algohub.common.jwt.exception.ExpiredTokenException;
+import com.gamzabat.algohub.common.jwt.exception.TokenException;
 import com.gamzabat.algohub.feature.comment.exception.CommentValidationException;
 import com.gamzabat.algohub.feature.group.ranking.exception.CannotFoundRankingException;
 import com.gamzabat.algohub.feature.group.studygroup.exception.CannotFoundGroupException;
@@ -145,6 +147,18 @@ public class CustomExceptionHandler {
 
 	@ExceptionHandler(CannotFoundUserException.class)
 	protected ResponseEntity<ErrorResponse> handler(CannotFoundUserException e) {
+		return ResponseEntity.status(e.getCode())
+			.body(new ErrorResponse(e.getCode(), e.getError(), null));
+	}
+
+	@ExceptionHandler(TokenException.class)
+	protected ResponseEntity<ErrorResponse> handler(TokenException e) {
+		return ResponseEntity.status(e.getCode())
+			.body(new ErrorResponse(e.getCode(), e.getError(), null));
+	}
+
+	@ExceptionHandler(ExpiredTokenException.class)
+	protected ResponseEntity<ErrorResponse> handler(ExpiredTokenException e) {
 		return ResponseEntity.status(e.getCode())
 			.body(new ErrorResponse(e.getCode(), e.getError(), null));
 	}

--- a/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.gamzabat.algohub.common.annotation.AuthedUser;
+import com.gamzabat.algohub.common.jwt.dto.ReissueTokenRequest;
 import com.gamzabat.algohub.exception.RequestException;
 import com.gamzabat.algohub.feature.user.domain.User;
 import com.gamzabat.algohub.feature.user.dto.CheckEmailRequest;
@@ -23,7 +24,7 @@ import com.gamzabat.algohub.feature.user.dto.DeleteUserRequest;
 import com.gamzabat.algohub.feature.user.dto.EditUserPasswordRequest;
 import com.gamzabat.algohub.feature.user.dto.RegisterRequest;
 import com.gamzabat.algohub.feature.user.dto.SignInRequest;
-import com.gamzabat.algohub.feature.user.dto.SignInResponse;
+import com.gamzabat.algohub.feature.user.dto.TokenResponse;
 import com.gamzabat.algohub.feature.user.dto.UpdateUserRequest;
 import com.gamzabat.algohub.feature.user.dto.UserInfoResponse;
 import com.gamzabat.algohub.feature.user.service.UserService;
@@ -53,10 +54,20 @@ public class UserController {
 
 	@PostMapping(value = "/auth/sign-in")
 	@Operation(summary = "로그인 API")
-	public ResponseEntity<SignInResponse> signIn(@Valid @RequestBody SignInRequest request, Errors errors) {
+	public ResponseEntity<TokenResponse> signIn(@Valid @RequestBody SignInRequest request, Errors errors) {
 		if (errors.hasErrors())
 			throw new RequestException("로그인 요청이 올바르지 않습니다.", errors);
-		SignInResponse response = userService.signIn(request);
+		TokenResponse response = userService.signIn(request);
+		return ResponseEntity.ok().body(response);
+	}
+
+	@PostMapping(value = "/auth/reissue-token")
+	@Operation(summary = "토큰 재발급 API")
+	public ResponseEntity<TokenResponse> reissueToken(@Valid @RequestBody ReissueTokenRequest request,
+		Errors errors) {
+		if (errors.hasErrors())
+			throw new RequestException("토큰 재발급 요청이 올바르지 않습니다.", errors);
+		TokenResponse response = userService.reissueToken(request);
 		return ResponseEntity.ok().body(response);
 	}
 

--- a/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
@@ -36,12 +36,12 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/users")
+@RequestMapping("/api")
 @Tag(name = "회원 API", description = "회원 관련된 API 명세서")
 public class UserController {
 	private final UserService userService;
 
-	@PostMapping(value = "/sign-up", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PostMapping(value = "/auth/sign-up", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Operation(summary = "회원 가입 API")
 	public ResponseEntity<Void> register(@Valid @RequestPart RegisterRequest request, Errors errors,
 		@RequestPart(required = false) MultipartFile profileImage) {
@@ -51,7 +51,7 @@ public class UserController {
 		return ResponseEntity.ok().build();
 	}
 
-	@PostMapping(value = "/sign-in")
+	@PostMapping(value = "/auth/sign-in")
 	@Operation(summary = "로그인 API")
 	public ResponseEntity<SignInResponse> signIn(@Valid @RequestBody SignInRequest request, Errors errors) {
 		if (errors.hasErrors())
@@ -60,14 +60,14 @@ public class UserController {
 		return ResponseEntity.ok().body(response);
 	}
 
-	@GetMapping(value = "/me")
+	@GetMapping(value = "/users/me")
 	@Operation(summary = "회원 정보 조회 API")
 	public ResponseEntity<UserInfoResponse> userInfo(@AuthedUser User user) {
 		UserInfoResponse userInfo = userService.userInfo(user);
 		return ResponseEntity.ok().body(userInfo);
 	}
 
-	@PatchMapping(value = "/me", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PatchMapping(value = "/users/me", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
 	@Operation(summary = "회원 정보 수정 API")
 	public ResponseEntity<Void> updateInfo(@AuthedUser User user, @RequestPart UpdateUserRequest request,
 		@RequestPart(required = false) MultipartFile profileImage) {
@@ -76,7 +76,7 @@ public class UserController {
 		return ResponseEntity.ok().build();
 	}
 
-	@DeleteMapping(value = "/me")
+	@DeleteMapping(value = "/users/me")
 	@Operation(summary = "회원 정보 삭제 API")
 	public ResponseEntity<Void> deleteUser(@AuthedUser User user, @Valid @RequestBody DeleteUserRequest request,
 		Errors errors) {
@@ -87,21 +87,21 @@ public class UserController {
 		return ResponseEntity.ok().build();
 	}
 
-	@DeleteMapping("/sign-out")
+	@DeleteMapping("/auth/sign-out")
 	@Operation(summary = "로그아웃 API")
 	public ResponseEntity<Void> logout(HttpServletRequest request) {
 		userService.logout(request);
 		return ResponseEntity.ok().build();
 	}
 
-	@GetMapping("/check-baekjoon-nickname")
+	@GetMapping("/users/check-baekjoon-nickname")
 	@Operation(summary = "백준 닉네임 유효성 검증 API", description = "회원가입 진행 시, 백준 닉네임이 유효한지 검증하는 API")
 	public ResponseEntity<Void> checkBjNickname(@RequestParam String bjNickname) {
 		userService.checkBjNickname(bjNickname);
 		return ResponseEntity.ok().build();
 	}
 
-	@PatchMapping("/me/password")
+	@PatchMapping("/users/me/password")
 	@Operation(summary = "비밀번호 변경 API")
 	public ResponseEntity<Void> editPassword(@AuthedUser User user,
 		@Valid @RequestBody EditUserPasswordRequest request, Errors errors) {
@@ -112,7 +112,7 @@ public class UserController {
 		return ResponseEntity.ok().build();
 	}
 
-	@PostMapping("/check-email")
+	@PostMapping("/users/check-email")
 	@Operation(summary = "이메일 중복 검사 API", description = "회원가입 진행 시, 이메일 형태 및 중복을 검사하는 API")
 	public ResponseEntity<Void> checkEmailDuplication(@Valid @RequestBody CheckEmailRequest request, Errors errors) {
 		if (errors.hasErrors())
@@ -122,14 +122,14 @@ public class UserController {
 		return ResponseEntity.ok().build();
 	}
 
-	@GetMapping("/check-nickname")
+	@GetMapping("/users/check-nickname")
 	@Operation(summary = "닉네임 중복 검사 API", description = "회원가입 진행 시, 닉네임 형식 및 중복을 검사하는 API")
 	public ResponseEntity<Void> checkNickname(@RequestParam String nickname) {
 		userService.checkNickname(nickname);
 		return ResponseEntity.ok().build();
 	}
 
-	@GetMapping(value = "/{userNickname}")
+	@GetMapping(value = "/users/{userNickname}")
 	@Operation(summary = "타 회원 정보 조회 API")
 	public ResponseEntity<UserInfoResponse> getOtherUserInfo(
 		@PathVariable String userNickname) {

--- a/src/main/java/com/gamzabat/algohub/feature/user/dto/SignInResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/dto/SignInResponse.java
@@ -1,5 +1,0 @@
-package com.gamzabat.algohub.feature.user.dto;
-
-public record SignInResponse(String accessToken,
-							 String refreshToken) {
-}

--- a/src/main/java/com/gamzabat/algohub/feature/user/dto/SignInResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/dto/SignInResponse.java
@@ -1,4 +1,5 @@
 package com.gamzabat.algohub.feature.user.dto;
 
-public record SignInResponse(String token) {
+public record SignInResponse(String accessToken,
+							 String refreshToken) {
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/dto/TokenResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/dto/TokenResponse.java
@@ -1,0 +1,5 @@
+package com.gamzabat.algohub.feature.user.dto;
+
+public record TokenResponse(String accessToken,
+							String refreshToken) {
+}

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -23,6 +23,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.gamzabat.algohub.common.jwt.TokenProvider;
 import com.gamzabat.algohub.common.jwt.dto.JwtDTO;
+import com.gamzabat.algohub.common.jwt.dto.ReissueTokenRequest;
 import com.gamzabat.algohub.common.redis.RedisService;
 import com.gamzabat.algohub.enums.Role;
 import com.gamzabat.algohub.exception.JwtRequestException;
@@ -34,7 +35,7 @@ import com.gamzabat.algohub.feature.user.dto.DeleteUserRequest;
 import com.gamzabat.algohub.feature.user.dto.EditUserPasswordRequest;
 import com.gamzabat.algohub.feature.user.dto.RegisterRequest;
 import com.gamzabat.algohub.feature.user.dto.SignInRequest;
-import com.gamzabat.algohub.feature.user.dto.SignInResponse;
+import com.gamzabat.algohub.feature.user.dto.TokenResponse;
 import com.gamzabat.algohub.feature.user.dto.UpdateUserRequest;
 import com.gamzabat.algohub.feature.user.dto.UserInfoResponse;
 import com.gamzabat.algohub.feature.user.exception.BOJServerErrorException;
@@ -76,7 +77,7 @@ public class UserService {
 	}
 
 	@Transactional
-	public SignInResponse signIn(SignInRequest request) {
+	public TokenResponse signIn(SignInRequest request) {
 		UsernamePasswordAuthenticationToken authenticationToken
 			= new UsernamePasswordAuthenticationToken(request.email(), request.password());
 		Authentication authenticate;
@@ -87,7 +88,7 @@ public class UserService {
 		}
 		JwtDTO result = tokenProvider.generateTokens(authenticate);
 		log.info("success to sign in");
-		return new SignInResponse(result.getAccessToken(), result.getRefreshToken());
+		return new TokenResponse(result.getAccessToken(), result.getRefreshToken());
 	}
 
 	@Transactional(readOnly = true)
@@ -204,5 +205,15 @@ public class UserService {
 	private boolean isInvalidNicknameForm(String nickname) {
 		String regex = "[^a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ]";
 		return nickname.length() < 3 || nickname.length() > 16 || Pattern.compile(regex).matcher(nickname).find();
+	}
+
+	@Transactional
+	public TokenResponse reissueToken(ReissueTokenRequest request) {
+		String expiredToken = request.expiredAccessToken();
+		String refreshToken = request.refreshToken();
+
+		TokenResponse response = tokenProvider.reissueTokens(expiredToken, refreshToken);
+		log.info("success to reissue tokens");
+		return response;
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -75,7 +75,7 @@ public class UserService {
 		log.info("success to register");
 	}
 
-	@Transactional(readOnly = true)
+	@Transactional
 	public SignInResponse signIn(SignInRequest request) {
 		UsernamePasswordAuthenticationToken authenticationToken
 			= new UsernamePasswordAuthenticationToken(request.email(), request.password());
@@ -85,8 +85,9 @@ public class UserService {
 		} catch (BadCredentialsException e) {
 			throw new UncorrectedPasswordException("비밀번호가 틀렸습니다.");
 		}
-		JwtDTO token = tokenProvider.generateToken(authenticate);
-		return new SignInResponse(token.getToken());
+		JwtDTO result = tokenProvider.generateTokens(authenticate);
+		log.info("success to sign in");
+		return new SignInResponse(result.getAccessToken(), result.getRefreshToken());
 	}
 
 	@Transactional(readOnly = true)
@@ -131,7 +132,7 @@ public class UserService {
 		if (accessToken == null)
 			throw new JwtRequestException(HttpStatus.BAD_REQUEST.value(), "BAD_REQUEST", "토큰이 비어있습니다.");
 
-		long tokenExpiration = tokenProvider.getTokenExpiration();
+		long tokenExpiration = tokenProvider.getAccessTokenExpirationTime();
 		redisService.setValues(accessToken, "logout", Duration.ofMillis(tokenExpiration));
 		log.info("success to logout");
 	}

--- a/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
@@ -39,7 +39,7 @@ import com.gamzabat.algohub.feature.user.dto.CheckEmailRequest;
 import com.gamzabat.algohub.feature.user.dto.DeleteUserRequest;
 import com.gamzabat.algohub.feature.user.dto.RegisterRequest;
 import com.gamzabat.algohub.feature.user.dto.SignInRequest;
-import com.gamzabat.algohub.feature.user.dto.SignInResponse;
+import com.gamzabat.algohub.feature.user.dto.TokenResponse;
 import com.gamzabat.algohub.feature.user.dto.UpdateUserRequest;
 import com.gamzabat.algohub.feature.user.dto.UserInfoResponse;
 import com.gamzabat.algohub.feature.user.exception.BOJServerErrorException;
@@ -182,7 +182,7 @@ class UserControllerTest {
 	void signIn() throws Exception {
 		// given
 		SignInRequest request = new SignInRequest("email", "password");
-		SignInResponse response = new SignInResponse("access-token", "refresh-token");
+		TokenResponse response = new TokenResponse("access-token", "refresh-token");
 		when(userService.signIn(any(SignInRequest.class))).thenReturn(response);
 		// when, then
 		mockMvc.perform(post("/api/auth/sign-in")

--- a/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
@@ -97,7 +97,7 @@ class UserControllerTest {
 
 		doNothing().when(userService).register(any(RegisterRequest.class), any(MultipartFile.class));
 		// when, then
-		mockMvc.perform(multipart("/api/users/sign-up")
+		mockMvc.perform(multipart("/api/auth/sign-up")
 				.file(requestPart)
 				.file(profileImage)
 				.contentType(MediaType.MULTIPART_FORM_DATA))
@@ -117,7 +117,7 @@ class UserControllerTest {
 
 		doNothing().when(userService).register(any(RegisterRequest.class), any());
 		// when, then
-		mockMvc.perform(multipart("/api/users/sign-up")
+		mockMvc.perform(multipart("/api/auth/sign-up")
 				.file(requestPart)
 				.contentType(MediaType.MULTIPART_FORM_DATA))
 			.andExpect(status().isOk());
@@ -143,7 +143,7 @@ class UserControllerTest {
 		MockMultipartFile profileImage = new MockMultipartFile("profileImage", "profile.jpg", "image/jpeg",
 			"image".getBytes());
 		// when, then
-		mockMvc.perform(multipart("/api/users/sign-up")
+		mockMvc.perform(multipart("/api/auth/sign-up")
 				.file(requestPart)
 				.file(profileImage)
 				.contentType(MediaType.MULTIPART_FORM_DATA))
@@ -166,7 +166,7 @@ class UserControllerTest {
 		doThrow(new UserValidationException("이미 사용 중인 이메일 입니다.")).when(userService)
 			.register(any(RegisterRequest.class), any(MultipartFile.class));
 		// when, then
-		mockMvc.perform(multipart("/api/users/sign-up")
+		mockMvc.perform(multipart("/api/auth/sign-up")
 				.file(requestPart)
 				.file(profileImage)
 				.contentType(MediaType.MULTIPART_FORM_DATA))
@@ -185,7 +185,7 @@ class UserControllerTest {
 		SignInResponse response = new SignInResponse("token");
 		when(userService.signIn(any(SignInRequest.class))).thenReturn(response);
 		// when, then
-		mockMvc.perform(post("/api/users/sign-in")
+		mockMvc.perform(post("/api/auth/sign-in")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isOk())
@@ -204,7 +204,7 @@ class UserControllerTest {
 		// given
 		SignInRequest request = new SignInRequest(email, password);
 		// when, then
-		mockMvc.perform(post("/api/users/sign-in")
+		mockMvc.perform(post("/api/auth/sign-in")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isBadRequest())
@@ -220,7 +220,7 @@ class UserControllerTest {
 		SignInRequest request = new SignInRequest("invalidEmail", "password");
 		doThrow(new UserValidationException("존재하지 않는 회원 입니다.")).when(userService).signIn(any(SignInRequest.class));
 		// when, then
-		mockMvc.perform(post("/api/users/sign-in")
+		mockMvc.perform(post("/api/auth/sign-in")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isBadRequest())
@@ -236,7 +236,7 @@ class UserControllerTest {
 		SignInRequest request = new SignInRequest("email", "invalidPassword");
 		doThrow(new UncorrectedPasswordException("비밀번호가 틀렸습니다.")).when(userService).signIn(any(SignInRequest.class));
 		// when, then
-		mockMvc.perform(post("/api/users/sign-in")
+		mockMvc.perform(post("/api/auth/sign-in")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isBadRequest())

--- a/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
@@ -182,14 +182,15 @@ class UserControllerTest {
 	void signIn() throws Exception {
 		// given
 		SignInRequest request = new SignInRequest("email", "password");
-		SignInResponse response = new SignInResponse("token");
+		SignInResponse response = new SignInResponse("access-token", "refresh-token");
 		when(userService.signIn(any(SignInRequest.class))).thenReturn(response);
 		// when, then
 		mockMvc.perform(post("/api/auth/sign-in")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.token").value("token"));
+			.andExpect(jsonPath("$.accessToken").value("access-token"))
+			.andExpect(jsonPath("$.refreshToken").value("refresh-token"));
 
 		verify(userService, times(1)).signIn(request);
 	}

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -46,7 +46,7 @@ import com.gamzabat.algohub.feature.user.dto.DeleteUserRequest;
 import com.gamzabat.algohub.feature.user.dto.EditUserPasswordRequest;
 import com.gamzabat.algohub.feature.user.dto.RegisterRequest;
 import com.gamzabat.algohub.feature.user.dto.SignInRequest;
-import com.gamzabat.algohub.feature.user.dto.SignInResponse;
+import com.gamzabat.algohub.feature.user.dto.TokenResponse;
 import com.gamzabat.algohub.feature.user.dto.UpdateUserRequest;
 import com.gamzabat.algohub.feature.user.dto.UserInfoResponse;
 import com.gamzabat.algohub.feature.user.exception.BOJServerErrorException;
@@ -147,7 +147,7 @@ class UserServiceTest {
 			authentication);
 		when(tokenProvider.generateTokens(authentication)).thenReturn(jwtDTO);
 		// when
-		SignInResponse response = userService.signIn(request);
+		TokenResponse response = userService.signIn(request);
 		// then
 		assertThat(response.accessToken()).isEqualTo(accessToken);
 		assertThat(response.refreshToken()).isEqualTo(refreshToken);

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -137,17 +137,20 @@ class UserServiceTest {
 	void signIn() {
 		// given
 		SignInRequest request = new SignInRequest(email, password);
+		String accessToken = "access-token";
+		String refreshToken = "refresh-token";
 		Authentication authentication = mock(Authentication.class);
-		JwtDTO jwtDTO = new JwtDTO("access-token", "mocked-token-string");
+		JwtDTO jwtDTO = new JwtDTO("Baerer", accessToken, refreshToken);
 		AuthenticationManager authenticationManager = mock(AuthenticationManager.class);
 		when(authManager.getObject()).thenReturn(authenticationManager);
 		when(authManager.getObject().authenticate(any(UsernamePasswordAuthenticationToken.class))).thenReturn(
 			authentication);
-		when(tokenProvider.generateToken(authentication)).thenReturn(jwtDTO);
+		when(tokenProvider.generateTokens(authentication)).thenReturn(jwtDTO);
 		// when
 		SignInResponse response = userService.signIn(request);
 		// then
-		assertThat(response.token()).isEqualTo("mocked-token-string");
+		assertThat(response.accessToken()).isEqualTo(accessToken);
+		assertThat(response.refreshToken()).isEqualTo(refreshToken);
 	}
 
 	@Test
@@ -244,7 +247,7 @@ class UserServiceTest {
 		HttpServletRequest request = mock(HttpServletRequest.class);
 		String token = "mocked-token-string";
 		when(tokenProvider.resolveToken(request)).thenReturn(token);
-		when(tokenProvider.getTokenExpiration()).thenReturn(6000L);
+		when(tokenProvider.getAccessTokenExpirationTime()).thenReturn(6000L);
 		// when
 		userService.logout(request);
 		// then


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://github.com/GAMZA-BAT/algohub-server/issues/230

## 🚀 Description
<!-- 작업 내용 -->
- refresh token을 도입했습니다.
- 일반적인 구현은 하나의 refresh token으로 여러 번 access token 발급이 가능합니다.
- 여기서 더 보안을 챙기고 싶으면 `RTR (Refresh Token Rotation)` 기법을 사용할 수 있습니다. 
- RTR 기법이란 간단히 말해 하나의 refresh token은 하나의 access token만 발급할 수 있는 원리입니다.
- 보안을 얻지만 jwt의 stateless라는 장점을 잃어버리는 구현인지라 어느정도 trade off가 발생하는 기법입니다.
- 트랜잭션 전파에 대해서도 다시 공부해서 구현한지라 어렵고 너무 오래걸렸네요..
- `@Transactional` 어노테이션에 `noRollbackFor` 속성을 사용하면 특정 예외 클래스가 발생했을 때, 해당 지점까지의 수행을 commit 합니다. (전체 rollback X)
- 이번 구현에서는 토큰 재발급 시 만료된 refresh token이 감지됐을 때, 해당 refresh token을 즉각 무효화하기 위해 repository에서 삭제해야했습니다.
- 따라서 `ExpiredTokenException`이 발생했을 경우는 토큰 제거가 꼭 commit 되어야 하므로 `noRollbackFor = ExpiredTokenException.class`를 추가했습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->