### PR TITLE
env : 에러 로그 웹훅 수정

### DIFF
--- a/src/main/java/com/gamzabat/algohub/common/logging/DiscordLogAppender.java
+++ b/src/main/java/com/gamzabat/algohub/common/logging/DiscordLogAppender.java
@@ -15,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.classic.spi.ThrowableProxyUtil;
@@ -26,30 +27,50 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @Setter
 public class DiscordLogAppender extends AppenderBase<ILoggingEvent> {
+
 	private String discordWebhookUrl;
 
 	@Override
 	protected void append(ILoggingEvent event) {
-		Map<String, String> mdcPropertyMap = event.getMDCPropertyMap();
-
-		String levelStr = event.getLevel().levelStr;
-		String exceptionBrief = "";
 		IThrowableProxy throwable = event.getThrowableProxy();
+		boolean isException = (throwable != null);
 
-		if (throwable != null) {
-			exceptionBrief = throwable.getClassName() + ": " + throwable.getMessage();
+		//  ERROR 레벨이지만 Throwable이 없는 경우 -> log.error
+		if (event.getLevel() == Level.ERROR && !isException) {
+			sendMinimalErrorLog(event);
+			return;
 		}
 
-		if (exceptionBrief.isEmpty()) {
-			exceptionBrief = "EXCEPTION 정보가 남지 않았습니다.";
-		}
+		sendDetailedLog(event);
+	}
+
+	private void sendMinimalErrorLog(ILoggingEvent event) {
+		String levelStr = event.getLevel().levelStr;
 
 		Map<String, Object> embed = new HashMap<>();
-		embed.put("title", "[" + levelStr + "] Exception 발생");
+		embed.put("title", "[" + levelStr + "] 에러 로그 탐지");
 		embed.put("color", getColorForLevel(levelStr));
 		embed.put("timestamp", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
 
-		// Embed Fields
+		List<Map<String, String>> fields = new ArrayList<>();
+		fields.add(createField("에러 메시지", event.getFormattedMessage(), false));
+		embed.put("fields", fields);
+
+		sendToDiscordEmbed(embed);
+	}
+
+	private void sendDetailedLog(ILoggingEvent event) {
+		Map<String, String> mdcPropertyMap = event.getMDCPropertyMap();
+		String levelStr = event.getLevel().levelStr;
+		IThrowableProxy throwable = event.getThrowableProxy();
+
+		String exceptionBrief = throwable.getClassName() + ": " + throwable.getMessage();
+
+		Map<String, Object> embed = new HashMap<>();
+		embed.put("title", "[" + levelStr + "] " + "Exception 발생");
+		embed.put("color", getColorForLevel(levelStr));
+		embed.put("timestamp", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
+
 		List<Map<String, String>> fields = new ArrayList<>();
 		fields.add(createField("문제 간략 내용", exceptionBrief, false));
 		fields.add(createField("요청 URI", escape(mdcPropertyMap.get(MDCUtil.MDC_REQUEST_URI)), true));
@@ -58,22 +79,13 @@ public class DiscordLogAppender extends AppenderBase<ILoggingEvent> {
 		fields.add(createField("파라미터", escape(mdcPropertyMap.get(MDCUtil.MDC_PARAMETER)), true));
 		fields.add(createField("요청 Body", escape(mdcPropertyMap.get(MDCUtil.MDC_REQUEST_BODY)), true));
 
+		// Stacktrace
+		String exceptionDetail = ThrowableProxyUtil.asString(throwable);
+		fields.add(createField("Exception 상세 내용", truncate(exceptionDetail), false));
+
 		embed.put("fields", fields);
 
-		if (throwable != null) {
-			String exceptionDetail = ThrowableProxyUtil.asString(throwable);
-			fields.add(createField("Exception 상세 내용", truncate(exceptionDetail), false));
-		}
-
 		sendToDiscordEmbed(embed);
-	}
-
-	private Map<String, String> createField(String name, String value, boolean inline) {
-		Map<String, String> field = new HashMap<>();
-		field.put("name", name);
-		field.put("value", value != null ? value : "없음");
-		field.put("inline", String.valueOf(inline));
-		return field;
 	}
 
 	private void sendToDiscordEmbed(Map<String, Object> embed) {
@@ -88,7 +100,6 @@ public class DiscordLogAppender extends AppenderBase<ILoggingEvent> {
 
 		try {
 			ResponseEntity<String> response = restTemplate.postForEntity(discordWebhookUrl, request, String.class);
-
 			if (!response.getStatusCode().is2xxSuccessful()) {
 				addError("Failed to send log message to Discord: " + response.getStatusCode());
 			}
@@ -97,13 +108,23 @@ public class DiscordLogAppender extends AppenderBase<ILoggingEvent> {
 		}
 	}
 
+	private Map<String, String> createField(String name, String value, boolean inline) {
+		Map<String, String> field = new HashMap<>();
+		field.put("name", name);
+		field.put("value", value != null ? value : "없음");
+		field.put("inline", String.valueOf(inline));
+		return field;
+	}
+
 	private String escape(String value) {
 		return value != null ? StringEscapeUtils.escapeJson(value) : "없음";
 	}
 
 	private String truncate(String value) {
 		final int MAX_LENGTH = 1000;
-		return value != null && value.length() > MAX_LENGTH ? value.substring(0, MAX_LENGTH) + "..." : value;
+		return value != null && value.length() > MAX_LENGTH
+			? value.substring(0, MAX_LENGTH) + "..."
+			: value;
 	}
 
 	private int getColorForLevel(String level) {
@@ -116,5 +137,4 @@ public class DiscordLogAppender extends AppenderBase<ILoggingEvent> {
 			default -> 0x000000; // Black
 		};
 	}
-
 }


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close #311 

## 🚀 Description
<!-- 작업 내용 -->
- 디스코드에 에러 발생시 알림이 날아옵니다. Exception 발생시엔 괜찮았는데, `log.error`는 정상 작동하지 않았어요.
AS - IS
<img width="333" alt="스크린샷 2025-01-25 오후 11 51 36" src="https://github.com/user-attachments/assets/05eb4486-d9d2-4878-879b-03ac319a4969" />

TO - BE
<img width="239" alt="image" src="https://github.com/user-attachments/assets/58ae9512-01a9-4ba9-bb0d-36a3bb80ce00" />

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
- Throwable 객체가 담겨있을때는 Exception, 아닌 경우엔 log.error입니다. 이 점을 인지하고 보시면 편할 것 같아요.

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->