### PR TITLE
fix : 토큰 resolve 시 null 반환을 예외 throw로 수정

### DIFF
--- a/src/main/java/com/gamzabat/algohub/common/jwt/TokenProvider.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/TokenProvider.java
@@ -161,7 +161,8 @@ public class TokenProvider {
 		String token = request.getHeader("Authorization");
 		if (StringUtils.hasValue(token) && token.startsWith("Bearer"))
 			return token.substring(7);
-		return null;
+
+		throw new JwtRequestException(HttpStatus.BAD_REQUEST.value(), "BAD_REQUEST", "유효한 형태의 토큰이 존재하지 않습니다.");
 	}
 
 	private Claims getClaims(String expiredToken) {

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -29,7 +29,6 @@ import com.gamzabat.algohub.common.jwt.dto.ReissueTokenRequest;
 import com.gamzabat.algohub.common.redis.RedisService;
 import com.gamzabat.algohub.enums.ImageType;
 import com.gamzabat.algohub.enums.Role;
-import com.gamzabat.algohub.exception.JwtRequestException;
 import com.gamzabat.algohub.exception.UserValidationException;
 import com.gamzabat.algohub.feature.group.studygroup.exception.CannotFoundUserException;
 import com.gamzabat.algohub.feature.image.service.ImageService;
@@ -168,9 +167,6 @@ public class UserService {
 	@Transactional
 	public void logout(HttpServletRequest request) {
 		String accessToken = tokenProvider.resolveToken(request);
-		if (accessToken == null)
-			throw new JwtRequestException(HttpStatus.BAD_REQUEST.value(), "BAD_REQUEST", "토큰이 비어있습니다.");
-
 		long tokenExpiration = tokenProvider.getAccessTokenExpirationTime();
 		redisService.setValues(accessToken, "logout", Duration.ofMillis(tokenExpiration));
 		log.info("success to logout");

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -5,8 +5,6 @@ import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Field;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -39,7 +37,6 @@ import com.gamzabat.algohub.common.jwt.dto.JwtDTO;
 import com.gamzabat.algohub.common.redis.RedisService;
 import com.gamzabat.algohub.enums.ImageType;
 import com.gamzabat.algohub.enums.Role;
-import com.gamzabat.algohub.exception.JwtRequestException;
 import com.gamzabat.algohub.exception.UserValidationException;
 import com.gamzabat.algohub.feature.group.studygroup.exception.CannotFoundUserException;
 import com.gamzabat.algohub.feature.image.service.ImageService;
@@ -259,20 +256,6 @@ class UserServiceTest {
 		userService.logout(request);
 		// then
 		verify(redisService, times(1)).setValues(eq(token), eq("logout"), eq(Duration.ofMillis(6000L)));
-	}
-
-	@Test
-	@DisplayName("로그아웃 실패 : 비어있는 토큰")
-	void logoutFailed() {
-		// given
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		when(tokenProvider.resolveToken(request)).thenReturn(null);
-		// when, then
-		assertThatThrownBy(() -> userService.logout(request))
-			.isInstanceOf(JwtRequestException.class)
-			.hasFieldOrPropertyWithValue("code", HttpStatus.BAD_REQUEST.value())
-			.hasFieldOrPropertyWithValue("error", "BAD_REQUEST")
-			.hasFieldOrPropertyWithValue("messages", new ArrayList<>(List.of("토큰이 비어있습니다.")));
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://github.com/GAMZA-BAT/algohub-server/issues/265

## 🚀 Description
<!-- 작업 내용 -->
- 기존에는 로그아웃 할 때, 토큰 값이 비어있으면 JwtRequestException을 던졌습니다.
- 원래 JwtRequestException이 JwtFilter 내에서만 사용되던거라, CustomExceptionHandler에는 등록이 안되어 있었습니다.
- 그래서 userService에서 던졌을 때 캐치되지 못해 500이 띄워졌었습니다.

- 그냥 Handler에 추가를 할까 했는데, 토큰이 null인 케이스가 filter에서 걸러지지 못하는게 너무 짜쳐서 TokenProvider를 좀 뒤적였습니다.
- TokenProvider의 resolvedToken 메소드를 보시면, 기존에는 token이 올바른 형태가 아닐 경우 null을 리턴하고 있었습니다.
- 이 부분에서 null 반환을 지우고 JwtRequestException을 던져 JwtFilter단에서 초기 예외처리하도록 수정했습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->