### PR TITLE
feat: Send message to discord when the server get uncaught exceptions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Create application.yml
         run: echo "${{ secrets.APPLICATION_YML }}" | base64 --decode > src/main/resources/application.yml
 
+      - name: Create webhook.yml
+        run: echo "${{ secrets.WEBHOOK_YML }}" | base64 --decode > src/main/resources/webhook.yml
+
       - name: Test YML
         run: ls -l src/main/resources
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Create application.yml
         run: echo "${{ secrets.APPLICATION_YML }}" | base64 --decode > src/main/resources/application.yml
 
+      - name: Create webhook.yml
+        run: echo "${{ secrets.WEBHOOK_YML }}" | base64 --decode > src/main/resources/webhook.yml
+
       - name: Test YML
         run: ls -l src/main/resources
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.assertj:assertj-core:3.23.0'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
+    implementation 'org.codehaus.janino:janino:3.1.9'
+    implementation 'org.apache.commons:commons-text:1.13.0'
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
@@ -67,4 +69,8 @@ clean {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+test {
+    systemProperty 'spring.profiles.active', 'local'
 }

--- a/src/main/java/com/gamzabat/algohub/common/logging/DiscordLogAppender.java
+++ b/src/main/java/com/gamzabat/algohub/common/logging/DiscordLogAppender.java
@@ -1,0 +1,120 @@
+package com.gamzabat.algohub.common.logging;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.text.StringEscapeUtils;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.ThrowableProxyUtil;
+import ch.qos.logback.core.AppenderBase;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@Setter
+public class DiscordLogAppender extends AppenderBase<ILoggingEvent> {
+	private String discordWebhookUrl;
+
+	@Override
+	protected void append(ILoggingEvent event) {
+		Map<String, String> mdcPropertyMap = event.getMDCPropertyMap();
+
+		String levelStr = event.getLevel().levelStr;
+		String exceptionBrief = "";
+		IThrowableProxy throwable = event.getThrowableProxy();
+
+		if (throwable != null) {
+			exceptionBrief = throwable.getClassName() + ": " + throwable.getMessage();
+		}
+
+		if (exceptionBrief.isEmpty()) {
+			exceptionBrief = "EXCEPTION 정보가 남지 않았습니다.";
+		}
+
+		Map<String, Object> embed = new HashMap<>();
+		embed.put("title", "[" + levelStr + "] Exception 발생");
+		embed.put("color", getColorForLevel(levelStr));
+		embed.put("timestamp", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
+
+		// Embed Fields
+		List<Map<String, String>> fields = new ArrayList<>();
+		fields.add(createField("문제 간략 내용", exceptionBrief, false));
+		fields.add(createField("요청 URI", escape(mdcPropertyMap.get(MDCUtil.MDC_REQUEST_URI)), true));
+		fields.add(createField("HTTP 헤더", escape(mdcPropertyMap.get(MDCUtil.MDC_HEADER)), true));
+		fields.add(createField("HTTP 메서드", escape(mdcPropertyMap.get(MDCUtil.MDC_REQUEST_METHOD)), true));
+		fields.add(createField("파라미터", escape(mdcPropertyMap.get(MDCUtil.MDC_PARAMETER)), true));
+		fields.add(createField("요청 Body", escape(mdcPropertyMap.get(MDCUtil.MDC_REQUEST_BODY)), true));
+
+		embed.put("fields", fields);
+
+		if (throwable != null) {
+			String exceptionDetail = ThrowableProxyUtil.asString(throwable);
+			fields.add(createField("Exception 상세 내용", truncate(exceptionDetail), false));
+		}
+
+		sendToDiscordEmbed(embed);
+	}
+
+	private Map<String, String> createField(String name, String value, boolean inline) {
+		Map<String, String> field = new HashMap<>();
+		field.put("name", name);
+		field.put("value", value != null ? value : "없음");
+		field.put("inline", String.valueOf(inline));
+		return field;
+	}
+
+	private void sendToDiscordEmbed(Map<String, Object> embed) {
+		RestTemplate restTemplate = new RestTemplate();
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+
+		Map<String, Object> payload = new HashMap<>();
+		payload.put("embeds", List.of(embed));
+
+		HttpEntity<Map<String, Object>> request = new HttpEntity<>(payload, headers);
+
+		try {
+			ResponseEntity<String> response = restTemplate.postForEntity(discordWebhookUrl, request, String.class);
+
+			if (!response.getStatusCode().is2xxSuccessful()) {
+				addError("Failed to send log message to Discord: " + response.getStatusCode());
+			}
+		} catch (Exception e) {
+			log.warn("Exception occurred while sending log message to Discord", e);
+		}
+	}
+
+	private String escape(String value) {
+		return value != null ? StringEscapeUtils.escapeJson(value) : "없음";
+	}
+
+	private String truncate(String value) {
+		final int MAX_LENGTH = 1000;
+		return value != null && value.length() > MAX_LENGTH ? value.substring(0, MAX_LENGTH) + "..." : value;
+	}
+
+	private int getColorForLevel(String level) {
+		return switch (level) {
+			case "ERROR" -> 0xFF0000; // Red
+			case "WARN" -> 0xFFFF00; // Yellow
+			case "INFO" -> 0x00FF00; // Green
+			case "DEBUG" -> 0x0000FF; // Blue
+			case "TRACE" -> 0xAAAAAA; // Gray
+			default -> 0x000000; // Black
+		};
+	}
+
+}

--- a/src/main/java/com/gamzabat/algohub/common/logging/MDCFilter.java
+++ b/src/main/java/com/gamzabat/algohub/common/logging/MDCFilter.java
@@ -1,0 +1,29 @@
+package com.gamzabat.algohub.common.logging;
+
+import java.io.IOException;
+
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.WebUtils;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class MDCFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		HttpServletRequest nativeRequest = WebUtils.getNativeRequest(request, HttpServletRequest.class);
+
+		MDCUtil.setJsonValue(MDCUtil.MDC_REQUEST_URI, MDCUtil.getRequestUri(nativeRequest));
+		MDCUtil.set(MDCUtil.MDC_REQUEST_METHOD, MDCUtil.getMethod(nativeRequest));
+		MDCUtil.set(MDCUtil.MDC_HEADER, MDCUtil.getHeader(nativeRequest));
+		MDCUtil.set(MDCUtil.MDC_PARAMETER, MDCUtil.getParameter(nativeRequest));
+		MDCUtil.set(MDCUtil.MDC_REQUEST_BODY, MDCUtil.getBody(nativeRequest));
+
+		filterChain.doFilter(request, response);
+
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/common/logging/MDCUtil.java
+++ b/src/main/java/com/gamzabat/algohub/common/logging/MDCUtil.java
@@ -1,0 +1,83 @@
+package com.gamzabat.algohub.common.logging;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.MDC;
+import org.slf4j.spi.MDCAdapter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.WebUtils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@Component
+public class MDCUtil {
+	public static final String MDC_REQUEST_URI = "requestUri";
+	public static final String MDC_REQUEST_METHOD = "requestMethod";
+	public static final String MDC_REQUEST_BODY = "requestBody";
+	public static final String MDC_HEADER = "header";
+	public static final String MDC_PARAMETER = "parameter";
+
+	private static final ObjectMapper mapper = new ObjectMapper();
+	private static final MDCAdapter mdcAdapter = MDC.getMDCAdapter();
+
+	private MDCUtil() {
+	}
+
+	public static void set(String key, Object value) {
+		if (value != null) {
+			mdcAdapter.put(key, value.toString());
+		}
+	}
+
+	public static void setJsonValue(String key, Object value) {
+		try {
+			String json = value != null
+				? mapper.writerWithDefaultPrettyPrinter().writeValueAsString(value)
+				: "내용이 없습니다.";
+			mdcAdapter.put(key, json);
+		} catch (JsonProcessingException e) {
+			throw new IllegalArgumentException("Failed to serialize value to JSON for key: " + key, e);
+		}
+	}
+
+	public static String getRequestUri(HttpServletRequest request) {
+		return request.getRequestURI();
+	}
+
+	public static Map<String, String> getHeader(HttpServletRequest request) {
+		Map<String, String> headerMap = new HashMap<>();
+		request.getHeaderNames().asIterator()
+			.forEachRemaining(name -> {
+				if (!name.equals("user-agent")) {
+					headerMap.put(name, request.getHeader(name));
+				}
+			});
+		return headerMap;
+	}
+
+	public static Map<String, String> getParameter(HttpServletRequest request) {
+		Map<String, String> paramMap = new HashMap<>();
+		request.getParameterNames().asIterator()
+			.forEachRemaining(name -> paramMap.put(name, request.getParameter(name)));
+
+		return paramMap;
+	}
+
+	public static String getBody(HttpServletRequest request) {
+		RequestBodyWrapper requestBodyWrapper = WebUtils.getNativeRequest(request, RequestBodyWrapper.class);
+
+		if (requestBodyWrapper != null) {
+			return requestBodyWrapper.getBody();
+		}
+
+		return "requestBody 정보 없음";
+	}
+
+	public static String getMethod(HttpServletRequest request) {
+		return request.getMethod();
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/common/logging/RequestBodyWrapper.java
+++ b/src/main/java/com/gamzabat/algohub/common/logging/RequestBodyWrapper.java
@@ -1,0 +1,86 @@
+package com.gamzabat.algohub.common.logging;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.coyote.BadRequestException;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import lombok.Getter;
+
+@Getter
+public class RequestBodyWrapper extends HttpServletRequestWrapper {
+	private final String body;
+
+	public RequestBodyWrapper(HttpServletRequest request) throws BadRequestException {
+		super(request);
+
+		if (isMultipartRequest(request)) {
+			body = null; //  cannot read multipart request body
+			return;
+		}
+
+		StringBuilder builder = new StringBuilder();
+
+		try (BufferedReader reader = request.getReader()) {
+			char[] buffer = new char[1024];
+			int read;
+			while ((read = reader.read(buffer)) != -1) {
+				builder.append(buffer, 0, read);
+			}
+		} catch (IOException e) {
+			throw new BadRequestException("Failed to read request body", e);
+		}
+
+		body = builder.toString();
+	}
+
+	private boolean isMultipartRequest(HttpServletRequest request) {
+		String contentType = request.getContentType();
+		return contentType != null && contentType.startsWith("multipart/form-data");
+	}
+
+	@Override
+	public ServletInputStream getInputStream() {
+		final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(
+			body != null ? body.getBytes(StandardCharsets.UTF_8) : new byte[0]);
+		return new ServletInputStream() {
+			private boolean finished = false;
+
+			@Override
+			public boolean isFinished() {
+				return finished;
+			}
+
+			@Override
+			public boolean isReady() {
+				return true;
+			}
+
+			@Override
+			public void setReadListener(ReadListener readListener) {
+				throw new UnsupportedOperationException("ReadListener is not supported");
+			}
+
+			@Override
+			public int read() {
+				int data = byteArrayInputStream.read();
+				if (data == -1) {
+					finished = true;
+				}
+				return data;
+			}
+		};
+	}
+
+	@Override
+	public BufferedReader getReader() {
+		return new BufferedReader(new InputStreamReader(this.getInputStream(), StandardCharsets.UTF_8));
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/common/logging/RequestWrappingFilter.java
+++ b/src/main/java/com/gamzabat/algohub/common/logging/RequestWrappingFilter.java
@@ -1,0 +1,23 @@
+package com.gamzabat.algohub.common.logging;
+
+import java.io.IOException;
+
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class RequestWrappingFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		RequestBodyWrapper bodyWrapper = new RequestBodyWrapper(request);
+		filterChain.doFilter(bodyWrapper, response);
+
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/config/MDCFilterConfig.java
+++ b/src/main/java/com/gamzabat/algohub/config/MDCFilterConfig.java
@@ -1,0 +1,31 @@
+package com.gamzabat.algohub.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.gamzabat.algohub.common.logging.MDCFilter;
+import com.gamzabat.algohub.common.logging.RequestWrappingFilter;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Configuration
+@Slf4j
+public class MDCFilterConfig {
+
+	@Bean
+	public FilterRegistrationBean<RequestWrappingFilter> secondFilter() {
+		FilterRegistrationBean<RequestWrappingFilter> filterRegistrationBean = new FilterRegistrationBean<>(
+			new RequestWrappingFilter());
+		filterRegistrationBean.setOrder(0);
+		return filterRegistrationBean;
+	}
+
+	@Bean
+	public FilterRegistrationBean<MDCFilter> thirdFilter() {
+		FilterRegistrationBean<MDCFilter> filterRegistrationBean = new FilterRegistrationBean<>(new MDCFilter());
+		filterRegistrationBean.setOrder(1);
+		return filterRegistrationBean;
+	}
+
+}

--- a/src/main/resources/console-appender.xml
+++ b/src/main/resources/console-appender.xml
@@ -1,0 +1,7 @@
+<included>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%-5level) %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/discord-appender.xml
+++ b/src/main/resources/discord-appender.xml
@@ -1,0 +1,11 @@
+<included>
+    <appender name="DISCORD" class="com.gamzabat.algohub.common.logging.DiscordLogAppender">
+        <param name="discordWebhookUrl" value="${discordWebhookUrl}"/>
+    </appender>
+    <appender name="ASYNC_DISCORD" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="DISCORD"/>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+</included>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <springProperty name="discordWebhookUrl" source="logging.discord.webhook-url"/>
+
+    <include resource="console-appender.xml"/>
+    <logger name="com.gamzabat.algohub" level="DEBUG"/>
+    
+    <springProfile name="prod">
+        <include resource="discord-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <!-- prod에서만 DISCORD 전송 -->
+            <appender-ref ref="ASYNC_DISCORD"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="!prod">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+</configuration>


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close #262 
## 🚀 Description
<!-- 작업 내용 -->
- 서버에서 Uncaught exception이 발생하면 디스코드로 웹훅을 날립니다. 정확히는 ERROR 로그가 발생하면 날아와요.
- 개발 환경에서 날리지 않도록 spring의 프로파일 기능을 대애애충 활용했는데, 도커쓰면 좋겠다는 생각 더더욱 드네요.
- 이거 하고 나면 이제 cloudWatch에서 로그보는거 작업할게요.


## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
- 이거 기술적으로 뭐 설명할게 많은데, 어디부터 설명할지 난감,, 
- slf4j는 인터페이스고, 사실 구현체는 Logback이란 친구예요. 
- 쓰다보니까 너무길다. 그냥 코드에 코멘트 달게요 

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->
yml파일이 바뀌었어요. 머지되면 톡방에 올릴게요. 