### PR TITLE
fix : JwtFilter 예외 엔드포인트 추가

### DIFF
--- a/src/main/java/com/gamzabat/algohub/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/JwtAuthenticationFilter.java
@@ -21,12 +21,22 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private final TokenProvider tokenProvider;
-	private final List<String> excludedPaths = Arrays.asList("/api/auth/sign-in", "/api/auth/sign-up",
-		"/api/auth/reissue-token");
+	private final List<String> excludedPaths = Arrays.asList(
+		"/swagger-ui",
+		"/v3/api-docs",
+		"/api/auth/sign-in",
+		"/api/auth/sign-up",
+		"/api/auth/reissue-token",
+		"/api/users/check-email",
+		"/api/users/check-nickname",
+		"/api/users/check-baekjoon-nickname");
 
 	@Override
 	protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
 		String path = request.getRequestURI();
+		if (path.startsWith("/api/users/") && request.getMethod().equals("GET"))
+			return !path.equals("/api/users/me");
+
 		return excludedPaths.stream().anyMatch(path::startsWith);
 	}
 

--- a/src/main/java/com/gamzabat/algohub/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/JwtAuthenticationFilter.java
@@ -50,10 +50,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
-		if (shouldNotFilter(request)) {
-			filterChain.doFilter(request, response);
-			return;
-		}
 		try {
 			String token = tokenProvider.resolveToken(request);
 			if (token != null && tokenProvider.validateToken(token)) {

--- a/src/main/java/com/gamzabat/algohub/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.gamzabat.algohub.common.jwt;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -34,10 +35,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	@Override
 	protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
 		String path = request.getRequestURI();
-		if (path.startsWith("/api/users/") && request.getMethod().equals("GET"))
-			return !path.equals("/api/users/me");
+		if (excludedPaths.stream().anyMatch(path::startsWith))
+			return true;
 
-		return excludedPaths.stream().anyMatch(path::startsWith);
+		return isOtherUserInfoEndpoint(path);
+	}
+
+	private static boolean isOtherUserInfoEndpoint(String path) {
+		Pattern infoPattern = Pattern.compile("^/api/users/(?!me$)[^/]+$");
+		Pattern groupsPattern = Pattern.compile("^/api/users/(?!me)[^/]+/groups$");
+		return infoPattern.matcher(path).matches() || groupsPattern.matcher(path).matches();
 	}
 
 	@Override

--- a/src/main/java/com/gamzabat/algohub/common/jwt/TokenProvider.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/TokenProvider.java
@@ -161,7 +161,7 @@ public class TokenProvider {
 		String token = request.getHeader("Authorization");
 		if (StringUtils.hasValue(token) && token.startsWith("Bearer"))
 			return token.substring(7);
-		return null;
+		throw new JwtRequestException(HttpStatus.BAD_REQUEST.value(), "BAD_REQUEST", "유효한 형태의 토큰이 존재하지 않습니다.");
 	}
 
 	private Claims getClaims(String expiredToken) {

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -29,7 +29,6 @@ import com.gamzabat.algohub.common.jwt.dto.ReissueTokenRequest;
 import com.gamzabat.algohub.common.redis.RedisService;
 import com.gamzabat.algohub.enums.ImageType;
 import com.gamzabat.algohub.enums.Role;
-import com.gamzabat.algohub.exception.JwtRequestException;
 import com.gamzabat.algohub.exception.UserValidationException;
 import com.gamzabat.algohub.feature.group.studygroup.exception.CannotFoundUserException;
 import com.gamzabat.algohub.feature.image.service.ImageService;
@@ -168,9 +167,6 @@ public class UserService {
 	@Transactional
 	public void logout(HttpServletRequest request) {
 		String accessToken = tokenProvider.resolveToken(request);
-		if (accessToken == null)
-			throw new JwtRequestException(HttpStatus.BAD_REQUEST.value(), "BAD_REQUEST", "토큰이 비어있습니다.");
-
 		long tokenExpiration = tokenProvider.getAccessTokenExpirationTime();
 		redisService.setValues(accessToken, "logout", Duration.ofMillis(tokenExpiration));
 		log.info("success to logout");

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -5,8 +5,6 @@ import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Field;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -39,7 +37,6 @@ import com.gamzabat.algohub.common.jwt.dto.JwtDTO;
 import com.gamzabat.algohub.common.redis.RedisService;
 import com.gamzabat.algohub.enums.ImageType;
 import com.gamzabat.algohub.enums.Role;
-import com.gamzabat.algohub.exception.JwtRequestException;
 import com.gamzabat.algohub.exception.UserValidationException;
 import com.gamzabat.algohub.feature.group.studygroup.exception.CannotFoundUserException;
 import com.gamzabat.algohub.feature.image.service.ImageService;
@@ -259,20 +256,6 @@ class UserServiceTest {
 		userService.logout(request);
 		// then
 		verify(redisService, times(1)).setValues(eq(token), eq("logout"), eq(Duration.ofMillis(6000L)));
-	}
-
-	@Test
-	@DisplayName("로그아웃 실패 : 비어있는 토큰")
-	void logoutFailed() {
-		// given
-		HttpServletRequest request = mock(HttpServletRequest.class);
-		when(tokenProvider.resolveToken(request)).thenReturn(null);
-		// when, then
-		assertThatThrownBy(() -> userService.logout(request))
-			.isInstanceOf(JwtRequestException.class)
-			.hasFieldOrPropertyWithValue("code", HttpStatus.BAD_REQUEST.value())
-			.hasFieldOrPropertyWithValue("error", "BAD_REQUEST")
-			.hasFieldOrPropertyWithValue("messages", new ArrayList<>(List.of("토큰이 비어있습니다.")));
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://github.com/GAMZA-BAT/algohub-server/issues/271

## 🚀 Description
<!-- 작업 내용 -->
- 저번 Issue에서 로그아웃 시 Jwt가 null인 케이스를 JwtFilter에서 예외를 던질 수 있도록 수정했었습니다.
- 그랬더니 API 전체가 펑 터졌네요 ㅎㅎ
- Swagger 엔드포인트가 JwtFilter를 거치면서 예외가 발생하고 접속 자체가 안되더라고요.
- Swagger 관련 엔트포인트와 추가로 토큰 없이 호출할 수 있는 API들도 JwtFilter를 거치지 않도록 예외 리스트에 추가했습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
- `/api/users/{userNickname}`과 `/api/users/{userNickname}/groups`의 경우, path variable을 사용합니다.
- 이 부분에서 `/api/users/me`, `/api/users/me/groups`와 구분해서 필터링 하는 것이 꽤 까다로워서 정규식을 사용했습니다.
- 더 깔끔하게 구분할 수 있는 코드가 있을지 모르겠네요.. 의견 있다면 피드백 부탁드려요!

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->