### PR TITLE
refactor : 닉네임 검증 시 한글 제한 추가 

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -225,7 +225,7 @@ public class UserService {
 	public void checkNickname(String nickname) {
 		if (isInvalidNicknameForm(nickname))
 			throw new CheckNicknameValidationException(HttpStatus.BAD_REQUEST.value(),
-				"닉네임은 3글자 이상, 16글자 이하이며 특수문자 불가입니다.");
+				"닉네임은 영문과 숫자로 구성된 3~16글자여야 합니다.");
 
 		if (userRepository.existsByNickname(nickname))
 			throw new CheckNicknameValidationException(HttpStatus.CONFLICT.value(), "이미 사용 중인 닉네임입니다.");
@@ -244,7 +244,7 @@ public class UserService {
 	}
 
 	private boolean isInvalidNicknameForm(String nickname) {
-		String regex = "[^a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ]";
+		String regex = "[^a-zA-Z0-9]";
 		return nickname.length() < 3 || nickname.length() > 16 || Pattern.compile(regex).matcher(nickname).find();
 	}
 

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -357,7 +357,7 @@ class UserServiceTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {"***asdf", "16글자가초과된nickname입니다", "ab"})
+	@ValueSource(strings = {"***asdf", "16asdfasdfnicknameasdf", "ab"})
 	@DisplayName("닉네임 중복 검사 : 잘못된 형식의 닉네임")
 	void checkNickname_2(String invalidNickname) {
 		// given
@@ -365,7 +365,7 @@ class UserServiceTest {
 		assertThatThrownBy(() -> userService.checkNickname(invalidNickname))
 			.isInstanceOf(CheckNicknameValidationException.class)
 			.hasFieldOrPropertyWithValue("code", HttpStatus.BAD_REQUEST.value())
-			.hasFieldOrPropertyWithValue("error", "닉네임은 3글자 이상, 16글자 이하이며 특수문자 불가입니다.");
+			.hasFieldOrPropertyWithValue("error", "닉네임은 영문과 숫자로 구성된 3~16글자여야 합니다.");
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://github.com/GAMZA-BAT/algohub-server/issues/300

## 🚀 Description
<!-- 작업 내용 -->
- 기존에 영문, 한글, 숫자 포함한 3~16글자의 닉네임 조건에서 한글을 뺐습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->