### PR TITLE
refactor : 알림 목록 조회 시 필요한 id 필드 추가

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/StudyGroupService.java
@@ -592,6 +592,7 @@ public class StudyGroupService {
 		notificationService.sendNotificationToMembers(
 			studyGroup,
 			members,
+			null, null,
 			NotificationCategory.NEW_MEMBER_JOINED,
 			NotificationCategory.NEW_MEMBER_JOINED.getMessage(newMember.getUser().getNickname())
 		);

--- a/src/main/java/com/gamzabat/algohub/feature/notice/service/NoticeCommentService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notice/service/NoticeCommentService.java
@@ -23,7 +23,6 @@ import com.gamzabat.algohub.feature.notice.dto.CreateNoticeCommentRequest;
 import com.gamzabat.algohub.feature.notice.exception.NoticeValidationException;
 import com.gamzabat.algohub.feature.notice.repository.NoticeCommentRepository;
 import com.gamzabat.algohub.feature.notice.repository.NoticeRepository;
-import com.gamzabat.algohub.feature.notification.service.NotificationService;
 import com.gamzabat.algohub.feature.user.domain.User;
 
 import lombok.RequiredArgsConstructor;
@@ -37,7 +36,6 @@ public class NoticeCommentService implements CommentService<CreateNoticeCommentR
 	private final NoticeCommentRepository noticeCommentRepository;
 	private final StudyGroupRepository studyGroupRepository;
 	private final GroupMemberRepository groupMemberRepository;
-	private final NotificationService notificationService;
 
 	@Override
 	@Transactional
@@ -50,21 +48,7 @@ public class NoticeCommentService implements CommentService<CreateNoticeCommentR
 			.content(request.content())
 			.build());
 
-		sendCommentNotification(notice, user, request.content());
 		log.info("success to create notice comment. commentId: {}, noticeId: {}", comment.getId(), notice.getId());
-	}
-
-	private void sendCommentNotification(Notice notice, User user, String content) {
-		String message = content.length() <= 35 ? content : content.substring(0, 35) + "...";
-		try {
-			notificationService.send(notice.getAuthor().getEmail(),
-				user.getNickname() + "님이 코멘트를 남겼습니다.",
-				notice.getStudyGroup(),
-				message);
-		} catch (Exception e) {
-			log.info("failed to send comment notice notification. noticeId: {}, userId: {}, error: {}",
-				notice.getId(), user.getId(), e.getMessage());
-		}
 	}
 
 	@Override

--- a/src/main/java/com/gamzabat/algohub/feature/notification/domain/Notification.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notification/domain/Notification.java
@@ -3,6 +3,8 @@ package com.gamzabat.algohub.feature.notification.domain;
 import java.time.LocalDateTime;
 
 import com.gamzabat.algohub.feature.group.studygroup.domain.StudyGroup;
+import com.gamzabat.algohub.feature.problem.domain.Problem;
+import com.gamzabat.algohub.feature.solution.domain.Solution;
 import com.gamzabat.algohub.feature.user.domain.User;
 
 import jakarta.persistence.Entity;
@@ -30,16 +32,24 @@ public class Notification {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "study_group_id")
 	private StudyGroup studyGroup;
-
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "problem_id")
+	private Problem problem;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "solution_id")
+	private Solution solution;
 	private String message;
 	private boolean isRead;
 	private String subContent;
 	private LocalDateTime createdAt;
 
 	@Builder
-	public Notification(User user, StudyGroup studyGroup, String message, boolean isRead, String subContent) {
+	public Notification(User user, StudyGroup studyGroup, Problem problem, Solution solution, String message,
+		boolean isRead, String subContent) {
 		this.user = user;
 		this.studyGroup = studyGroup;
+		this.problem = problem;
+		this.solution = solution;
 		this.message = message;
 		this.isRead = isRead;
 		this.subContent = subContent;

--- a/src/main/java/com/gamzabat/algohub/feature/notification/dto/GetNotificationResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notification/dto/GetNotificationResponse.java
@@ -3,7 +3,12 @@ package com.gamzabat.algohub.feature.notification.dto;
 import com.gamzabat.algohub.common.DateFormatUtil;
 import com.gamzabat.algohub.feature.notification.domain.Notification;
 
+import jakarta.annotation.Nullable;
+
 public record GetNotificationResponse(Long id,
+									  Long groupId,
+									  @Nullable Long problemId,
+									  @Nullable Long solutionId,
 									  String groupName,
 									  String groupImage,
 									  String message,
@@ -13,6 +18,9 @@ public record GetNotificationResponse(Long id,
 	public static GetNotificationResponse toDTO(Notification notification) {
 		return new GetNotificationResponse(
 			notification.getId(),
+			notification.getStudyGroup().getId(),
+			notification.getProblem() != null ? notification.getProblem().getId() : null,
+			notification.getSolution() != null ? notification.getSolution().getId() : null,
 			notification.getStudyGroup().getName(),
 			notification.getStudyGroup().getGroupImage(),
 			notification.getMessage(),

--- a/src/main/java/com/gamzabat/algohub/feature/notification/service/NotificationService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notification/service/NotificationService.java
@@ -28,6 +28,8 @@ import com.gamzabat.algohub.feature.notification.exception.NotificationValidatio
 import com.gamzabat.algohub.feature.notification.repository.EmitterRepositoryImpl;
 import com.gamzabat.algohub.feature.notification.repository.NotificationRepository;
 import com.gamzabat.algohub.feature.notification.repository.NotificationSettingRepository;
+import com.gamzabat.algohub.feature.problem.domain.Problem;
+import com.gamzabat.algohub.feature.solution.domain.Solution;
 import com.gamzabat.algohub.feature.user.domain.User;
 import com.gamzabat.algohub.feature.user.repository.UserRepository;
 
@@ -99,8 +101,9 @@ public class NotificationService {
 	}
 
 	@Transactional
-	public void send(String receiver, String message, StudyGroup studyGroup, String subContent) {
-		Notification notification = createNotification(receiver, message, studyGroup, subContent);
+	public void send(String receiver, String message, StudyGroup studyGroup, Problem problem, Solution solution,
+		String subContent) {
+		Notification notification = createNotification(receiver, message, studyGroup, subContent, problem, solution);
 		notificationRepository.save(notification);
 		Map<String, SseEmitter> sseEmitter = emitterRepository.findAllEmitterStartWithByEmail(receiver);
 		sseEmitter.forEach(
@@ -111,14 +114,15 @@ public class NotificationService {
 		);
 	}
 
-	private void sendList(List receiverList, String message, StudyGroup studyGroup, String subContent) {
+	private void sendList(List receiverList, String message, StudyGroup studyGroup, String subContent, Problem problem,
+		Solution solution) {
 		List<Notification> notifications = new ArrayList<>();
 		Map<String, SseEmitter> sseEmitters;
 		for (int i = 0; i < receiverList.size(); i++) {
 			int finalI = i;
 			sseEmitters = new HashMap<>();
 			Notification notification = createNotification(receiverList.get(i).toString(), message, studyGroup,
-				subContent);
+				subContent, problem, solution);
 			notifications.add(notification);
 			notificationRepository.save(notification);
 			sseEmitters.putAll(emitterRepository.findAllEmitterStartWithByEmail(receiverList.get(i).toString()));
@@ -131,12 +135,15 @@ public class NotificationService {
 		}
 	}
 
-	private Notification createNotification(String receiver, String message, StudyGroup studyGroup, String subContent) {
+	private Notification createNotification(String receiver, String message, StudyGroup studyGroup, String subContent,
+		Problem problem, Solution solution) {
 		return Notification.builder()
 			.user(
 				userRepository.findByEmail(receiver).orElseThrow(() -> new UserValidationException("존재 하지 않는 회원 입니다.")))
 			.message(message)
 			.studyGroup(studyGroup)
+			.problem(problem)
+			.solution(solution)
 			.subContent(subContent)
 			.isRead(false)
 			.build();
@@ -179,7 +186,8 @@ public class NotificationService {
 	}
 
 	@Transactional
-	public void sendNotificationToMembers(StudyGroup group, List<GroupMember> receiver,
+	public void sendNotificationToMembers(StudyGroup group, List<GroupMember> receiver, Problem problem,
+		Solution solution,
 		NotificationCategory category, String message) {
 		List<String> users = new ArrayList<>();
 		for (GroupMember member : receiver) {
@@ -195,7 +203,7 @@ public class NotificationService {
 		}
 
 		try {
-			sendList(users, message, group, null);
+			sendList(users, message, group, null, problem, solution);
 		} catch (Exception e) {
 			log.warn("failed to send notification", e);
 		}

--- a/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
@@ -71,7 +71,7 @@ public class ProblemService {
 		int level = getProblemLevel(apiResult);
 		String title = getProblemTitle(apiResult);
 
-		problemRepository.save(Problem.builder()
+		Problem problem = problemRepository.save(Problem.builder()
 			.studyGroup(group)
 			.link(request.link())
 			.number(Integer.parseInt(number))
@@ -85,6 +85,8 @@ public class ProblemService {
 			notificationService.sendNotificationToMembers(
 				group,
 				groupMemberRepository.findAllByStudyGroup(group),
+				problem,
+				null,
 				NotificationCategory.PROBLEM_STARTED,
 				NotificationCategory.PROBLEM_STARTED.getMessage(title)
 			);
@@ -291,6 +293,8 @@ public class ProblemService {
 			notificationService.sendNotificationToMembers(
 				problem.getStudyGroup(),
 				groupMemberRepository.findAllByStudyGroup(problem.getStudyGroup()),
+				problem,
+				null,
 				NotificationCategory.PROBLEM_STARTED,
 				NotificationCategory.PROBLEM_STARTED.getMessage(problem.getTitle())
 			);
@@ -303,6 +307,8 @@ public class ProblemService {
 			notificationService.sendNotificationToMembers(
 				problem.getStudyGroup(),
 				groupMemberRepository.findAllByStudyGroup(problem.getStudyGroup()),
+				problem,
+				null,
 				NotificationCategory.PROBLEM_DEADLINE_REACHED,
 				NotificationCategory.PROBLEM_DEADLINE_REACHED.getMessage(problem.getTitle())
 			);

--- a/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionCommentService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionCommentService.java
@@ -68,6 +68,8 @@ public class SolutionCommentService implements CommentService<CreateSolutionComm
 		notificationService.sendNotificationToMembers(
 			solution.getProblem().getStudyGroup(),
 			List.of(member),
+			null,
+			solution,
 			NotificationCategory.NEW_COMMENT_POSTED,
 			NotificationCategory.NEW_COMMENT_POSTED.getMessage(commenter.getNickname())
 		);

--- a/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
@@ -222,14 +222,16 @@ public class SolutionService {
 				rankingUpdateService.updateRanking(studyGroup);
 			}
 
-			sendNewSolutionNotification(studyGroup, member.get());
+			sendNewSolutionNotification(studyGroup, member.get(), problem);
 		}
 	}
 
-	private void sendNewSolutionNotification(StudyGroup group, GroupMember solver) {
+	private void sendNewSolutionNotification(StudyGroup group, GroupMember solver, Problem problem) {
 		notificationService.sendNotificationToMembers(
 			group,
 			groupMemberRepository.findAllByStudyGroup(group),
+			problem,
+			null,
 			NotificationCategory.NEW_SOLUTION_POSTED,
 			NotificationCategory.NEW_SOLUTION_POSTED.getMessage(solver.getUser().getNickname())
 		);

--- a/src/test/java/com/gamzabat/algohub/feature/notice/service/NoticeCommentServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/notice/service/NoticeCommentServiceTest.java
@@ -117,7 +117,7 @@ class NoticeCommentServiceTest {
 		assertThat(result.getContent()).isEqualTo("content");
 		assertThat(result.getUser()).isEqualTo(user2);
 		assertThat(result.getNotice()).isEqualTo(notice);
-		verify(notificationService, times(1)).send(any(), any(), any(), any());
+		// verify(notificationService, times(1)).send(any(), any(), any(), any(), any(), any());
 	}
 
 	@Test
@@ -132,7 +132,7 @@ class NoticeCommentServiceTest {
 		assertThatThrownBy(() -> commentService.createComment(user, 10L, request))
 			.isInstanceOf(NoticeValidationException.class)
 			.hasFieldOrPropertyWithValue("error", "공지사항이 존재하지 않습니다.");
-		verify(notificationService, never()).send(any(), any(), any(), any());
+		verify(notificationService, never()).send(any(), any(), any(), any(), any(), any());
 	}
 
 	@Test
@@ -148,7 +148,7 @@ class NoticeCommentServiceTest {
 			.isInstanceOf(StudyGroupValidationException.class)
 			.hasFieldOrPropertyWithValue("code", HttpStatus.NOT_FOUND.value())
 			.hasFieldOrPropertyWithValue("error", "스터디 그룹이 존재하지 않습니다.");
-		verify(notificationService, never()).send(any(), any(), any(), any());
+		verify(notificationService, never()).send(any(), any(), any(), any(), any(), any());
 	}
 
 	@Test
@@ -166,27 +166,7 @@ class NoticeCommentServiceTest {
 			.isInstanceOf(GroupMemberValidationException.class)
 			.hasFieldOrPropertyWithValue("code", HttpStatus.FORBIDDEN.value())
 			.hasFieldOrPropertyWithValue("error", "참여하지 않은 그룹 입니다.");
-		verify(notificationService, never()).send(any(), any(), any(), any());
-	}
-
-	@Test
-	@DisplayName("댓글 작성 성공, 알림 전송 실패")
-	void createCommentSuccess_NotificationFailed() {
-		// given
-		CreateNoticeCommentRequest request = CreateNoticeCommentRequest.builder()
-			.content("content")
-			.build();
-		when(noticeRepository.findById(10L)).thenReturn(Optional.ofNullable(notice));
-		when(studyGroupRepository.findById(30L)).thenReturn(Optional.ofNullable(studyGroup));
-		when(groupMemberRepository.existsByUserAndStudyGroup(user2, studyGroup)).thenReturn(true);
-		when(commentRepository.save(any(NoticeComment.class))).thenReturn(comment);
-		doThrow(new RuntimeException()).when(notificationService).send(any(), any(), any(), any());
-		// when
-		commentService.createComment(user2, 10L, request);
-		// then
-		verify(commentRepository, times(1)).save(any(NoticeComment.class));
-		verify(notificationService, times(1)).send(any(), any(), any(), any());
-		verify(notificationRepository, never()).save(any());
+		verify(notificationService, never()).send(any(), any(), any(), any(), any(), any());
 	}
 
 	@Test

--- a/src/test/java/com/gamzabat/algohub/service/ProblemServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/ProblemServiceTest.java
@@ -175,7 +175,7 @@ class ProblemServiceTest {
 		assertThat(result.getLevel()).isEqualTo(1);
 		assertThat(result.getStartDate()).isEqualTo(LocalDate.now());
 		assertThat(result.getEndDate()).isEqualTo(LocalDate.now().plusDays(10));
-		verify(notificationService, times(1)).sendNotificationToMembers(any(), any(), any(), any());
+		verify(notificationService, times(1)).sendNotificationToMembers(any(), any(), any(), any(), any(), any());
 	}
 
 	@Test
@@ -777,7 +777,7 @@ class ProblemServiceTest {
 		// when
 		problemService.dailyProblemScheduler();
 		// then
-		verify(notificationService, times(20)).sendNotificationToMembers(any(), any(), any(), any());
+		verify(notificationService, times(20)).sendNotificationToMembers(any(), any(), any(), any(), any(), any());
 	}
 
 	@Test

--- a/src/test/java/com/gamzabat/algohub/service/SolutionCommentServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/SolutionCommentServiceTest.java
@@ -140,7 +140,7 @@ class SolutionCommentServiceTest {
 		assertThat(result.getContent()).isEqualTo("content");
 		assertThat(result.getUser()).isEqualTo(user2);
 		assertThat(result.getSolution()).isEqualTo(solution);
-		verify(notificationService, times(1)).sendNotificationToMembers(any(), any(), any(), any());
+		verify(notificationService, times(1)).sendNotificationToMembers(any(), any(), any(), any(), any(), any());
 	}
 
 	@Test
@@ -155,7 +155,7 @@ class SolutionCommentServiceTest {
 		assertThatThrownBy(() -> commentService.createComment(user, 10L, request))
 			.isInstanceOf(SolutionValidationException.class)
 			.hasFieldOrPropertyWithValue("error", "존재하지 않는 풀이 입니다.");
-		verify(notificationService, never()).send(any(), any(), any(), any());
+		verify(notificationService, never()).send(any(), any(), any(), any(), any(), any());
 	}
 
 	@Test
@@ -172,7 +172,7 @@ class SolutionCommentServiceTest {
 			.isInstanceOf(ProblemValidationException.class)
 			.hasFieldOrPropertyWithValue("code", HttpStatus.NOT_FOUND.value())
 			.hasFieldOrPropertyWithValue("error", "존재하지 않는 문제 입니다.");
-		verify(notificationService, never()).send(any(), any(), any(), any());
+		verify(notificationService, never()).send(any(), any(), any(), any(), any(), any());
 	}
 
 	@Test
@@ -190,7 +190,7 @@ class SolutionCommentServiceTest {
 			.isInstanceOf(StudyGroupValidationException.class)
 			.hasFieldOrPropertyWithValue("code", HttpStatus.NOT_FOUND.value())
 			.hasFieldOrPropertyWithValue("error", "존재하지 않는 그룹 입니다.");
-		verify(notificationService, never()).send(any(), any(), any(), any());
+		verify(notificationService, never()).send(any(), any(), any(), any(), any(), any());
 	}
 
 	@Test
@@ -209,7 +209,7 @@ class SolutionCommentServiceTest {
 			.isInstanceOf(GroupMemberValidationException.class)
 			.hasFieldOrPropertyWithValue("code", HttpStatus.FORBIDDEN.value())
 			.hasFieldOrPropertyWithValue("error", "참여하지 않은 그룹 입니다.");
-		verify(notificationService, never()).send(any(), any(), any(), any());
+		verify(notificationService, never()).send(any(), any(), any(), any(), any(), any());
 	}
 
 	@Test

--- a/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
@@ -468,7 +468,7 @@ class SolutionServiceTest {
 
 		// then
 		verify(solutionRepository, times(1)).save(any(Solution.class));
-		verify(notificationService, times(1)).sendNotificationToMembers(any(), any(), any(), any());
+		verify(notificationService, times(1)).sendNotificationToMembers(any(), any(), any(), any(), any(), any());
 	}
 
 	@Test

--- a/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/StudyGroupServiceTest.java
@@ -240,7 +240,7 @@ class StudyGroupServiceTest {
 		assertThat(result.getStudyGroup()).isEqualTo(group);
 		assertThat(result.getUser()).isEqualTo(user2);
 		verify(groupMemberRepository, times(1)).save(any(GroupMember.class));
-		verify(notificationService, times(1)).sendNotificationToMembers(any(), any(), any(), any());
+		verify(notificationService, times(1)).sendNotificationToMembers(any(), any(), any(), any(), any(), any());
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://github.com/GAMZA-BAT/algohub-server/issues/245

## 🚀 Description
<!-- 작업 내용 -->
- 라우팅에 필요한 groupId, problemId, solutionId를 알림 목록 조회 DTO에 추가했습니다.
- 공지 관련 알림도 생길텐데 여기서 하려다가 건들게 너무 많아질 것 같아서 따로 이슈 파고 그 때 noticeId도 추가하겠습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->