### PR TITLE
feat : Implement reset-password

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,8 +64,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     // OAuth2
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    //email
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework.retry:spring-retry'
 }
-
 clean {
     delete file('src/main/generated')
 }
@@ -87,7 +90,7 @@ tasks.named("processResources") {
     dependsOn("preScript")
 }
 
-tasks.named("bootRun"){
+tasks.named("bootRun") {
     dependsOn("preScript")
 }
 

--- a/prepare-build.sh
+++ b/prepare-build.sh
@@ -27,5 +27,6 @@ download_yml "mysql-dev.yml"
 download_yml "mysql-prod.yml"
 download_yml "webhook.yml"
 download_yml "github.yml"
+download_yml "smtp.yml"
 
 wait

--- a/src/main/java/com/gamzabat/algohub/AlgohubApplication.java
+++ b/src/main/java/com/gamzabat/algohub/AlgohubApplication.java
@@ -4,9 +4,13 @@ import java.util.TimeZone;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling
+@EnableAsync
+@EnableRetry
 @SpringBootApplication
 public class AlgohubApplication {
 

--- a/src/main/java/com/gamzabat/algohub/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/JwtAuthenticationFilter.java
@@ -29,6 +29,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		"/api/auth/sign-up",
 		"/api/auth/reissue-token",
 		"/api/solutions",
+		"/api/auth/reset-password",
 		"/api/users/check-email",
 		"/api/users/check-nickname",
 		"/api/users/check-baekjoon-nickname",

--- a/src/main/java/com/gamzabat/algohub/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/gamzabat/algohub/exception/CustomExceptionHandler.java
@@ -29,6 +29,7 @@ import com.gamzabat.algohub.feature.user.exception.CheckBjNicknameValidationExce
 import com.gamzabat.algohub.feature.user.exception.CheckEmailFormException;
 import com.gamzabat.algohub.feature.user.exception.CheckNicknameValidationException;
 import com.gamzabat.algohub.feature.user.exception.CheckPasswordFormException;
+import com.gamzabat.algohub.feature.user.exception.ResetPasswordValidationError;
 import com.gamzabat.algohub.feature.user.exception.UncorrectedPasswordException;
 
 @ControllerAdvice
@@ -189,5 +190,11 @@ public class CustomExceptionHandler {
 	protected ResponseEntity<ErrorResponse> handler(GithubApiException e) {
 		return ResponseEntity.internalServerError()
 			.body(new ErrorResponse(HttpStatus.SERVICE_UNAVAILABLE.value(), e.getMessage(), null));
+	}
+
+	@ExceptionHandler(ResetPasswordValidationError.class)
+	protected ResponseEntity<ErrorResponse> handler(ResetPasswordValidationError e) {
+		return ResponseEntity.badRequest()
+			.body(new ErrorResponse(HttpStatus.BAD_REQUEST.value(), e.getMessage(), null));
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/exception/MessagingRuntimeException.java
+++ b/src/main/java/com/gamzabat/algohub/exception/MessagingRuntimeException.java
@@ -1,0 +1,7 @@
+package com.gamzabat.algohub.exception;
+
+public class MessagingRuntimeException extends RuntimeException {
+	public MessagingRuntimeException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
@@ -23,6 +23,7 @@ import com.gamzabat.algohub.feature.user.dto.CheckEmailRequest;
 import com.gamzabat.algohub.feature.user.dto.DeleteUserRequest;
 import com.gamzabat.algohub.feature.user.dto.EditUserPasswordRequest;
 import com.gamzabat.algohub.feature.user.dto.RegisterRequest;
+import com.gamzabat.algohub.feature.user.dto.ResetPasswordRequest;
 import com.gamzabat.algohub.feature.user.dto.SignInRequest;
 import com.gamzabat.algohub.feature.user.dto.TokenResponse;
 import com.gamzabat.algohub.feature.user.dto.UpdateUserRequest;
@@ -150,5 +151,21 @@ public class UserController {
 		@PathVariable String userNickname) {
 		UserInfoResponse userInfo = userService.otherUserInfo(userNickname);
 		return ResponseEntity.ok().body(userInfo);
+	}
+
+	@PostMapping(value = "/auth/reset-password")
+	@Operation(summary = "비밀번호 초기화 메일 발송 API")
+	public ResponseEntity<Void> sendResetPasswordMail(@RequestParam String email) {
+		userService.sendResetPasswordMail(email);
+		return ResponseEntity.ok().build();
+	}
+
+	@PatchMapping("/auth/reset-password")
+	@Operation(summary = "비밀번호 재설정 API")
+	public ResponseEntity<Void> resetPassword(@RequestBody ResetPasswordRequest request, Errors errors) {
+		if (errors.hasErrors())
+			throw new RequestException("비밀번호 재설정 요청이 올바르지 않습니다.", errors);
+		userService.resetPassword(request);
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/domain/ResetPassword.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/domain/ResetPassword.java
@@ -1,0 +1,43 @@
+package com.gamzabat.algohub.feature.user.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class ResetPassword {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	private String token;
+
+	private LocalDateTime expiredAt;
+
+	private Boolean done = false;
+
+	@Builder
+	public ResetPassword(User user, String token) {
+		this.user = user;
+		this.token = token;
+		this.expiredAt = LocalDateTime.now().plusHours(3);
+	}
+
+	public void makeDone() {
+		this.done = true;
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/feature/user/dto/ResetPasswordRequest.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/dto/ResetPasswordRequest.java
@@ -1,0 +1,8 @@
+package com.gamzabat.algohub.feature.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ResetPasswordRequest(
+	@NotBlank String token,
+	@NotBlank String password) {
+}

--- a/src/main/java/com/gamzabat/algohub/feature/user/dto/ResetPasswordRequest.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/dto/ResetPasswordRequest.java
@@ -3,6 +3,6 @@ package com.gamzabat.algohub.feature.user.dto;
 import jakarta.validation.constraints.NotBlank;
 
 public record ResetPasswordRequest(
-	@NotBlank String token,
-	@NotBlank String password) {
+	@NotBlank(message = "비밀번호 재설정 토큰은 필수 항목입니다.") String token,
+	@NotBlank(message = "변경할 비밀번호는 필수 항목입니다.") String password) {
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/exception/ResetPasswordValidationError.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/exception/ResetPasswordValidationError.java
@@ -1,0 +1,7 @@
+package com.gamzabat.algohub.feature.user.exception;
+
+public class ResetPasswordValidationError extends RuntimeException {
+	public ResetPasswordValidationError(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/feature/user/repository/ResetPasswordRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/repository/ResetPasswordRepository.java
@@ -1,0 +1,14 @@
+package com.gamzabat.algohub.feature.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.gamzabat.algohub.feature.user.domain.ResetPassword;
+
+public interface ResetPasswordRepository extends JpaRepository<ResetPassword, Long> {
+
+	@Query("select r from ResetPassword r join fetch r.user where r.token = :token")
+	Optional<ResetPassword> findByToken(String token);
+}

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/EmailService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/EmailService.java
@@ -1,0 +1,64 @@
+package com.gamzabat.algohub.feature.user.service;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import com.gamzabat.algohub.exception.MessagingRuntimeException;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EmailService {
+	private static final String FROM_ADDRESS = "noreply@algohub.kr";
+	private static final String RESET_PASSWORD_SUBJECT = "[AlgoHub] 비밀번호 찾기";
+	//TODO: When the work is completed on the client side, it needs to be replaced with the appropriate URL.
+	private static final String RESET_PASSWORD_CLIENT_ENDPOINT = "https://algohub.kr";
+	private final JavaMailSender mailSender;
+	private final TemplateEngine templateEngine;
+
+	@Async
+	@Retryable(
+		retryFor = {MessagingException.class},
+		backoff = @org.springframework.retry.annotation.Backoff(delay = 3000)
+	)
+	public CompletableFuture<Void> sendResetPasswordMail(String to, String token) {
+		Context context = new Context();
+		context.setVariable("verificationUrl", RESET_PASSWORD_CLIENT_ENDPOINT + "?token=" + token);
+		String emailContent = templateEngine.process("reset-password", context);
+		MimeMessage message = mailSender.createMimeMessage();
+
+		try {
+
+			MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+			helper.setTo(to);
+			helper.setFrom(FROM_ADDRESS);
+			helper.setSubject(RESET_PASSWORD_SUBJECT);
+			helper.setText(emailContent, true);
+			mailSender.send(message);
+			return CompletableFuture.completedFuture(null);
+		} catch (MessagingException e) {
+			log.warn("Failed to send email, retry. : {}", e.toString());
+			throw new MessagingRuntimeException(e);
+		}
+	}
+
+	@Recover
+	public CompletableFuture<Void> failedToSendResetPasswordMail(MessagingRuntimeException e, String to, String token) {
+		log.error("Failed to send reset password email to {} after retries. Exception: {}", to, e.getMessage(), e);
+
+		return CompletableFuture.completedFuture(null);
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/EmailService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/EmailService.java
@@ -58,7 +58,8 @@ public class EmailService {
 	@Recover
 	public CompletableFuture<Void> failedToSendResetPasswordMail(MessagingRuntimeException e, String to, String token) {
 		log.error("Failed to send reset password email to {} after retries. Exception: {}", to, e.getMessage(), e);
-
-		return CompletableFuture.completedFuture(null);
+		CompletableFuture<Void> failedFuture = new CompletableFuture<>();
+		failedFuture.completeExceptionally(e);
+		return failedFuture;
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -4,7 +4,10 @@ import static com.gamzabat.algohub.constants.ApiConstants.*;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Base64;
 import java.util.regex.Pattern;
 
 import org.springframework.http.HttpEntity;
@@ -32,10 +35,12 @@ import com.gamzabat.algohub.enums.Role;
 import com.gamzabat.algohub.exception.UserValidationException;
 import com.gamzabat.algohub.feature.group.studygroup.exception.CannotFoundUserException;
 import com.gamzabat.algohub.feature.image.service.ImageService;
+import com.gamzabat.algohub.feature.user.domain.ResetPassword;
 import com.gamzabat.algohub.feature.user.domain.User;
 import com.gamzabat.algohub.feature.user.dto.DeleteUserRequest;
 import com.gamzabat.algohub.feature.user.dto.EditUserPasswordRequest;
 import com.gamzabat.algohub.feature.user.dto.RegisterRequest;
+import com.gamzabat.algohub.feature.user.dto.ResetPasswordRequest;
 import com.gamzabat.algohub.feature.user.dto.SignInRequest;
 import com.gamzabat.algohub.feature.user.dto.TokenResponse;
 import com.gamzabat.algohub.feature.user.dto.UpdateUserRequest;
@@ -45,7 +50,9 @@ import com.gamzabat.algohub.feature.user.exception.CheckBjNicknameValidationExce
 import com.gamzabat.algohub.feature.user.exception.CheckEmailFormException;
 import com.gamzabat.algohub.feature.user.exception.CheckNicknameValidationException;
 import com.gamzabat.algohub.feature.user.exception.CheckPasswordFormException;
+import com.gamzabat.algohub.feature.user.exception.ResetPasswordValidationError;
 import com.gamzabat.algohub.feature.user.exception.UncorrectedPasswordException;
+import com.gamzabat.algohub.feature.user.repository.ResetPasswordRepository;
 import com.gamzabat.algohub.feature.user.repository.UserRepository;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -63,6 +70,8 @@ public class UserService {
 	private final AuthenticationManagerBuilder authManager;
 	private final RedisService redisService;
 	private final RestTemplate restTemplate;
+	private final ResetPasswordRepository resetPasswordRepository;
+	private final EmailService emailService;
 
 	@Transactional
 	public void register(RegisterRequest request, MultipartFile profileImage) {
@@ -261,6 +270,40 @@ public class UserService {
 		return response;
 	}
 
+	@Transactional
+	public void sendResetPasswordMail(String email) {
+		User user = userRepository.findByEmail(email)
+			.orElseThrow(() -> new CannotFoundUserException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 이메일의 유저입니다."));
+		String token = UserService.generateSecureToken();
+		ResetPassword resetPassword = ResetPassword.builder()
+			.user(user)
+			.token(token)
+			.build();
+		resetPasswordRepository.save(resetPassword);
+		log.info("success to create reset password token. Token: {}", resetPassword.getToken());
+
+		emailService.sendResetPasswordMail(user.getEmail(), token).thenAccept(unused ->
+			log.info("success to send reset password mail.")
+		);
+	}
+
+	@Transactional
+	public void resetPassword(ResetPasswordRequest request) {
+		ResetPassword resetPassword = resetPasswordRepository.findByToken(request.token())
+			.orElseThrow(() -> new ResetPasswordValidationError("유효하지 않은 요청입니다."));
+		if (resetPassword.getExpiredAt().isBefore(LocalDateTime.now()))
+			throw new ResetPasswordValidationError("기한이 만료된 비밀번호 수정 요청입니다.");
+		if (resetPassword.getDone())
+			throw new ResetPasswordValidationError("이미 수정이 완료된 요청입니다.");
+		checkPasswordForm(request.password());
+
+		String encodedPassword = passwordEncoder.encode(request.password());
+		resetPassword.getUser().editPassword(encodedPassword);
+		resetPassword.makeDone();
+		log.info("success to reset password.");
+
+	}
+
 	private void checkEmailForm(String email) {
 		if (!isValidEmailForm(email))
 			throw new CheckEmailFormException(HttpStatus.BAD_REQUEST.value(), "이메일 형식이 아닙니다");
@@ -291,6 +334,13 @@ public class UserService {
 		}
 		return password.matches(passwordPattern);
 
+	}
+
+	private static String generateSecureToken() {
+		final int TOKEN_LENGTH = 32;
+		byte[] bytes = new byte[TOKEN_LENGTH];
+		new SecureRandom().nextBytes(bytes);
+		return Base64.getEncoder().withoutPadding().encodeToString(bytes);
 	}
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,7 @@ spring:
       - "jwt.yml"
       - "webhook.yml"
       - "github.yml"
+      - "smtp.yml"
   profiles:
     active: dev
     group:
@@ -41,6 +42,17 @@ spring:
   output:
     ansi:
       enabled: always
+  mail:
+    host: ${smtp-host}
+    port: 587
+    username: ${smtp-username}
+    password: ${smtp-password}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
 cloud:
   aws:
     s3:

--- a/src/main/resources/templates/reset-password.html
+++ b/src/main/resources/templates/reset-password.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>비밀번호 재설정</title>
+    <style type="text/css">
+        /* 인라인 CSS 사용 권장 (일부 이메일 클라이언트에서는 외부 CSS를 무시함) */
+        .button {
+            background-color: #007bff;
+            border: none;
+            color: white;
+            padding: 10px 20px;
+            text-align: center;
+            text-decoration: none;
+            display: inline-block;
+            font-size: 16px;
+            margin: 4px 2px;
+            cursor: pointer;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+<h2>비밀번호를 잊으셨군요?</h2>
+<p>아래 버튼을 클릭하여 비밀번호를 재설정 해주세요.</p>
+<a th:href="${verificationUrl}" class="button">비밀번호 재설정하기</a>
+</body>
+</html>

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -5,7 +5,9 @@ import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Field;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +19,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
@@ -40,10 +43,12 @@ import com.gamzabat.algohub.enums.Role;
 import com.gamzabat.algohub.exception.UserValidationException;
 import com.gamzabat.algohub.feature.group.studygroup.exception.CannotFoundUserException;
 import com.gamzabat.algohub.feature.image.service.ImageService;
+import com.gamzabat.algohub.feature.user.domain.ResetPassword;
 import com.gamzabat.algohub.feature.user.domain.User;
 import com.gamzabat.algohub.feature.user.dto.DeleteUserRequest;
 import com.gamzabat.algohub.feature.user.dto.EditUserPasswordRequest;
 import com.gamzabat.algohub.feature.user.dto.RegisterRequest;
+import com.gamzabat.algohub.feature.user.dto.ResetPasswordRequest;
 import com.gamzabat.algohub.feature.user.dto.SignInRequest;
 import com.gamzabat.algohub.feature.user.dto.TokenResponse;
 import com.gamzabat.algohub.feature.user.dto.UpdateUserRequest;
@@ -51,7 +56,10 @@ import com.gamzabat.algohub.feature.user.dto.UserInfoResponse;
 import com.gamzabat.algohub.feature.user.exception.BOJServerErrorException;
 import com.gamzabat.algohub.feature.user.exception.CheckBjNicknameValidationException;
 import com.gamzabat.algohub.feature.user.exception.CheckNicknameValidationException;
+import com.gamzabat.algohub.feature.user.exception.CheckPasswordFormException;
+import com.gamzabat.algohub.feature.user.exception.ResetPasswordValidationError;
 import com.gamzabat.algohub.feature.user.exception.UncorrectedPasswordException;
+import com.gamzabat.algohub.feature.user.repository.ResetPasswordRepository;
 import com.gamzabat.algohub.feature.user.repository.UserRepository;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -74,8 +82,14 @@ class UserServiceTest {
 	private RedisService redisService;
 	@Mock
 	private RestTemplate restTemplate;
+	@Mock
+	private ResetPasswordRepository resetPasswordRepository;
+	@Mock
+	private EmailService emailService;
 	@Captor
 	private ArgumentCaptor<User> userCaptor;
+	@Captor
+	private ArgumentCaptor<ResetPassword> passwordCaptor;
 
 	private final String email = "test@email.com";
 	private final String password = "password1!";
@@ -83,7 +97,9 @@ class UserServiceTest {
 	private final String encoded = "encoded";
 	private final String imageUrl = "1_test@email.com_image.jpg";
 	private final String bjNickname = "bjNickname";
+	private final String RESET_PASSWORD_TOKEN = "RESET_PASSWORD_TOKEN";
 	private User user;
+	private ResetPassword resetPassword;
 
 	@BeforeEach
 	void setUp() throws NoSuchFieldException, IllegalAccessException {
@@ -99,6 +115,14 @@ class UserServiceTest {
 		Field userId = User.class.getDeclaredField("id");
 		userId.setAccessible(true);
 		userId.set(user, 1L);
+
+		resetPassword = ResetPassword.builder()
+			.user(user)
+			.token(RESET_PASSWORD_TOKEN)
+			.build();
+		Field resetId = ResetPassword.class.getDeclaredField("id");
+		resetId.setAccessible(true);
+		resetId.set(resetPassword, 1L);
 	}
 
 	@Test
@@ -416,6 +440,116 @@ class UserServiceTest {
 				assertThat(ex.getCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
 				assertThat(ex.getError()).isEqualTo("해당 유저는 존재하지 않습니다.");
 			});
+	}
+
+	@Test
+	@DisplayName("비밀번호 변경 메일 발송 실패 : 존재하지 않는 유저 ")
+	void resetPasswordEmail_failed1() {
+		//given
+		when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+		//when, then
+		assertThatThrownBy(() -> userService.sendResetPasswordMail(email))
+			.isInstanceOf(CannotFoundUserException.class)
+			.satisfies(exception -> {
+				CannotFoundUserException ex = (CannotFoundUserException)exception;
+				assertThat(ex.getCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+				assertThat(ex.getError()).isEqualTo("존재하지 않는 이메일의 유저입니다.");
+			});
+	}
+
+	@Test
+	@DisplayName("비밀번호 변경 메일 발송 성공")
+	void resetPasswordEmail_suceess() {
+		//give
+		when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+		when(emailService.sendResetPasswordMail(eq(email), anyString())).thenReturn(
+			CompletableFuture.completedFuture(null));
+
+		//when
+		userService.sendResetPasswordMail(email);
+
+		//then
+		verify(resetPasswordRepository, times(1)).save(passwordCaptor.capture());
+		ResetPassword resetPassword = passwordCaptor.getValue();
+		assertThat(resetPassword.getUser()).isEqualTo(user);
+
+		verify(emailService, times(1)).sendResetPasswordMail(anyString(), anyString());
+
+	}
+
+	@Test
+	@DisplayName("비밀번호 변경 실패 : 없는 Token")
+	void resetPassword_failed1() {
+		//give
+		ResetPasswordRequest request = new ResetPasswordRequest(RESET_PASSWORD_TOKEN, password);
+		when(resetPasswordRepository.findByToken(RESET_PASSWORD_TOKEN)).thenReturn(Optional.empty());
+
+		//when, then
+		assertThatThrownBy(() -> userService.resetPassword(request))
+			.isInstanceOf(ResetPasswordValidationError.class)
+			.hasFieldOrPropertyWithValue("message", "유효하지 않은 요청입니다.");
+	}
+
+	@Test
+	@DisplayName("비밀번호 변경 실패 : 만료된 요청")
+	void resetPassword_failed2() {
+		//give
+		LocalDateTime now = LocalDateTime.now();
+		ResetPasswordRequest request = new ResetPasswordRequest(RESET_PASSWORD_TOKEN, password);
+		when(resetPasswordRepository.findByToken(RESET_PASSWORD_TOKEN)).thenReturn(Optional.of(resetPassword));
+
+		//when, then
+		try (MockedStatic<LocalDateTime> mockedStatic = mockStatic(LocalDateTime.class)) {
+			mockedStatic.when(LocalDateTime::now).thenReturn(now.plusHours(3));
+			assertThatThrownBy(() -> userService.resetPassword(request))
+				.isInstanceOf(ResetPasswordValidationError.class)
+				.hasFieldOrPropertyWithValue("message", "기한이 만료된 비밀번호 수정 요청입니다.");
+		}
+
+	}
+
+	@Test
+	@DisplayName("비밀번호 변경 실패 : 이미 완료된 토큰")
+	void resetPassword_failed3() {
+		//give
+		ResetPasswordRequest request = new ResetPasswordRequest(RESET_PASSWORD_TOKEN, password);
+		when(resetPasswordRepository.findByToken(RESET_PASSWORD_TOKEN)).thenReturn(Optional.of(resetPassword));
+		resetPassword.makeDone();
+		//when, then
+		assertThatThrownBy(() -> userService.resetPassword(request))
+			.isInstanceOf(ResetPasswordValidationError.class)
+			.hasFieldOrPropertyWithValue("message", "이미 수정이 완료된 요청입니다.");
+	}
+
+	@Test
+	@DisplayName("비밀번호 변경 실패 : 비밀번호 조건 만족 안함")
+	void resetPassword_failed4() {
+		//give
+		ResetPasswordRequest request = new ResetPasswordRequest(RESET_PASSWORD_TOKEN, "pass");
+		when(resetPasswordRepository.findByToken(RESET_PASSWORD_TOKEN)).thenReturn(Optional.of(resetPassword));
+		//when, then
+		assertThatThrownBy(() -> userService.resetPassword(request))
+			.isInstanceOf(CheckPasswordFormException.class)
+			.satisfies(exception -> {
+				CheckPasswordFormException ex = (CheckPasswordFormException)exception;
+				assertThat(ex.getCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+				assertThat(ex.getErrors()).isEqualTo("올바르지 않은 비밀번호 형식입니다");
+			});
+	}
+
+	@Test
+	@DisplayName("비밀번호 변경 성공")
+	void resetPassword_success() {
+		//give
+		ResetPasswordRequest request = new ResetPasswordRequest(RESET_PASSWORD_TOKEN, password);
+		when(resetPasswordRepository.findByToken(RESET_PASSWORD_TOKEN)).thenReturn(Optional.of(resetPassword));
+		//when
+		userService.resetPassword(request);
+		//then
+		verify(passwordEncoder, times(1)).encode(password);
+		assertThat(resetPassword.getDone()).isTrue();
+		assertThat(user.getPassword()).isEqualTo(passwordEncoder.encode(password));
 	}
 
 }


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close #323 

## 🚀 Description
<!-- 작업 내용 -->
- 비밀번호 찾기 기능을 구현합니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
비밀번호 찾기 플로우는 다음과 같아요
1. email을 기반으로 비밀번호 찾기 수행시, 비밀번호를 리셋할 수 있는 링크를 담아 email로 전송. 
    - 이 때, 유저를 식별할 수 있는 식별자를 같이 링크에 포함시킴. 이 식별자는 절대 유추할 수 없어야 함.  
2.  email의 링크에서 비밀번호 찾기 수행. 유효 기간은 3시간임.
    - url에 포함된 식별자를 기반으로 어떤 유저인지 체크하고, 비밀번호를 바꿔줌. 암호화 하는것과, 이 링크를 일회용으로 유지하는것 잊지 말기  

참고로 아직 클라이언트 작업이 안 되어서, 당장 이메일에 보내지는 링크로는 제대로 작동하지 않아요. 다만 클라 작업 완료되면 한 줄 변경만으로 완벽히 동작할거에요.
## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->
피처 구현은 오랜만이라 재밌었어요.

이제 우리 도메인(algohub)의 이메일을 가지려면, 메일서버가 필요해요.
많이 쓰는게 Google workspace인데, 유료입니다 (보통 메일 도메인과 서버를 가지면 기업이라서,,)
메일서버를 제 도커에 띄우는 방법도 있는데, 메일서버는 꽤나 무거워요. 램을 최소 3기가는 먹을거라서 띄우기 싫었습니다. 지금도 도커가 3기가정도 먹고있거든요 
그래서 한정된 무료 메일서버인 [zoho](https://www.zoho.com/)를 이용했어요. cloudflare랑 integration이 잘 되어있어서, 도메인 소유권 인증이나 여러 인증 과정이 원클릭이라 편했습니다.

아무튼 저 서비스에 들어가서, algohub.kr이 우리 도메인인지 인증한 다음
smtp 서비스를 통해 이메일을 쏠 수 있게 되었어요.
그래서 yml에 zoho에서 발급해준 username, password, host를 기재해두고 
smtp를 통해 이메일을 쏩니다. 