### PR TITLE
feat : 그룹 설정 목록 API 추가

### DIFF
--- a/src/main/java/com/gamzabat/algohub/enums/GroupStatus.java
+++ b/src/main/java/com/gamzabat/algohub/enums/GroupStatus.java
@@ -1,0 +1,28 @@
+package com.gamzabat.algohub.enums;
+
+import java.time.LocalDate;
+
+import com.gamzabat.algohub.feature.group.studygroup.domain.StudyGroup;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum GroupStatus {
+	QUEUED("Queued"),
+	IN_PROGRESS("InProgress"),
+	DONE("Done");
+
+	private final String value;
+
+	public static GroupStatus getStatus(StudyGroup group) {
+		LocalDate today = LocalDate.now();
+		if (group.getStartDate().isAfter(today))
+			return QUEUED;
+		if (group.getEndDate().isBefore(today))
+			return DONE;
+
+		return IN_PROGRESS;
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/controller/StudyGroupController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/controller/StudyGroupController.java
@@ -25,6 +25,7 @@ import com.gamzabat.algohub.feature.group.studygroup.dto.EditGroupRequest;
 import com.gamzabat.algohub.feature.group.studygroup.dto.EditGroupVisibilityRequest;
 import com.gamzabat.algohub.feature.group.studygroup.dto.GetGroupMemberResponse;
 import com.gamzabat.algohub.feature.group.studygroup.dto.GetGroupResponse;
+import com.gamzabat.algohub.feature.group.studygroup.dto.GetGroupSettingResponse;
 import com.gamzabat.algohub.feature.group.studygroup.dto.GetStudyGroupListsResponse;
 import com.gamzabat.algohub.feature.group.studygroup.dto.GetStudyGroupWithCodeResponse;
 import com.gamzabat.algohub.feature.group.studygroup.dto.GroupCodeResponse;
@@ -184,5 +185,12 @@ public class StudyGroupController {
 		@PathVariable String userNickname) {
 		GetStudyGroupListsResponse response = studyGroupService.getOtherStudyGroupList(userNickname);
 		return ResponseEntity.ok().body(response);
+	}
+
+	@GetMapping(value = "/groups/settings")
+	@Operation(summary = "그룹 설정 목록 조회 API", description = "설정 탭에서 그룹 목록을 조회하는 API")
+	public ResponseEntity<List<GetGroupSettingResponse>> getStudyGroupSettings(@AuthedUser User user) {
+		List<GetGroupSettingResponse> responses = studyGroupService.getStudyGroupSettings(user);
+		return ResponseEntity.ok().body(responses);
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/dto/GetGroupSettingResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/dto/GetGroupSettingResponse.java
@@ -1,0 +1,31 @@
+package com.gamzabat.algohub.feature.group.studygroup.dto;
+
+import com.gamzabat.algohub.common.DateFormatUtil;
+import com.gamzabat.algohub.enums.GroupStatus;
+import com.gamzabat.algohub.feature.group.studygroup.domain.GroupMember;
+import com.gamzabat.algohub.feature.group.studygroup.domain.StudyGroup;
+import com.gamzabat.algohub.feature.group.studygroup.etc.RoleOfGroupMember;
+
+public record GetGroupSettingResponse(Long id,
+									  String name,
+									  String startDate,
+									  String endDate,
+									  RoleOfGroupMember role,
+									  boolean isBookmarked,
+									  boolean isVisible,
+									  String status) {
+
+	public static GetGroupSettingResponse toDto(StudyGroup group, GroupMember member, boolean isBookmarked,
+		boolean isVisible) {
+		return new GetGroupSettingResponse(
+			group.getId(),
+			group.getName(),
+			DateFormatUtil.formatDate(group.getStartDate()),
+			DateFormatUtil.formatDate(group.getEndDate()),
+			member.getRole(),
+			isBookmarked,
+			isVisible,
+			GroupStatus.getStatus(group).getValue()
+		);
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/dto/GetStudyGroupResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/dto/GetStudyGroupResponse.java
@@ -1,6 +1,7 @@
 package com.gamzabat.algohub.feature.group.studygroup.dto;
 
 import com.gamzabat.algohub.common.DateFormatUtil;
+import com.gamzabat.algohub.enums.GroupStatus;
 import com.gamzabat.algohub.feature.group.studygroup.domain.GroupMember;
 import com.gamzabat.algohub.feature.group.studygroup.domain.StudyGroup;
 import com.gamzabat.algohub.feature.group.studygroup.etc.RoleOfGroupMember;
@@ -14,6 +15,7 @@ public record GetStudyGroupResponse(Long id,
 									String introduction,
 									String ownerNickname,
 									RoleOfGroupMember role,
+									String status,
 									boolean isBookmarked,
 									boolean isVisible) {
 	public static GetStudyGroupResponse toDTO(StudyGroup group, GroupMember member, boolean isBookmarked, User owner,
@@ -27,6 +29,7 @@ public record GetStudyGroupResponse(Long id,
 			group.getIntroduction(),
 			owner.getNickname(),
 			member.getRole(),
+			GroupStatus.getStatus(group).getValue(),
 			isBookmarked,
 			isVisible
 		);

--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
@@ -255,34 +255,49 @@ public class StudyGroupService {
 	@Transactional(readOnly = true)
 	public GetStudyGroupListsResponse getStudyGroupList(User user) {
 		List<StudyGroup> groups = groupRepository.findAllByUser(user);
-
-		List<GetStudyGroupResponse> bookmarked = bookmarkedStudyGroupRepository.findAllByUser(user).stream()
-			.map(bookmark -> getStudyGroupResponseDTO(user, bookmark.getStudyGroup()))
-			.toList();
-
 		LocalDate today = LocalDate.now();
 
-		List<GetStudyGroupResponse> done = groups.stream()
-			.filter(group -> group.getEndDate() != null && group.getEndDate().isBefore(today))
+		List<GetStudyGroupResponse> bookmarked = groups.stream()
+			.filter(group -> isBookmarked(user, group))
 			.map(group -> getStudyGroupResponseDTO(user, group))
+			.toList();
+
+		List<GetStudyGroupResponse> done = groups.stream()
+			.filter(group -> isDone(today, group))
+			.map(group -> getStudyGroupResponseDTO(user, group))
+			.filter(response -> !bookmarked.contains(response))
 			.toList();
 
 		List<GetStudyGroupResponse> inProgress = groups.stream()
 			.filter(
-				group -> !(group.getStartDate() == null || group.getStartDate().isAfter(today))
-					&& !(group.getEndDate() == null || group.getEndDate().isBefore(today)))
+				group -> isInProgress(today, group))
 			.map(group -> getStudyGroupResponseDTO(user, group))
+			.filter(response -> !bookmarked.contains(response))
 			.toList();
 
 		List<GetStudyGroupResponse> queued = groups.stream()
-			.filter(group -> group.getStartDate() != null && group.getStartDate().isAfter(today))
+			.filter(group -> isQueued(today, group))
 			.map(group -> getStudyGroupResponseDTO(user, group))
+			.filter(response -> !bookmarked.contains(response))
 			.toList();
 
 		GetStudyGroupListsResponse response = new GetStudyGroupListsResponse(bookmarked, done, inProgress, queued);
 
-		log.info("success to get study group list");
+		log.info("success to get my study group list");
 		return response;
+	}
+
+	private static boolean isDone(LocalDate today, StudyGroup group) {
+		return group.getEndDate() != null && group.getEndDate().isBefore(today);
+	}
+
+	private static boolean isInProgress(LocalDate today, StudyGroup group) {
+		return !(group.getStartDate() == null || group.getStartDate().isAfter(today))
+			&& !(group.getEndDate() == null || group.getEndDate().isBefore(today));
+	}
+
+	private static boolean isQueued(LocalDate today, StudyGroup group) {
+		return group.getStartDate() != null && group.getStartDate().isAfter(today);
 	}
 
 	private GetStudyGroupResponse getStudyGroupResponseDTO(User user, StudyGroup group) {
@@ -547,31 +562,30 @@ public class StudyGroupService {
 			.orElseThrow(() -> new CannotFoundUserException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 유저입니다."));
 		List<StudyGroup> groups = groupRepository.findAllByUser(targetUser);
 
-		List<GetStudyGroupResponse> bookmarked = bookmarkedStudyGroupRepository.findAllByUser(targetUser).stream()
-			.filter(group -> isVisible(group.getStudyGroup(), targetUser))
-			.map(bookmark -> getStudyGroupResponseDTO(targetUser, bookmark.getStudyGroup()))
-			.toList();
-
 		LocalDate today = LocalDate.now();
 
-		List<GetStudyGroupResponse> done = groups.stream()
-			.filter(group -> group.getEndDate() != null && group.getEndDate().isBefore(today) && isVisible(group,
-				targetUser))
+		List<GetStudyGroupResponse> bookmarked = groups.stream()
+			.filter(group -> isBookmarked(targetUser, group) && isVisible(group, targetUser))
 			.map(group -> getStudyGroupResponseDTO(targetUser, group))
+			.toList();
+
+		List<GetStudyGroupResponse> done = groups.stream()
+			.filter(group -> isDone(today, group) && isVisible(group, targetUser))
+			.map(group -> getStudyGroupResponseDTO(targetUser, group))
+			.filter(response -> !bookmarked.contains(response))
 			.toList();
 
 		List<GetStudyGroupResponse> inProgress = groups.stream()
 			.filter(
-				group -> !(group.getStartDate() == null || group.getStartDate().isAfter(today))
-					&& !(group.getEndDate() == null || group.getEndDate().isBefore(today)) && isVisible(group,
-					targetUser))
+				group -> isInProgress(today, group) && isVisible(group, targetUser))
 			.map(group -> getStudyGroupResponseDTO(targetUser, group))
+			.filter(response -> !bookmarked.contains(response))
 			.toList();
 
 		List<GetStudyGroupResponse> queued = groups.stream()
-			.filter(group -> group.getStartDate() != null && group.getStartDate().isAfter(today) && isVisible(group,
-				targetUser))
+			.filter(group -> isQueued(today, group) && isVisible(group, targetUser))
 			.map(group -> getStudyGroupResponseDTO(targetUser, group))
+			.filter(response -> !bookmarked.contains(response))
 			.toList();
 
 		GetStudyGroupListsResponse response = new GetStudyGroupListsResponse(bookmarked, done, inProgress, queued);

--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
@@ -33,6 +33,7 @@ import com.gamzabat.algohub.feature.group.studygroup.dto.EditGroupRequest;
 import com.gamzabat.algohub.feature.group.studygroup.dto.EditGroupVisibilityRequest;
 import com.gamzabat.algohub.feature.group.studygroup.dto.GetGroupMemberResponse;
 import com.gamzabat.algohub.feature.group.studygroup.dto.GetGroupResponse;
+import com.gamzabat.algohub.feature.group.studygroup.dto.GetGroupSettingResponse;
 import com.gamzabat.algohub.feature.group.studygroup.dto.GetStudyGroupListsResponse;
 import com.gamzabat.algohub.feature.group.studygroup.dto.GetStudyGroupResponse;
 import com.gamzabat.algohub.feature.group.studygroup.dto.GetStudyGroupWithCodeResponse;
@@ -595,5 +596,19 @@ public class StudyGroupService {
 			NotificationCategory.NEW_MEMBER_JOINED,
 			NotificationCategory.NEW_MEMBER_JOINED.getMessage(newMember.getUser().getNickname())
 		);
+	}
+
+	@Transactional(readOnly = true)
+	public List<GetGroupSettingResponse> getStudyGroupSettings(User user) {
+		List<StudyGroup> groups = groupRepository.findAllByUser(user);
+
+		List<GetGroupSettingResponse> response = groups.stream().map(group -> {
+			GroupMember member = groupMemberRepository.findByUserAndStudyGroup(user, group)
+				.orElseThrow(
+					() -> new GroupMemberValidationException(HttpStatus.FORBIDDEN.value(), "참여하지 않은 스터디 그룹입니다."));
+			return GetGroupSettingResponse.toDto(group, member, member.getIsVisible(), isBookmarked(user, group));
+		}).toList();
+		log.info("success to get my study groups settings");
+		return response;
 	}
 }

--- a/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/studygroup/controller/StudyGroupControllerTest.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gamzabat.algohub.common.DateFormatUtil;
 import com.gamzabat.algohub.common.jwt.TokenProvider;
 import com.gamzabat.algohub.config.SpringSecurityConfig;
+import com.gamzabat.algohub.enums.GroupStatus;
 import com.gamzabat.algohub.exception.StudyGroupValidationException;
 import com.gamzabat.algohub.exception.UserValidationException;
 import com.gamzabat.algohub.feature.group.studygroup.controller.StudyGroupController;
@@ -216,7 +217,7 @@ class StudyGroupControllerTest {
 			bookmarked.add(new GetStudyGroupResponse(
 				(long)i, "name" + i, "groupImage" + 1,
 				DateFormatUtil.formatDate(LocalDate.now()), DateFormatUtil.formatDate(LocalDate.now().plusDays(i)),
-				"introduction" + 1, "nickname", RoleOfGroupMember.OWNER, true, true
+				"introduction" + 1, "nickname", RoleOfGroupMember.OWNER, GroupStatus.DONE.getValue(), true, true
 			));
 		}
 
@@ -224,21 +225,22 @@ class StudyGroupControllerTest {
 			done.add(new GetStudyGroupResponse(
 				(long)i, "name" + i, "groupImage" + 1,
 				DateFormatUtil.formatDate(LocalDate.now()), DateFormatUtil.formatDate(LocalDate.now().plusDays(i)),
-				"introduction" + 1, "nickname", RoleOfGroupMember.ADMIN, true, true
+				"introduction" + 1, "nickname", RoleOfGroupMember.ADMIN, GroupStatus.DONE.getValue(), true, true
 			));
 		}
 		for (int i = 0; i < 10; i++) {
 			inProgress.add(new GetStudyGroupResponse(
 				(long)i, "name" + i, "groupImage" + 1,
 				DateFormatUtil.formatDate(LocalDate.now()), DateFormatUtil.formatDate(LocalDate.now().plusDays(i)),
-				"introduction" + 1, "nickname", RoleOfGroupMember.PARTICIPANT, true, true
+				"introduction" + 1, "nickname", RoleOfGroupMember.PARTICIPANT, GroupStatus.IN_PROGRESS.getValue(), true,
+				true
 			));
 		}
 		for (int i = 0; i < 10; i++) {
 			queued.add(new GetStudyGroupResponse(
 				(long)i, "name" + i, "groupImage" + 1,
 				DateFormatUtil.formatDate(LocalDate.now()), DateFormatUtil.formatDate(LocalDate.now().plusDays(i)),
-				"introduction" + 1, "nickname", RoleOfGroupMember.PARTICIPANT, true, true
+				"introduction" + 1, "nickname", RoleOfGroupMember.PARTICIPANT, GroupStatus.QUEUED.getValue(), true, true
 			));
 		}
 		GetStudyGroupListsResponse response = new GetStudyGroupListsResponse(bookmarked, done, inProgress, queued);

--- a/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
@@ -37,6 +37,7 @@ import com.gamzabat.algohub.feature.group.studygroup.dto.CreateGroupRequest;
 import com.gamzabat.algohub.feature.group.studygroup.dto.EditGroupRequest;
 import com.gamzabat.algohub.feature.group.studygroup.dto.EditGroupVisibilityRequest;
 import com.gamzabat.algohub.feature.group.studygroup.dto.GetGroupMemberResponse;
+import com.gamzabat.algohub.feature.group.studygroup.dto.GetGroupSettingResponse;
 import com.gamzabat.algohub.feature.group.studygroup.dto.GetStudyGroupListsResponse;
 import com.gamzabat.algohub.feature.group.studygroup.dto.GetStudyGroupResponse;
 import com.gamzabat.algohub.feature.group.studygroup.dto.UpdateBookmarkResponse;
@@ -98,8 +99,6 @@ class StudyGroupServiceTest {
 	private RankingRepository rankingRepository;
 	@Mock
 	private ObjectProvider<StudyGroupService> studyGroupServiceObjectProvider;
-	@InjectMocks
-	private StudyGroupService groupService = mock(StudyGroupService.class);
 	@Mock
 	private ImageService imageService;
 	private User user, owner, user2, user3;
@@ -870,6 +869,59 @@ class StudyGroupServiceTest {
 			assertThat(bookmarked.get(i).isBookmarked()).isTrue();
 			assertThat(bookmarked.get(i).role()).isEqualTo(RoleOfGroupMember.OWNER);
 		}
+	}
+
+	@Test
+	@DisplayName("그룹 설정 목록 조회 성공")
+	void getStudyGroupSettings() {
+		// given
+		StudyGroup queued = StudyGroup.builder()
+			.name("queued")
+			.startDate(LocalDate.now().plusDays(10))
+			.endDate(LocalDate.now().plusDays(30))
+			.build();
+		GroupMember queuedMember = GroupMember.builder()
+			.studyGroup(queued)
+			.user(user)
+			.role(RoleOfGroupMember.PARTICIPANT)
+			.build();
+		when(groupMemberRepository.findByUserAndStudyGroup(user, queued)).thenReturn(Optional.of(queuedMember));
+		when(bookmarkedStudyGroupRepository.existsByUserAndStudyGroup(user, queued)).thenReturn(false);
+		StudyGroup inProgress = StudyGroup.builder()
+			.name("inProgress")
+			.startDate(LocalDate.now().minusDays(10))
+			.endDate(LocalDate.now().plusDays(30))
+			.build();
+		GroupMember inProgressMember = GroupMember.builder()
+			.studyGroup(inProgress)
+			.user(user)
+			.role(RoleOfGroupMember.ADMIN)
+			.build();
+		when(groupMemberRepository.findByUserAndStudyGroup(user, inProgress)).thenReturn(Optional.of(inProgressMember));
+		when(bookmarkedStudyGroupRepository.existsByUserAndStudyGroup(user, queued)).thenReturn(true);
+		StudyGroup done = StudyGroup.builder()
+			.name("done")
+			.startDate(LocalDate.now().minusDays(30))
+			.endDate(LocalDate.now().minusDays(10))
+			.build();
+		GroupMember doneMember = GroupMember.builder()
+			.studyGroup(done)
+			.user(user)
+			.role(RoleOfGroupMember.OWNER)
+			.build();
+		when(groupMemberRepository.findByUserAndStudyGroup(user, done)).thenReturn(Optional.of(doneMember));
+		when(bookmarkedStudyGroupRepository.existsByUserAndStudyGroup(user, queued)).thenReturn(false);
+		when(studyGroupRepository.findAllByUser(user)).thenReturn(List.of(queued, inProgress, done));
+		// when
+		List<GetGroupSettingResponse> responses = studyGroupService.getStudyGroupSettings(user);
+		// then
+		assertThat(responses.size()).isEqualTo(3);
+		assertThat(responses.get(0).name()).isEqualTo("queued");
+		assertThat(responses.get(0).status()).isEqualTo("Queued");
+		assertThat(responses.get(1).name()).isEqualTo("inProgress");
+		assertThat(responses.get(1).status()).isEqualTo("InProgress");
+		assertThat(responses.get(2).name()).isEqualTo("done");
+		assertThat(responses.get(2).status()).isEqualTo("Done");
 	}
 
 }

--- a/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
@@ -390,24 +390,13 @@ class StudyGroupServiceTest {
 			when(groupMemberRepository.findByUserAndStudyGroup(user, group)).thenReturn(
 				Optional.ofNullable(groupMember1));
 		}
-		List<BookmarkedStudyGroup> bookmarks = new ArrayList<>(10);
-		for (int i = 0; i < 10; i++) {
-			bookmarks.add(BookmarkedStudyGroup.builder()
-				.studyGroup(groups.get(i))
-				.user(user)
-				.build());
-			when(bookmarkedStudyGroupRepository.existsByUserAndStudyGroup(user, groups.get(i))).thenReturn(true);
-		}
-		when(bookmarkedStudyGroupRepository.findAllByUser(user)).thenReturn(bookmarks);
 		when(studyGroupRepository.findAllByUser(user)).thenReturn(groups);
 		// when
 		GetStudyGroupListsResponse result = studyGroupService.getStudyGroupList(user);
 		// then
-		List<GetStudyGroupResponse> bookmarked = result.getBookmarked();
 		List<GetStudyGroupResponse> done = result.getDone();
 		List<GetStudyGroupResponse> inProgress = result.getInProgress();
 		List<GetStudyGroupResponse> queued = result.getQueued();
-		assertThat(bookmarked.size()).isEqualTo(10);
 		assertThat(done.size()).isEqualTo(10);
 		assertThat(inProgress.size()).isEqualTo(10);
 		assertThat(queued.size()).isEqualTo(10);
@@ -416,7 +405,7 @@ class StudyGroupServiceTest {
 			assertThat(done.get(i).ownerNickname()).isEqualTo("nickname1");
 			assertThat(done.get(i).startDate()).isEqualTo(DateFormatUtil.formatDate(LocalDate.now().minusDays(i + 30)));
 			assertThat(done.get(i).endDate()).isEqualTo(DateFormatUtil.formatDate(LocalDate.now().minusDays(30)));
-			assertThat(done.get(i).isBookmarked()).isTrue();
+			assertThat(done.get(i).isBookmarked()).isFalse();
 			assertThat(done.get(i).role()).isEqualTo(RoleOfGroupMember.OWNER);
 		}
 		for (int i = 0; i < 10; i++) {
@@ -435,15 +424,6 @@ class StudyGroupServiceTest {
 			assertThat(queued.get(i).endDate()).isEqualTo(DateFormatUtil.formatDate(LocalDate.now().plusDays(i + 30)));
 			assertThat(queued.get(i).isBookmarked()).isFalse();
 			assertThat(queued.get(i).role()).isEqualTo(RoleOfGroupMember.OWNER);
-		}
-		for (int i = 0; i < 10; i++) {
-			assertThat(bookmarked.get(i).name()).isEqualTo("name" + i);
-			assertThat(bookmarked.get(i).ownerNickname()).isEqualTo("nickname1");
-			assertThat(bookmarked.get(i).startDate()).isEqualTo(
-				DateFormatUtil.formatDate(LocalDate.now().minusDays(i + 30)));
-			assertThat(bookmarked.get(i).endDate()).isEqualTo(DateFormatUtil.formatDate(LocalDate.now().minusDays(30)));
-			assertThat(bookmarked.get(i).isBookmarked()).isTrue();
-			assertThat(bookmarked.get(i).role()).isEqualTo(RoleOfGroupMember.OWNER);
 		}
 	}
 
@@ -810,38 +790,22 @@ class StudyGroupServiceTest {
 				Optional.ofNullable(groupMember1));
 			when(groupMemberRepository.existsByUserAndStudyGroupAndIsVisible(user, group, true)).thenReturn(true);
 		}
-		List<BookmarkedStudyGroup> bookmarks = new ArrayList<>(10);
-		for (int i = 0; i < 10; i++) {
-			bookmarks.add(BookmarkedStudyGroup.builder()
-				.studyGroup(groups.get(i))
-				.user(user)
-				.build());
-			when(bookmarkedStudyGroupRepository.existsByUserAndStudyGroup(user, groups.get(i))).thenReturn(true);
-			when(groupMemberRepository.existsByUserAndStudyGroupAndIsVisible(user, groups.get(i), true)).thenReturn(
-				true);
-		}
-		when(bookmarkedStudyGroupRepository.findAllByUser(user)).thenReturn(bookmarks);
 		when(studyGroupRepository.findAllByUser(user)).thenReturn(groups);
 		when(userRepository.findByNickname(user.getNickname())).thenReturn(Optional.of(user));
 		when(studyGroupRepository.findAllByUser(user)).thenReturn(groups);
 		// when
 		GetStudyGroupListsResponse result = studyGroupService.getOtherStudyGroupList(user.getNickname());
 		// then
-		List<GetStudyGroupResponse> bookmarked = result.getBookmarked();
 		List<GetStudyGroupResponse> done = result.getDone();
 		List<GetStudyGroupResponse> inProgress = result.getInProgress();
 		List<GetStudyGroupResponse> queued = result.getQueued();
-		assertThat(bookmarked.size()).isEqualTo(10);
 		assertThat(done.size()).isEqualTo(10);
 		assertThat(inProgress.size()).isEqualTo(10);
 		assertThat(queued.size()).isEqualTo(10);
 		for (int i = 0; i < 10; i++) {
 			assertThat(done.get(i).name()).isEqualTo("name" + i);
 			assertThat(done.get(i).ownerNickname()).isEqualTo("nickname1");
-			assertThat(done.get(i).startDate()).isEqualTo(DateFormatUtil.formatDate(LocalDate.now().minusDays(i + 30)));
-			assertThat(done.get(i).endDate()).isEqualTo(DateFormatUtil.formatDate(LocalDate.now().minusDays(30)));
-			assertThat(done.get(i).isBookmarked()).isTrue();
-			assertThat(done.get(i).role()).isEqualTo(RoleOfGroupMember.OWNER);
+			assertThat(done.get(i).isBookmarked()).isFalse();
 		}
 		for (int i = 0; i < 10; i++) {
 			assertThat(inProgress.get(i).name()).isEqualTo("name" + i);
@@ -859,15 +823,6 @@ class StudyGroupServiceTest {
 			assertThat(queued.get(i).endDate()).isEqualTo(DateFormatUtil.formatDate(LocalDate.now().plusDays(i + 30)));
 			assertThat(queued.get(i).isBookmarked()).isFalse();
 			assertThat(queued.get(i).role()).isEqualTo(RoleOfGroupMember.OWNER);
-		}
-		for (int i = 0; i < 10; i++) {
-			assertThat(bookmarked.get(i).name()).isEqualTo("name" + i);
-			assertThat(bookmarked.get(i).ownerNickname()).isEqualTo("nickname1");
-			assertThat(bookmarked.get(i).startDate()).isEqualTo(
-				DateFormatUtil.formatDate(LocalDate.now().minusDays(i + 30)));
-			assertThat(bookmarked.get(i).endDate()).isEqualTo(DateFormatUtil.formatDate(LocalDate.now().minusDays(30)));
-			assertThat(bookmarked.get(i).isBookmarked()).isTrue();
-			assertThat(bookmarked.get(i).role()).isEqualTo(RoleOfGroupMember.OWNER);
 		}
 	}
 


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://github.com/GAMZA-BAT/algohub-server/issues/240

## 🚀 Description
<!-- 작업 내용 -->
- 그룹 설정 목록을 조회하는 API 를 추가했습니다.
- 그룹 목록 조회 시 bookmarked에 포함된 그룹들은 상태 별 카테고리에 포함 안되도록 수정했습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->