### PR TITLE
env: Enforce the server's timezone to be set as Asia/Seoul (KST)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,5 +71,5 @@ jobs:
           echo "${{ secrets.EC2_SSH_KEY }}" > private_key.pem
           chmod 400 private_key.pem
           sudo scp -i private_key.pem -o StrictHostKeyChecking=no build/libs/algohub-0.0.1-SNAPSHOT.jar ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USERNAME }}/algohub.jar
-          sudo ssh -i private_key.pem -o StrictHostKeyChecking=no ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} "pgrep java | xargs kill -9; nohup java -jar /home/${{ secrets.EC2_USERNAME }}/algohub.jar > app.log 2>&1 &"
+          sudo ssh -i private_key.pem -o StrictHostKeyChecking=no ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} "pgrep java | xargs kill -9; nohup java -jar -Duser.timezone=Asia/Seoul /home/${{ secrets.EC2_USERNAME }}/algohub.jar > app.log 2>&1 &"
           rm -f private_key.pem

--- a/build.gradle
+++ b/build.gradle
@@ -74,4 +74,5 @@ tasks.named('test') {
 
 test {
     systemProperty 'spring.profiles.active', 'local'
+    systemProperty 'user.timezone', 'Asia/Seoul'
 }

--- a/src/main/java/com/gamzabat/algohub/AlgohubApplication.java
+++ b/src/main/java/com/gamzabat/algohub/AlgohubApplication.java
@@ -1,5 +1,7 @@
 package com.gamzabat.algohub;
 
+import java.util.TimeZone;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -9,6 +11,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class AlgohubApplication {
 
 	public static void main(String[] args) {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
 		SpringApplication.run(AlgohubApplication.class, args);
 	}
 


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close #272 

## 🚀 Description
<!-- 작업 내용 -->
-  서버타임이 무조건 KST가 되도록 못박습니다 

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
- KST는 인식 못하고 Asia/Seoul이라고 써줘야 인식하는 슬픈 현실

