### PR TITLE
fix : in-progress 문제 목록 countQuery 오류 수정

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/problem/repository/querydsl/CustomProblemRepositoryImpl.java
+++ b/src/main/java/com/gamzabat/algohub/feature/problem/repository/querydsl/CustomProblemRepositoryImpl.java
@@ -40,12 +40,12 @@ public class CustomProblemRepositoryImpl implements CustomProblemRepository {
 		query.offset(pageable.getOffset())
 			.limit(pageable.getPageSize());
 
-		JPAQuery<Long> countQuery = problemCountQuery(query);
+		JPAQuery<Long> countQuery = problemCountQuery(user, group, unsolvedOnly);
 
 		return PageableExecutionUtils.getPage(query.fetch(), pageable, countQuery::fetchOne);
 	}
 
-	private void addUnsolvedProblemFilter(JPAQuery<Problem> query, User user) {
+	private void addUnsolvedProblemFilter(JPAQuery<?> query, User user) {
 		query
 			.where(
 				JPAExpressions.selectFrom(solution)
@@ -57,11 +57,16 @@ public class CustomProblemRepositoryImpl implements CustomProblemRepository {
 			);
 	}
 
-	private JPAQuery<Long> problemCountQuery(JPAQuery<Problem> query) {
-		return queryFactory.select(problem.count())
+	private JPAQuery<Long> problemCountQuery(User user, StudyGroup group, boolean unsolvedOnly) {
+		JPAQuery<Long> query = queryFactory.select(problem.count())
 			.from(problem)
-			.join(solution).fetchJoin()
-			.on(solution.problem.eq(problem))
-			.where(query.getMetadata().getWhere());
+			.where(problem.studyGroup.eq(group)
+				.and(problem.startDate.loe(LocalDate.now()))
+				.and(problem.endDate.goe(LocalDate.now())));
+
+		if (unsolvedOnly) {
+			addUnsolvedProblemFilter(query, user);
+		}
+		return query;
 	}
 }


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://github.com/GAMZA-BAT/algohub-server/issues/253

## 🚀 Description
<!-- 작업 내용 -->
- 기존에 count query 만들 때 조회 쿼리의 where 절을 그대로 떼오는 `getWhere()`을 사용했었는데 왜인진 모르겠지만 totalElement 계산이 의도대로 안되네요.
- 그래서 그냥 count query 자체를 새로 만들었더니 작동합니다. 원인 더 찾아봐야겠어요..

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->