### PR TITLE
feat: Add reset-password token validation API

### DIFF
--- a/src/main/java/com/gamzabat/algohub/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gamzabat/algohub/common/jwt/JwtAuthenticationFilter.java
@@ -30,6 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		"/api/auth/reissue-token",
 		"/api/solutions",
 		"/api/auth/reset-password",
+		"/api/auth/check-password-token",
 		"/api/users/check-email",
 		"/api/users/check-nickname",
 		"/api/users/check-baekjoon-nickname",

--- a/src/main/java/com/gamzabat/algohub/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/gamzabat/algohub/exception/CustomExceptionHandler.java
@@ -195,6 +195,6 @@ public class CustomExceptionHandler {
 	@ExceptionHandler(ResetPasswordValidationError.class)
 	protected ResponseEntity<ErrorResponse> handler(ResetPasswordValidationError e) {
 		return ResponseEntity.badRequest()
-			.body(new ErrorResponse(HttpStatus.BAD_REQUEST.value(), e.getMessage(), null));
+			.body(new ErrorResponse(e.getCode(), e.getErrors(), null));
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
@@ -168,4 +168,11 @@ public class UserController {
 		userService.resetPassword(request);
 		return ResponseEntity.ok().build();
 	}
+
+	@GetMapping("/auth/check-password-token")
+	@Operation(summary = "비밀번호 재설정 토큰 유효성 검증 API")
+	public ResponseEntity<Void> checkPasswordToken(@RequestParam String token) {
+		userService.validateResetPasswordToken(token);
+		return ResponseEntity.ok().build();
+	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/exception/ResetPasswordValidationError.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/exception/ResetPasswordValidationError.java
@@ -1,7 +1,14 @@
 package com.gamzabat.algohub.feature.user.exception;
 
+import lombok.Getter;
+
+@Getter
 public class ResetPasswordValidationError extends RuntimeException {
-	public ResetPasswordValidationError(String message) {
-		super(message);
+	private final int code;
+	private final String errors;
+
+	public ResetPasswordValidationError(int code, String errors) {
+		this.code = code;
+		this.errors = errors;
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -289,19 +289,27 @@ public class UserService {
 
 	@Transactional
 	public void resetPassword(ResetPasswordRequest request) {
-		ResetPassword resetPassword = resetPasswordRepository.findByToken(request.token())
-			.orElseThrow(() -> new ResetPasswordValidationError("유효하지 않은 요청입니다."));
-		if (resetPassword.getExpiredAt().isBefore(LocalDateTime.now()))
-			throw new ResetPasswordValidationError("기한이 만료된 비밀번호 수정 요청입니다.");
-		if (resetPassword.getDone())
-			throw new ResetPasswordValidationError("이미 수정이 완료된 요청입니다.");
+		ResetPassword resetPassword = getValidatedResetPassword(request.token());
 		checkPasswordForm(request.password());
 
 		String encodedPassword = passwordEncoder.encode(request.password());
 		resetPassword.getUser().editPassword(encodedPassword);
 		resetPassword.makeDone();
 		log.info("success to reset password.");
+	}
 
+	public void validateResetPasswordToken(String token) {
+		this.getValidatedResetPassword(token);
+	}
+
+	private ResetPassword getValidatedResetPassword(String token) {
+		ResetPassword resetPassword = resetPasswordRepository.findByToken(token)
+			.orElseThrow(() -> new ResetPasswordValidationError(HttpStatus.BAD_REQUEST.value(), "유효하지 않은 요청입니다."));
+		if (resetPassword.getExpiredAt().isBefore(LocalDateTime.now()))
+			throw new ResetPasswordValidationError(HttpStatus.GONE.value(), "기한이 만료된 비밀번호 수정 요청입니다.");
+		if (resetPassword.getDone())
+			throw new ResetPasswordValidationError(HttpStatus.CONFLICT.value(), "이미 수정이 완료된 요청입니다.");
+		return resetPassword;
 	}
 
 	private void checkEmailForm(String email) {

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -488,7 +488,11 @@ class UserServiceTest {
 		//when, then
 		assertThatThrownBy(() -> userService.resetPassword(request))
 			.isInstanceOf(ResetPasswordValidationError.class)
-			.hasFieldOrPropertyWithValue("message", "유효하지 않은 요청입니다.");
+			.satisfies(exception -> {
+				ResetPasswordValidationError ex = (ResetPasswordValidationError)exception;
+				assertThat(ex.getCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+				assertThat(ex.getErrors()).isEqualTo("유효하지 않은 요청입니다.");
+			});
 	}
 
 	@Test
@@ -504,7 +508,11 @@ class UserServiceTest {
 			mockedStatic.when(LocalDateTime::now).thenReturn(now.plusHours(3));
 			assertThatThrownBy(() -> userService.resetPassword(request))
 				.isInstanceOf(ResetPasswordValidationError.class)
-				.hasFieldOrPropertyWithValue("message", "기한이 만료된 비밀번호 수정 요청입니다.");
+				.satisfies(exception -> {
+					ResetPasswordValidationError ex = (ResetPasswordValidationError)exception;
+					assertThat(ex.getCode()).isEqualTo(HttpStatus.GONE.value());
+					assertThat(ex.getErrors()).isEqualTo("기한이 만료된 비밀번호 수정 요청입니다.");
+				});
 		}
 
 	}
@@ -519,7 +527,11 @@ class UserServiceTest {
 		//when, then
 		assertThatThrownBy(() -> userService.resetPassword(request))
 			.isInstanceOf(ResetPasswordValidationError.class)
-			.hasFieldOrPropertyWithValue("message", "이미 수정이 완료된 요청입니다.");
+			.satisfies(exception -> {
+				ResetPasswordValidationError ex = (ResetPasswordValidationError)exception;
+				assertThat(ex.getCode()).isEqualTo(HttpStatus.CONFLICT.value());
+				assertThat(ex.getErrors()).isEqualTo("이미 수정이 완료된 요청입니다.");
+			});
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close #329 

## 🚀 Description
<!-- 작업 내용 -->
- 비밀번호 재설정 토큰 유효성 검사를 api로 분리합니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
- 많관부 
