### PR TITLE
fix : skip jwt exists checking for add solution api

### DIFF
--- a/src/main/java/com/gamzabat/algohub/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/JwtAuthenticationFilter.java
@@ -28,6 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		"/api/auth/sign-in",
 		"/api/auth/sign-up",
 		"/api/auth/reissue-token",
+		"/api/solutions",
 		"/api/users/check-email",
 		"/api/users/check-nickname",
 		"/api/users/check-baekjoon-nickname",


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close #316 

## 🚀 Description
<!-- 작업 내용 -->
- 익스텐션으로 풀이 추가하는데, 이떄는 당연히 jwt가 없습니다. 그러나 jwt ㅇ ㅖ외처리가 안되어서 정상 호출이 안되고 있었어요.


## 아무나 보자마자 머지좀 