### PR TITLE
fix : 문제 관련 알림 전송 no session 에러 해결

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
@@ -281,6 +281,7 @@ public class ProblemService {
 		return response;
 	}
 
+	@Transactional
 	@Scheduled(cron = "0 0 0 * * ?", zone = "Asia/Seoul")
 	public void dailyProblemScheduler() {
 		LocalDate now = LocalDate.now();


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://github.com/GAMZA-BAT/algohub-server/issues/298

## 🚀 Description
<!-- 작업 내용 -->
- 아래는 문제 시작 알림 전송 스케줄러에 관한 에러 내용 일부입니다.
```
20250119T000002 scheduling-1 ERROR o.s.s.s.TaskUtils$LoggingErrorHandler Unexpected error occurred in scheduled task
org.hibernate.LazyInitializationException: could not initialize proxy [com.gamzabat.algohub.feature.user.domain.User#8] - no Session
...
```
- `LazyInitializationException`
    - 지연 로딩으로 엔티티를 로딩할 때, 해당 엔티티가 포함된 영속성 컨텍스트가 닫혀있거나 접근할 수 없는 상태일 경우 발생합니다.
- JPA의 지연로딩(`fetch = FetchType.LAZY`)이란, 필요한 시점에 연관된 객체의 데이터를 불러오는 것을 의미합니다.
    - ex ) 현재 `GroupMember` 에서 지연로딩하는 `User`
        
        ```java
        @ManyToOne(fetch = FetchType.LAZY)
        @JoinColumn(name = "user_id")
        private User user;
        ```
        
    - `groupMember.getUser()` : 프록시 객체 리턴 -> select user 쿼리 수행 X
    - `groupMember.getUser().getEmail()` => User의 실제 데이터가 필요하므로 이 때 select user 쿼리 수행 O
- 기본적으로 지연로딩은 객체가 영속성 컨텍스트에 있어야 한다는 조건이 있습니다.
    > 영속성 컨텍스트가 뭐에요? 
         데이터의 가상 저장소라고 생각하면 됩니다. DB에서 한 번 조회하고 나면 추가 DB 접근 필요 없이 사용할 수 있도록 저장하는 곳입니다. 
        
- 우리는 OSIV 설정을 안 했으므로 영속성 컨텍스트가 유지되는 범위는 `@Transactional` 적용 범위가 됩니다.

---
### Exception 발생 경로

1. 기존에 문제 관련 알림 스케줄러 메소드는 `@Transactional`이 없었습니다.
    
    ```java
    @Scheduled(cron = "0 0 0 * * ?", zone = "Asia/Seoul")
    public void dailyProblemScheduler() {
    		LocalDate now = LocalDate.now();
    		notifyProblemStartsToday(now);
    		notifyProblemEndsToday(now);
    }
    
    private void notifyProblemStartsToday(LocalDate now) {
        List<Problem> problems = problemRepository.findAllByStartDate(now);
        for (Problem problem : problems) {
            notificationService.sendNotificationToMembers(
                problem.getStudyGroup(),
                groupMemberRepository.findAllByStudyGroup(problem.getStudyGroup()),
                problem,
                ...
            );
        }
    }
    ...
    ```
    
  - 즉, 위 코드에서`problems`와 `groupMemberRepository.findAllByStudyGroup()` 으로 찾은 데이터들은 **영속성 컨텍스트에 포함되지 않습니다.**
2. 이 상태로 `sendNotificationToMembers()` 메소드를 호출하면서, 파라미터로는 영속성 컨텍스트에 포함 안된 members를 넘겨줍니다.
3. `sendNotificationToMembers()` 메소드의 로직 중, 아래 코드에서 에러가 발생합니다.
    
    ```java
    if (setting.isAllNotifications() && isSettingOn(setting, category))
    		users.add(member.getUser().getEmail());
    ```
    
- `member.getUser().getEmail()` 로 지연 조회 하려는데, member 객체가 현재 영속성 컨텍스트에 포함되지 않으니 `LazyInitializationException` 가 발생합니다.
    - 만약 `member.getUser()` 까지만 했다면 User 프록시 객체를 반환하므로 위 에러가 발생하지 않았을 것입니다.

---
- 기존에 영속성 컨텍스트에 포함되지 않던 members가 포함될 수 있도록 스케줄러 메소드 자체에 `@Trnasactional`을 붙여서 해결했습니다.
 ```java
@Transactional
@Scheduled(cron = "0 0 0 * * ?", zone = "Asia/Seoul")
public void dailyProblemScheduler() {
    ...
}
```


## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->
- 사실 테스트는 안해봤습니다. 스케줄러 테스트는 어떻게 할 지도 모르겠어요 정각까지 대기해야하나요?