### PR TITLE
feat : 그룹 역할 수정 시 OWNER로 수정할 경우 스터디장 위임 로직 추가

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/domain/GroupMember.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/domain/GroupMember.java
@@ -2,6 +2,8 @@ package com.gamzabat.algohub.feature.group.studygroup.domain;
 
 import java.time.LocalDate;
 
+import org.hibernate.annotations.DynamicUpdate;
+
 import com.gamzabat.algohub.feature.group.studygroup.etc.RoleOfGroupMember;
 import com.gamzabat.algohub.feature.user.domain.User;
 
@@ -22,6 +24,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
+@DynamicUpdate
 public class GroupMember {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
@@ -509,6 +509,10 @@ public class StudyGroupService {
 				() -> new GroupMemberValidationException(HttpStatus.BAD_REQUEST.value(), "해당 스터디 그룹에 참여하지 않은 회원입니다."));
 
 		member.updateRole(RoleOfGroupMember.fromValue(request.role()));
+
+		if (RoleOfGroupMember.isOwner(member)) {
+			owner.updateRole(RoleOfGroupMember.PARTICIPANT);
+		}
 		log.info("success to update group member role");
 	}
 

--- a/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
@@ -604,7 +604,7 @@ class StudyGroupServiceTest {
 
 	@Test
 	@DisplayName("스터디 그룹 멤버 역할 수정 성공")
-	void updateGroupMemberRole() {
+	void updateGroupMemberRole_1() {
 		// given
 		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(2L, "ADMIN");
 		when(groupMemberRepository.findByUserAndStudyGroup(user, group)).thenReturn(Optional.ofNullable(groupMember1));
@@ -617,6 +617,24 @@ class StudyGroupServiceTest {
 		assertThat(groupMember2.getUser()).isEqualTo(user2);
 		assertThat(groupMember2.getStudyGroup()).isEqualTo(group);
 		assertThat(groupMember2.getRole()).isEqualTo(RoleOfGroupMember.ADMIN);
+	}
+
+	@Test
+	@DisplayName("스터디 그룹 멤버 역할 수정 성공 : OWNER로 수정")
+	void updateGroupMemberRole_2() {
+		// given
+		UpdateGroupMemberRoleRequest request = new UpdateGroupMemberRoleRequest(2L, "OWNER");
+		when(groupMemberRepository.findByUserAndStudyGroup(user, group)).thenReturn(Optional.ofNullable(groupMember1));
+		when(groupMemberRepository.findByUserAndStudyGroup(user2, group)).thenReturn(Optional.ofNullable(groupMember2));
+		when(studyGroupRepository.findById(groupId)).thenReturn(Optional.ofNullable(group));
+		when(userRepository.findById(anyLong())).thenReturn(Optional.ofNullable(user2));
+		// when
+		studyGroupService.updateGroupMemberRole(user, groupId, request);
+		// then
+		assertThat(groupMember2.getUser()).isEqualTo(user2);
+		assertThat(groupMember2.getStudyGroup()).isEqualTo(group);
+		assertThat(groupMember2.getRole()).isEqualTo(RoleOfGroupMember.OWNER);
+		assertThat(groupMember1.getRole()).isEqualTo(RoleOfGroupMember.PARTICIPANT);
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://github.com/GAMZA-BAT/algohub-server/issues/233

## 🚀 Description
<!-- 작업 내용 -->
- 멤버 역할을 OWNER로 수정하면 본인의 역할은 PARTICIPANT로 수정되는 로직을 추가했습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->