### PR TITLE
feat: Forward logs to cloudwatch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
     implementation 'org.codehaus.janino:janino:3.1.9'
     implementation 'org.apache.commons:commons-text:1.13.0'
+    implementation group: 'ca.pjer', name: 'logback-awslogs-appender', version: '1.6.0'
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'

--- a/src/main/resources/aws-appender.xml
+++ b/src/main/resources/aws-appender.xml
@@ -1,0 +1,18 @@
+<included>
+    <appender name="ASYNC_AWS_LOGS" class="ca.pjer.logback.AwsLogsAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+        <layout>
+            <pattern>%d{yyyyMMdd'T'HHmmss} %thread %level %logger{15} %msg%n</pattern>
+        </layout>
+
+        <logGroupName>algohub-prod</logGroupName>
+        <logStreamUuidPrefix>algohub-server-</logStreamUuidPrefix>
+        <logRegion>ap-northeast-2</logRegion>
+        <maxBatchLogEvents>50</maxBatchLogEvents>
+        <maxFlushTimeMillis>30000</maxFlushTimeMillis>
+        <maxBlockTimeMillis>5000</maxBlockTimeMillis>
+        <retentionTimeDays>0</retentionTimeDays>
+    </appender>
+</included>

--- a/src/main/resources/aws-appender.xml
+++ b/src/main/resources/aws-appender.xml
@@ -13,6 +13,6 @@
         <maxBatchLogEvents>50</maxBatchLogEvents>
         <maxFlushTimeMillis>30000</maxFlushTimeMillis>
         <maxBlockTimeMillis>5000</maxBlockTimeMillis>
-        <retentionTimeDays>0</retentionTimeDays>
+        <retentionTimeDays>60</retentionTimeDays>
     </appender>
 </included>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -5,14 +5,16 @@
 
     <include resource="console-appender.xml"/>
     <logger name="com.gamzabat.algohub" level="DEBUG"/>
-    
+
     <springProfile name="prod">
         <include resource="discord-appender.xml"/>
+        <include resource="aws-appender.xml"/>
 
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
             <!-- prod에서만 DISCORD 전송 -->
             <appender-ref ref="ASYNC_DISCORD"/>
+            <appender-ref ref="ASYNC_AWS_LOGS"/>
         </root>
     </springProfile>
 


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close #264 

## 🚀 Description
<!-- 작업 내용 -->
- 이제 로그가 aws로 날아와요~ 

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
- 이전 코드 작업해둔것 덕에 아주 적은 diff로 풀 수 있었어요 🙂
- 참고로 이걸 하려면, 서버가 도는 ec2 인스턴스에 credential을 등록해야해요. 
- `.aws/credentials`에서 다음 두 개를 등록해야 합니다. 이건 제가 발급해둔 로그온리 iam 계정으로 설정 해놨어요.
aws_access_key_id = 
aws_secret_access_key =

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->
머지되면 계정뿌림
5GB까지 무료인데, 쌓이는거 좀 보면서 결정합니다
- 점점 우리 서버에 필요한 환경 세팅이 많아지고 있어요. Java 21, Redis, aws, nohup, iptables(포트포워딩), etc... 만약 ec2 인스턴스를 새로 파야 한다고 하면 끔찍하겠죠? 
도커를 도입했을때 효용이 늘고 있네요 :) 
