### PR TITLE
env : Apply https for swagger

### DIFF
--- a/src/main/java/com/gamzabat/algohub/config/SwaggerConfig.java
+++ b/src/main/java/com/gamzabat/algohub/config/SwaggerConfig.java
@@ -1,18 +1,27 @@
 package com.gamzabat.algohub.config;
 
+import java.util.Arrays;
 import java.util.Collections;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import com.gamzabat.algohub.constants.ApiConstants;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 
 @Configuration
 public class SwaggerConfig {
+
+	@Value("${server.port}")
+	private String serverPort;
+
 	@Bean
 	public OpenAPI openAPI() {
 		SecurityScheme scheme = new SecurityScheme()
@@ -20,12 +29,22 @@ public class SwaggerConfig {
 			.in(SecurityScheme.In.HEADER).name("Authorization");
 		SecurityRequirement requirement = new SecurityRequirement().addList("bearerAuth");
 
+		Server prodServer = new Server();
+		prodServer.setDescription("Algohub API");
+		prodServer.setUrl(ApiConstants.SERVER_HTTPS_ENDPOINT);
+
+		Server localServer = new Server();
+		localServer.setDescription("Algohub API for LOCAL");
+		localServer.setUrl("http://localhost:" + serverPort);
+
 		return new OpenAPI()
 			.components(new Components().addSecuritySchemes("bearerAuth", scheme))
 			.security(Collections.singletonList(requirement))
 			.info(new Info()
 				.title("AlgoHub API 명세서")
 				.description("AlgoHub API 명세서 입니다.")
-				.version("1.0.0"));
+				.version("1.0.0"))
+			.servers(Arrays.asList(localServer, prodServer));
+
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/constants/ApiConstants.java
+++ b/src/main/java/com/gamzabat/algohub/constants/ApiConstants.java
@@ -4,6 +4,7 @@ public final class ApiConstants {
 	public static final String SOLVED_AC_PROBLEM_API_URL = "https://solved.ac/api/v3/problem/lookup?problemIds=";
 	public static final String BOJ_USER_PROFILE_URL = "https://www.acmicpc.net/user/";
 	public static final String BOJ_PROBLEM_URL = "www.acmicpc.net";
+	public static final String SERVER_HTTPS_ENDPOINT = "https://api.algohub.kr";
 
 	private ApiConstants() {
 		throw new RuntimeException("Can not instantiate : ApiConstants");


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close #290 

## 🚀 Description
<!-- 작업 내용 -->
- 우리이제 https됨
<img width="1146" alt="image" src="https://github.com/user-attachments/assets/66571524-ae32-4703-b5b9-5fa3e6a9ae7c" />


## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
- Swagger에서 이제 localhost (http)와, Prod 환경 서버를 골라서 테스트할 수 있게 했어요.
- 왜냐면, Swagger는 기본적으로 http 프로토콜만 지원합니다. 
    - 배포된 환경은 이제 https 프로토콜을 사용하는데, Swagger를 사용하면 api 요청은 http 엔드포인트로 보냅니다.
    - HTTPS에서 HTTP로 요청을 보내면 CORS 위배입니다. 따라서 브라우저가 block합니다
    - 그래서 명시적으로 우리의 https endpoint를 지정해주되, 우리(개발자)를 위해 Localhost도 넣어놨습니다.
<img width="552" alt="image" src="https://github.com/user-attachments/assets/6867c405-f20b-44a5-99e8-9bdec5b453a5" />


## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->