### PR TITLE
feat : 댓글 읽기 API 추가

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/solution/domain/SolutionComment.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/domain/SolutionComment.java
@@ -22,11 +22,13 @@ public class SolutionComment extends Comment {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "solution_id")
 	private Solution solution;
+	private boolean isRead;
 
 	@Builder
-	public SolutionComment(Solution solution, User user, String content) {
+	public SolutionComment(Solution solution, User user, String content, boolean isRead) {
 		super(user, content);
 		this.solution = solution;
+		this.isRead = isRead;
 	}
 
 }

--- a/src/main/java/com/gamzabat/algohub/feature/solution/domain/SolutionComment.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/domain/SolutionComment.java
@@ -31,4 +31,7 @@ public class SolutionComment extends Comment {
 		this.isRead = isRead;
 	}
 
+	public void markAsRead() {
+		this.isRead = true;
+	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/solution/dto/GetSolutionResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/dto/GetSolutionResponse.java
@@ -26,9 +26,10 @@ public class GetSolutionResponse {
 	private final String language;
 	private final Integer codeLength;
 	private final Long commentCount;
+	private final Boolean isRead;
 
 	public static GetSolutionResponse toDTO(Solution solution, Integer accuracy, Integer submitMemberCount,
-		Integer totalMemberCount, Long commentCount) {
+		Integer totalMemberCount, Long commentCount, Boolean isRead) {
 		return GetSolutionResponse.builder()
 			.solutionId(solution.getId())
 			.problemTitle(solution.getProblem().getTitle())
@@ -46,6 +47,7 @@ public class GetSolutionResponse {
 			.language(solution.getLanguage())
 			.codeLength(solution.getCodeLength())
 			.commentCount(commentCount)
+			.isRead(isRead)
 			.build();
 	}
 

--- a/src/main/java/com/gamzabat/algohub/feature/solution/dto/GetSolutionWithGroupIdResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/dto/GetSolutionWithGroupIdResponse.java
@@ -12,7 +12,7 @@ public class GetSolutionWithGroupIdResponse extends GetSolutionResponse {
 	private final Long groupId;
 
 	public static GetSolutionWithGroupIdResponse toDTO(Solution solution, Integer accuracy, Integer submitMemberCount,
-		Integer totalMemberCount, Long commentCount) {
+		Integer totalMemberCount, Long commentCount, Boolean isRead) {
 		return GetSolutionWithGroupIdResponse.builder()
 			.solutionId(solution.getId())
 			.problemTitle(solution.getProblem().getTitle())
@@ -30,6 +30,7 @@ public class GetSolutionWithGroupIdResponse extends GetSolutionResponse {
 			.language(solution.getLanguage())
 			.codeLength(solution.getCodeLength())
 			.commentCount(commentCount)
+			.isRead(isRead)
 			.groupId(solution.getProblem().getStudyGroup().getId())
 			.build();
 	}

--- a/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionCommentService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionCommentService.java
@@ -77,11 +77,15 @@ public class SolutionCommentService implements CommentService<CreateSolutionComm
 	}
 
 	@Override
-	@Transactional(readOnly = true)
+	@Transactional
 	public List<GetCommentResponse> getCommentList(User user, Long solutionId) {
 		Solution solution = checkSolutionValidation(user, solutionId);
 		List<SolutionComment> list = commentRepository.findAllBySolution(solution);
-		updateCommentRead(list);
+		for (SolutionComment comment : list) {
+			if (!comment.isRead()) {
+				comment.markAsRead();
+			}
+		}
 		List<GetCommentResponse> result = list.stream().map(GetCommentResponse::toDTO)
 			.sorted((s1, s2) -> s2.createdAt().compareTo(s1.createdAt())).toList();
 		log.info("success to get solution comment list. solutionId: {}", solutionId);
@@ -127,13 +131,5 @@ public class SolutionCommentService implements CommentService<CreateSolutionComm
 			throw new GroupMemberValidationException(HttpStatus.FORBIDDEN.value(), "참여하지 않은 그룹 입니다.");
 
 		return solution;
-	}
-
-	private void updateCommentRead(List<SolutionComment> commentList) {
-		for (SolutionComment comment : commentList) {
-			if (!comment.isRead()) {
-				comment.markAsRead();
-			}
-		}
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionCommentService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionCommentService.java
@@ -53,6 +53,7 @@ public class SolutionCommentService implements CommentService<CreateSolutionComm
 			.user(user)
 			.solution(solution)
 			.content(request.content())
+			.isRead(false)
 			.build());
 
 		sendCommentNotification(user, solution);

--- a/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionCommentService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionCommentService.java
@@ -81,6 +81,7 @@ public class SolutionCommentService implements CommentService<CreateSolutionComm
 	public List<GetCommentResponse> getCommentList(User user, Long solutionId) {
 		Solution solution = checkSolutionValidation(user, solutionId);
 		List<SolutionComment> list = commentRepository.findAllBySolution(solution);
+		updateCommentRead(list);
 		List<GetCommentResponse> result = list.stream().map(GetCommentResponse::toDTO)
 			.sorted((s1, s2) -> s2.createdAt().compareTo(s1.createdAt())).toList();
 		log.info("success to get solution comment list. solutionId: {}", solutionId);
@@ -128,4 +129,11 @@ public class SolutionCommentService implements CommentService<CreateSolutionComm
 		return solution;
 	}
 
+	private void updateCommentRead(List<SolutionComment> commentList) {
+		for (SolutionComment comment : commentList) {
+			if (!comment.isRead()) {
+				comment.markAsRead();
+			}
+		}
+	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
@@ -273,7 +273,7 @@ public class SolutionService {
 	}
 
 	private boolean isMySolution(User user, Solution solution) {
-		return solution.getUser() == user;
+		return solution.getUser().getId().equals(user.getId());
 	}
 
 	private boolean hasUnreadComment(Solution solution) {

--- a/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
@@ -164,7 +164,7 @@ public class SolutionService {
 		boolean isRead = true;
 
 		if (isMySolution(user, solution)) {
-			isRead = !hasUnreadComment(solution);
+			isRead = !isAllRead(solution);
 		}
 		return GetSolutionWithGroupIdResponse.toDTO(solution, accuracy, submitMemberCount, totalMemberCount,
 			commentCount, isRead);
@@ -179,7 +179,7 @@ public class SolutionService {
 		boolean isRead = true;
 
 		if (isMySolution(user, solution)) {
-			isRead = !hasUnreadComment(solution);
+			isRead = !isAllRead(solution);
 		}
 
 		return GetSolutionResponse.toDTO(solution, accuracy, submitMemberCount, totalMemberCount, commentCount, isRead);
@@ -276,7 +276,7 @@ public class SolutionService {
 		return solution.getUser().getId().equals(user.getId());
 	}
 
-	private boolean hasUnreadComment(Solution solution) {
+	private boolean isAllRead(Solution solution) {
 		List<SolutionComment> comments = solutionCommentRepository.findAllBySolution(solution);
 
 		for (SolutionComment solutionComment : comments) {

--- a/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
@@ -164,7 +164,7 @@ public class SolutionService {
 		boolean isRead = true;
 
 		if (isMySolution(user, solution)) {
-			isRead = !isAllRead(solution);
+			isRead = isAllCommentsRead(solution);
 		}
 		return GetSolutionWithGroupIdResponse.toDTO(solution, accuracy, submitMemberCount, totalMemberCount,
 			commentCount, isRead);
@@ -179,7 +179,7 @@ public class SolutionService {
 		boolean isRead = true;
 
 		if (isMySolution(user, solution)) {
-			isRead = isAllRead(solution);
+			isRead = isAllCommentsRead(solution);
 		}
 
 		return GetSolutionResponse.toDTO(solution, accuracy, submitMemberCount, totalMemberCount, commentCount, isRead);
@@ -276,7 +276,7 @@ public class SolutionService {
 		return solution.getUser().getId().equals(user.getId());
 	}
 
-	private boolean isAllRead(Solution solution) {
+	private boolean isAllCommentsRead(Solution solution) {
 		List<SolutionComment> comments = solutionCommentRepository.findAllBySolution(solution);
 
 		for (SolutionComment solutionComment : comments) {

--- a/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
@@ -29,6 +29,7 @@ import com.gamzabat.algohub.feature.notification.service.NotificationService;
 import com.gamzabat.algohub.feature.problem.domain.Problem;
 import com.gamzabat.algohub.feature.problem.repository.ProblemRepository;
 import com.gamzabat.algohub.feature.solution.domain.Solution;
+import com.gamzabat.algohub.feature.solution.domain.SolutionComment;
 import com.gamzabat.algohub.feature.solution.dto.CreateSolutionRequest;
 import com.gamzabat.algohub.feature.solution.dto.GetSolutionResponse;
 import com.gamzabat.algohub.feature.solution.dto.GetSolutionWithGroupIdResponse;
@@ -55,6 +56,7 @@ public class SolutionService {
 	private final SolutionCommentRepository commentRepository;
 	private final RankingService rankingService;
 	private final RankingUpdateService rankingUpdateService;
+	private final SolutionCommentRepository solutionCommentRepository;
 
 	@Transactional(readOnly = true)
 	public Page<GetSolutionResponse> getSolutionList(User user, Long problemId, String nickname,
@@ -72,7 +74,8 @@ public class SolutionService {
 		Page<Solution> solutions = solutionRepository.findAllFilteredSolutions(problem, nickname, language, result,
 			pageable);
 
-		return solutions.map(this::getGetSolutionResponse);
+		return solutions.map(solution -> this.getGetSolutionResponse(user, solution));
+
 	}
 
 	@Transactional(readOnly = true)
@@ -83,7 +86,7 @@ public class SolutionService {
 		StudyGroup group = solution.getProblem().getStudyGroup();
 
 		if (groupMemberRepository.existsByUserAndStudyGroup(user, group)) {
-			return getGetSolutionResponse(solution);
+			return getGetSolutionResponse(user, solution);
 		} else {
 			throw new UserValidationException("해당 풀이를 확인 할 권한이 없습니다.");
 		}
@@ -101,7 +104,7 @@ public class SolutionService {
 
 		Page<GetSolutionResponse> inProgressSolutions = solutionRepository.findAllFilteredMySolutionsInGroup(user,
 				group, problemNumber, language, result, ProgressCategory.IN_PROGRESS, pageable)
-			.map(this::getGetSolutionResponse);
+			.map(solution -> this.getGetSolutionResponse(user, solution));
 
 		log.info("success to get my in-progress solutions in group {}", groupId);
 		return inProgressSolutions;
@@ -118,7 +121,8 @@ public class SolutionService {
 		}
 
 		Page<GetSolutionResponse> expiredSolutions = solutionRepository.findAllFilteredMySolutionsInGroup(user, group,
-			problemNumber, language, result, ProgressCategory.EXPIRED, pageable).map(this::getGetSolutionResponse);
+				problemNumber, language, result, ProgressCategory.EXPIRED, pageable)
+			.map(solution -> this.getGetSolutionResponse(user, solution));
 
 		log.info("success to get my expired solutions in group {}", groupId);
 		return expiredSolutions;
@@ -130,9 +134,10 @@ public class SolutionService {
 		String result,
 		Pageable pageable) {
 		Page<GetSolutionWithGroupIdResponse> inProgressSolutions = solutionRepository.findAllFilteredMySolutions(user,
-			problemNumber,
-			language,
-			result, ProgressCategory.IN_PROGRESS, pageable).map(this::getGetSolutionWithGroupIdResponse);
+				problemNumber,
+				language,
+				result, ProgressCategory.IN_PROGRESS, pageable)
+			.map(solution -> this.getGetSolutionWithGroupIdResponse(user, solution));
 		log.info("success to get my in-progress solutions.");
 		return inProgressSolutions;
 	}
@@ -142,30 +147,42 @@ public class SolutionService {
 		String result,
 		Pageable pageable) {
 		Page<GetSolutionWithGroupIdResponse> expiredSolutions = solutionRepository.findAllFilteredMySolutions(user,
-			problemNumber,
-			language,
-			result, ProgressCategory.EXPIRED, pageable).map(this::getGetSolutionWithGroupIdResponse);
+				problemNumber,
+				language,
+				result, ProgressCategory.EXPIRED, pageable)
+			.map(solution -> this.getGetSolutionWithGroupIdResponse(user, solution));
 		log.info("success to get my expired solutions.");
 		return expiredSolutions;
 	}
 
-	private GetSolutionWithGroupIdResponse getGetSolutionWithGroupIdResponse(Solution solution) {
+	private GetSolutionWithGroupIdResponse getGetSolutionWithGroupIdResponse(User user, Solution solution) {
 		Integer correctCount = getCorrectCount(solution);
 		Integer submitMemberCount = solutionRepository.countDistinctUsersByProblem(solution.getProblem());
 		Integer totalMemberCount = groupMemberRepository.countMembersByStudyGroup(getGroup(solution)) + 1;
 		Integer accuracy = calculateAccuracy(submitMemberCount, correctCount);
 		long commentCount = commentRepository.countCommentsBySolutionId(solution.getId());
+		boolean isRead = true;
+
+		if (isMySolution(user, solution)) {
+			isRead = !hasUnreadComment(solution);
+		}
 		return GetSolutionWithGroupIdResponse.toDTO(solution, accuracy, submitMemberCount, totalMemberCount,
-			commentCount);
+			commentCount, isRead);
 	}
 
-	private GetSolutionResponse getGetSolutionResponse(Solution solution) {
+	private GetSolutionResponse getGetSolutionResponse(User user, Solution solution) {
 		Integer correctCount = getCorrectCount(solution);
 		Integer submitMemberCount = solutionRepository.countDistinctUsersByProblem(solution.getProblem());
 		Integer totalMemberCount = groupMemberRepository.countMembersByStudyGroup(getGroup(solution)) + 1;
 		Integer accuracy = calculateAccuracy(submitMemberCount, correctCount);
 		long commentCount = commentRepository.countCommentsBySolutionId(solution.getId());
-		return GetSolutionResponse.toDTO(solution, accuracy, submitMemberCount, totalMemberCount, commentCount);
+		boolean isRead = true;
+
+		if (isMySolution(user, solution)) {
+			isRead = !hasUnreadComment(solution);
+		}
+
+		return GetSolutionResponse.toDTO(solution, accuracy, submitMemberCount, totalMemberCount, commentCount, isRead);
 	}
 
 	private Integer getCorrectCount(Solution solution) {
@@ -253,5 +270,20 @@ public class SolutionService {
 
 	private StudyGroup getGroup(Solution solution) {
 		return solution.getProblem().getStudyGroup();
+	}
+
+	private boolean isMySolution(User user, Solution solution) {
+		return solution.getUser() == user;
+	}
+
+	private boolean hasUnreadComment(Solution solution) {
+		List<SolutionComment> comments = solutionCommentRepository.findAllBySolution(solution);
+
+		for (SolutionComment solutionComment : comments) {
+			if (!solutionComment.isRead())
+				return true;
+		}
+
+		return false;
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
@@ -179,7 +179,7 @@ public class SolutionService {
 		boolean isRead = true;
 
 		if (isMySolution(user, solution)) {
-			isRead = !isAllRead(solution);
+			isRead = isAllRead(solution);
 		}
 
 		return GetSolutionResponse.toDTO(solution, accuracy, submitMemberCount, totalMemberCount, commentCount, isRead);
@@ -281,9 +281,9 @@ public class SolutionService {
 
 		for (SolutionComment solutionComment : comments) {
 			if (!solutionComment.isRead())
-				return true;
+				return false;
 		}
 
-		return false;
+		return true;
 	}
 }

--- a/src/test/java/com/gamzabat/algohub/service/SolutionCommentServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/SolutionCommentServiceTest.java
@@ -87,8 +87,8 @@ class SolutionCommentServiceTest {
 		studyGroup = StudyGroup.builder().build();
 		problem = Problem.builder().studyGroup(studyGroup).build();
 		solution = Solution.builder().problem(problem).user(user).content("solution").build();
-		comment = SolutionComment.builder().user(user).content("content").solution(solution).build();
-		comment2 = SolutionComment.builder().user(user2).content("content").solution(solution).build();
+		comment = SolutionComment.builder().user(user).content("content").solution(solution).isRead(false).build();
+		comment2 = SolutionComment.builder().user(user2).content("content").solution(solution).isRead(false).build();
 
 		Field userField = User.class.getDeclaredField("id");
 		userField.setAccessible(true);
@@ -222,6 +222,7 @@ class SolutionCommentServiceTest {
 				.solution(solution)
 				.user(user)
 				.content("content" + i)
+				.isRead(true)
 				.build());
 		when(solutionRepository.findById(10L)).thenReturn(Optional.ofNullable(solution));
 		when(problemRepository.findById(20L)).thenReturn(Optional.ofNullable(problem));

--- a/src/test/java/com/gamzabat/algohub/service/SolutionCommentServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/SolutionCommentServiceTest.java
@@ -217,12 +217,19 @@ class SolutionCommentServiceTest {
 	void getComment_1() {
 		// given
 		List<SolutionComment> list = new ArrayList<>(30);
-		for (int i = 0; i < 30; i++)
+		for (int i = 0; i < 15; i++)
 			list.add(SolutionComment.builder()
 				.solution(solution)
 				.user(user)
 				.content("content" + i)
 				.isRead(true)
+				.build());
+		for (int i = 15; i < 30; i++)
+			list.add(SolutionComment.builder()
+				.solution(solution)
+				.user(user)
+				.content("content" + i)
+				.isRead(false)
 				.build());
 		when(solutionRepository.findById(10L)).thenReturn(Optional.ofNullable(solution));
 		when(problemRepository.findById(20L)).thenReturn(Optional.ofNullable(problem));
@@ -235,6 +242,11 @@ class SolutionCommentServiceTest {
 		assertThat(result.size()).isEqualTo(30);
 		for (int i = 0; i < 30; i++)
 			assertThat(result.get(i).content()).isEqualTo("content" + i);
+
+		for (SolutionComment comment : list) {
+			assertThat(comment.isRead()).isTrue();
+		}
+		
 	}
 
 	@Test

--- a/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
@@ -660,6 +660,7 @@ class SolutionServiceTest {
 				.language("Java 11")
 				.solvedDateTime(fixedDateTime)
 				.build();
+			inProgress.add(solution);
 			for (int j = 0; j < 10; j++)
 				comments.add(SolutionComment.builder()
 					.solution(solution)

--- a/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
@@ -38,6 +38,7 @@ import com.gamzabat.algohub.feature.notification.service.NotificationService;
 import com.gamzabat.algohub.feature.problem.domain.Problem;
 import com.gamzabat.algohub.feature.problem.repository.ProblemRepository;
 import com.gamzabat.algohub.feature.solution.domain.Solution;
+import com.gamzabat.algohub.feature.solution.domain.SolutionComment;
 import com.gamzabat.algohub.feature.solution.dto.CreateSolutionRequest;
 import com.gamzabat.algohub.feature.solution.dto.GetSolutionResponse;
 import com.gamzabat.algohub.feature.solution.dto.GetSolutionWithGroupIdResponse;
@@ -72,6 +73,7 @@ class SolutionServiceTest {
 	private StudyGroup group, group1;
 	private Long groupId = 30L;
 	private Integer problemNumber = 1010;
+	private SolutionComment solutionComment;
 	DateTimeFormatter formatter;
 
 	@BeforeEach
@@ -128,20 +130,31 @@ class SolutionServiceTest {
 		// given
 		Pageable pageable = PageRequest.of(0, 10);
 		List<Solution> list = new ArrayList<>();
-
+		List<SolutionComment> commentList = new ArrayList<>();
 		LocalDateTime fixedDateTime = LocalDateTime.now();
 
-		setTestSolutionList(list, fixedDateTime);
+		setTestSolutionAndCommentList(list, commentList, fixedDateTime);
 
 		Page<Solution> compileErrorPage = new PageImpl<>(list.subList(0, 10), pageable, 10);
 		Page<Solution> correctPage = new PageImpl<>(list.subList(10, 20), pageable, 10);
+		List<SolutionComment> readComments = new ArrayList<>(commentList.subList(0, 25));
+		List<SolutionComment> unReadComments = new ArrayList<>(commentList.subList(25, 50));
+
 		when(studyGroupRepository.findById(30L)).thenReturn(Optional.ofNullable(group));
 		when(problemRepository.findById(10L)).thenReturn(Optional.ofNullable(problem));
 		when(groupMemberRepository.existsByUserAndStudyGroup(user, group)).thenReturn(true);
 		when(solutionRepository.findAllFilteredSolutions(problem, null, null, "컴파일 에러", pageable)).thenReturn(
 			compileErrorPage);
+		for (int i = 0; i < 5; i++) {
+			when(solutionCommentRepository.findAllBySolution(compileErrorPage.getContent().get(i))).thenReturn(
+				readComments.subList(i * 5, i * 5 + 5));
+		}
 		when(solutionRepository.findAllFilteredSolutions(problem, null, null, "맞았습니다!!", pageable)).thenReturn(
 			correctPage);
+		for (int i = 0; i < 5; i++) {
+			when(solutionCommentRepository.findAllBySolution(correctPage.getContent().get(i))).thenReturn(
+				unReadComments.subList(i * 5, i * 5 + 5));
+		}
 		// when
 		Page<GetSolutionResponse> compileErrorResult = solutionService.getSolutionList(user, 10L, null, null, "컴파일 에러",
 			pageable);
@@ -158,6 +171,7 @@ class SolutionServiceTest {
 			assertThat(compileErrorResult.getContent().get(i).getExecutionTime()).isEqualTo(i);
 			assertThat(compileErrorResult.getContent().get(i).getNickname()).isEqualTo("nickname1");
 			assertThat(compileErrorResult.getContent().get(i).getLanguage()).isEqualTo("Java 11");
+			assertThat(compileErrorResult.getContent().get(i).getIsRead()).isEqualTo(true);
 			assertThat(compileErrorResult.getContent().get(i).getSolvedDateTime()).isEqualTo(
 				DateFormatUtil.formatDateTime(fixedDateTime));
 		}
@@ -168,6 +182,7 @@ class SolutionServiceTest {
 			assertThat(compileErrorResult.getContent().get(i).getExecutionTime()).isEqualTo(i);
 			assertThat(compileErrorResult.getContent().get(i).getNickname()).isEqualTo("nickname2");
 			assertThat(compileErrorResult.getContent().get(i).getLanguage()).isEqualTo("C++17");
+			assertThat(compileErrorResult.getContent().get(i).getIsRead()).isEqualTo(true);
 			assertThat(compileErrorResult.getContent().get(i).getSolvedDateTime()).isEqualTo(
 				DateFormatUtil.formatDateTime(fixedDateTime));
 		}
@@ -181,6 +196,7 @@ class SolutionServiceTest {
 			assertThat(correctResult.getContent().get(i).getExecutionTime()).isEqualTo(i + 10);
 			assertThat(correctResult.getContent().get(i).getNickname()).isEqualTo("nickname1");
 			assertThat(correctResult.getContent().get(i).getLanguage()).isEqualTo("Java 11");
+			assertThat(correctResult.getContent().get(i).getIsRead()).isEqualTo(false);
 			assertThat(correctResult.getContent().get(i).getSolvedDateTime()).isEqualTo(
 				DateFormatUtil.formatDateTime(fixedDateTime));
 		}
@@ -191,6 +207,7 @@ class SolutionServiceTest {
 			assertThat(correctResult.getContent().get(i).getExecutionTime()).isEqualTo(i + 10);
 			assertThat(correctResult.getContent().get(i).getNickname()).isEqualTo("nickname2");
 			assertThat(correctResult.getContent().get(i).getLanguage()).isEqualTo("PyPy3");
+			assertThat(correctResult.getContent().get(i).getIsRead()).isEqualTo(true);
 			assertThat(correctResult.getContent().get(i).getSolvedDateTime()).isEqualTo(
 				DateFormatUtil.formatDateTime(fixedDateTime));
 		}
@@ -202,10 +219,10 @@ class SolutionServiceTest {
 		// given
 		Pageable pageable = PageRequest.of(0, 10);
 		List<Solution> list = new ArrayList<>();
-
+		List<SolutionComment> commentList = new ArrayList<>();
 		LocalDateTime fixedDateTime = LocalDateTime.now();
 
-		setTestSolutionList(list, fixedDateTime);
+		setTestSolutionAndCommentList(list, commentList, fixedDateTime);
 
 		Page<Solution> solutionPage = new PageImpl<>(list.subList(10, 15), pageable, 5);
 
@@ -214,6 +231,7 @@ class SolutionServiceTest {
 		when(groupMemberRepository.existsByUserAndStudyGroup(user2, group)).thenReturn(true);
 		when(solutionRepository.findAllFilteredSolutions(problem, "nickname1", "Java", null, pageable)).thenReturn(
 			solutionPage);
+
 		// when
 		Page<GetSolutionResponse> result = solutionService.getSolutionList(user2, 10L, "nickname1", "Java", null,
 			pageable);
@@ -227,6 +245,7 @@ class SolutionServiceTest {
 			assertThat(result.getContent().get(i).getExecutionTime()).isEqualTo(i + 10);
 			assertThat(result.getContent().get(i).getNickname()).isEqualTo("nickname1");
 			assertThat(result.getContent().get(i).getLanguage()).isEqualTo("Java 11");
+			assertThat(result.getContent().get(i).getIsRead()).isEqualTo(true);
 			assertThat(result.getContent().get(i).getSolvedDateTime()).isEqualTo(
 				DateFormatUtil.formatDateTime(fixedDateTime));
 		}
@@ -289,8 +308,18 @@ class SolutionServiceTest {
 			.codeLength(10)
 			.solvedDateTime(LocalDateTime.now())
 			.build();
+		List<SolutionComment> commentList = new ArrayList<>();
+		for (int j = 0; j < 5; j++)
+			commentList.add(SolutionComment.builder()
+				.solution(solution)
+				.user(user)
+				.content("content" + j)
+				.isRead(false)
+				.build());
+
 		when(solutionRepository.findById(anyLong())).thenReturn(Optional.ofNullable(solution));
 		when(groupMemberRepository.existsByUserAndStudyGroup(user, group)).thenReturn(true);
+		when(solutionCommentRepository.findAllBySolution(solution)).thenReturn(commentList);
 		// when
 		GetSolutionResponse response = solutionService.getSolution(user, 10L);
 		// then
@@ -303,6 +332,7 @@ class SolutionServiceTest {
 		assertThat(response.getLanguage()).isEqualTo("Java");
 		assertThat(response.getCodeLength()).isEqualTo(10);
 		assertThat(response.getCommentCount()).isEqualTo(0);
+		assertThat(response.getIsRead()).isEqualTo(false);
 		assertThat(response.getSolvedDateTime()).isEqualTo(DateFormatUtil.formatDateTime(LocalDateTime.now()));
 	}
 
@@ -321,6 +351,15 @@ class SolutionServiceTest {
 			.codeLength(10)
 			.solvedDateTime(LocalDateTime.now())
 			.build();
+		List<SolutionComment> commentList = new ArrayList<>();
+		for (int j = 0; j < 5; j++)
+			commentList.add(SolutionComment.builder()
+				.solution(solution)
+				.user(user)
+				.content("content" + j)
+				.isRead(false)
+				.build());
+
 		when(solutionRepository.findById(anyLong())).thenReturn(Optional.ofNullable(solution));
 		when(groupMemberRepository.existsByUserAndStudyGroup(user2, group)).thenReturn(true);
 		// when
@@ -335,6 +374,7 @@ class SolutionServiceTest {
 		assertThat(response.getLanguage()).isEqualTo("Java");
 		assertThat(response.getCodeLength()).isEqualTo(10);
 		assertThat(response.getCommentCount()).isEqualTo(0);
+		assertThat(response.getIsRead()).isEqualTo(true);
 		assertThat(response.getSolvedDateTime()).isEqualTo(DateFormatUtil.formatDateTime(LocalDateTime.now()));
 	}
 
@@ -372,9 +412,10 @@ class SolutionServiceTest {
 			.hasFieldOrPropertyWithValue("errors", "해당 풀이를 확인 할 권한이 없습니다.");
 	}
 
-	private void setTestSolutionList(List<Solution> list, LocalDateTime fixedDateTime) {
+	private void setTestSolutionAndCommentList(List<Solution> list, List<SolutionComment> commentList,
+		LocalDateTime fixedDateTime) {
 		for (int i = 0; i < 5; i++) {
-			list.add(Solution.builder()
+			Solution solution = Solution.builder()
 				.problem(problem)
 				.content("content" + i)
 				.user(user)
@@ -384,7 +425,15 @@ class SolutionServiceTest {
 				.language("Java 11")
 				.codeLength(i)
 				.solvedDateTime(fixedDateTime)
-				.build());
+				.build();
+			list.add(solution);
+			for (int j = 0; j < 5; j++)
+				commentList.add(SolutionComment.builder()
+					.solution(solution)
+					.user(user)
+					.content("content" + j)
+					.isRead(true)
+					.build());
 		}
 		for (int i = 5; i < 10; i++) {
 			list.add(Solution.builder()
@@ -400,7 +449,7 @@ class SolutionServiceTest {
 				.build());
 		}
 		for (int i = 10; i < 15; i++) {
-			list.add(Solution.builder()
+			Solution solution = Solution.builder()
 				.problem(problem)
 				.content("content" + i)
 				.user(user)
@@ -410,7 +459,16 @@ class SolutionServiceTest {
 				.language("Java 11")
 				.codeLength(i)
 				.solvedDateTime(fixedDateTime)
-				.build());
+				.build();
+			list.add(solution);
+			for (int j = 5; j < 10; j++)
+				commentList.add(SolutionComment.builder()
+					.solution(solution)
+					.user(user)
+					.content("content" + j)
+					.isRead(false)
+					.build());
+
 		}
 		for (int i = 15; i < 20; i++) {
 			list.add(Solution.builder()
@@ -478,16 +536,32 @@ class SolutionServiceTest {
 		Pageable pageable = PageRequest.of(0, 10);
 		List<Solution> inProgress = new ArrayList<>();
 		LocalDateTime fixedDateTime = LocalDateTime.now();
+		List<SolutionComment> comments = new ArrayList<>();
 
 		for (int i = 0; i < 5; i++) {
-			inProgress.add(Solution.builder()
+			Solution solution = Solution.builder()
 				.problem(problem)
 				.user(user)
 				.codeLength(i)
 				.result("맞았습니다!!")
 				.language("Java 11")
 				.solvedDateTime(fixedDateTime)
-				.build());
+				.build();
+			inProgress.add(solution);
+			for (int j = 0; j < 5; j++)
+				comments.add(SolutionComment.builder()
+					.solution(solution)
+					.user(user)
+					.content("content" + j)
+					.isRead(false)
+					.build());
+			for (int j = 0; j < 5; j++)
+				comments.add(SolutionComment.builder()
+					.solution(solution)
+					.user(user)
+					.content("content" + j)
+					.isRead(true)
+					.build());
 		}
 
 		Page<Solution> inProgressPages = new PageImpl<>(inProgress, pageable, 10);
@@ -496,6 +570,10 @@ class SolutionServiceTest {
 		when(solutionRepository.findAllFilteredMySolutionsInGroup(user, group, problemNumber, null, null,
 			ProgressCategory.IN_PROGRESS,
 			pageable)).thenReturn(inProgressPages);
+		for (int i = 0; i < 5; i++) {
+			when(solutionCommentRepository.findAllBySolution(inProgressPages.getContent().get(i))).thenReturn(
+				comments.subList(i * 10, i * 10 + 10));
+		}
 		// when
 		Page<GetSolutionResponse> responses = solutionService.getMySolutionsInGroupInProgress(user, groupId,
 			problemNumber, null,
@@ -504,6 +582,7 @@ class SolutionServiceTest {
 		for (int i = 0; i < 5; i++) {
 			assertThat(responses.getContent().get(i).getNickname()).isEqualTo("nickname1");
 			assertThat(responses.getContent().get(i).getProblemLevel()).isEqualTo(problem.getLevel());
+			assertThat(responses.getContent().get(i).getIsRead()).isEqualTo(false);
 		}
 	}
 
@@ -513,16 +592,32 @@ class SolutionServiceTest {
 		// given
 		Pageable pageable = PageRequest.of(0, 10);
 		List<Solution> expired = new ArrayList<>();
+		List<SolutionComment> comments = new ArrayList<>();
 		LocalDateTime fixedDateTime = LocalDateTime.now();
 		for (int i = 0; i < 5; i++) {
-			expired.add(Solution.builder()
+			Solution solution = Solution.builder()
 				.problem(problem1)
 				.user(user)
 				.codeLength(i)
 				.result("틀렸습니다")
 				.language("Java 11")
 				.solvedDateTime(fixedDateTime)
-				.build());
+				.build();
+			expired.add(solution);
+			for (int j = 0; j < 5; j++)
+				comments.add(SolutionComment.builder()
+					.solution(solution)
+					.user(user)
+					.content("content" + j)
+					.isRead(false)
+					.build());
+			for (int j = 0; j < 5; j++)
+				comments.add(SolutionComment.builder()
+					.solution(solution)
+					.user(user)
+					.content("content" + j)
+					.isRead(true)
+					.build());
 		}
 
 		Page<Solution> expiredPages = new PageImpl<>(expired, pageable, 10);
@@ -531,6 +626,10 @@ class SolutionServiceTest {
 		when(solutionRepository.findAllFilteredMySolutionsInGroup(user, group, problemNumber, null, null,
 			ProgressCategory.EXPIRED,
 			pageable)).thenReturn(expiredPages);
+		for (int i = 0; i < 5; i++) {
+			when(solutionCommentRepository.findAllBySolution(expiredPages.getContent().get(i))).thenReturn(
+				comments.subList(i * 10, i * 10 + 10));
+		}
 		// when
 		Page<GetSolutionResponse> responses = solutionService.getMySolutionsInGroupExpired(user, groupId,
 			problemNumber, null,
@@ -538,6 +637,7 @@ class SolutionServiceTest {
 		// then
 		for (int i = 0; i < 5; i++) {
 			assertThat(responses.getContent().get(i).getNickname()).isEqualTo("nickname1");
+			assertThat(responses.getContent().get(i).getIsRead()).isEqualTo(false);
 			assertThat(responses.getContent().get(i).getProblemLevel()).isEqualTo(problem1.getLevel());
 		}
 	}
@@ -548,29 +648,42 @@ class SolutionServiceTest {
 		// given
 		Pageable pageable = PageRequest.of(0, 10);
 		List<Solution> inProgress = new ArrayList<>();
+		List<SolutionComment> comments = new ArrayList<>();
 		LocalDateTime fixedDateTime = LocalDateTime.now();
 
 		for (int i = 0; i < 5; i++) {
-			inProgress.add(Solution.builder()
+			Solution solution = Solution.builder()
 				.problem(problem)
 				.user(user)
 				.codeLength(i)
 				.result("맞았습니다!!")
 				.language("Java 11")
 				.solvedDateTime(fixedDateTime)
-				.build());
+				.build();
+			for (int j = 0; j < 10; j++)
+				comments.add(SolutionComment.builder()
+					.solution(solution)
+					.user(user)
+					.content("content" + j)
+					.isRead(true)
+					.build());
 		}
 
 		Page<Solution> inProgressPages = new PageImpl<>(inProgress, pageable, 10);
 
 		when(solutionRepository.findAllFilteredMySolutions(user, null, null, null,
 			ProgressCategory.IN_PROGRESS, pageable)).thenReturn(inProgressPages);
+		for (int i = 0; i < 5; i++) {
+			when(solutionCommentRepository.findAllBySolution(inProgressPages.getContent().get(i))).thenReturn(
+				comments.subList(i * 10, i * 10 + 10));
+		}
 		// when
 		Page<GetSolutionWithGroupIdResponse> responses = solutionService.getMySolutionsInProgress(user, null, null,
 			null, pageable);
 		// then
 		for (int i = 0; i < 5; i++) {
 			assertThat(responses.getContent().get(i).getNickname()).isEqualTo("nickname1");
+			assertThat(responses.getContent().get(i).getIsRead()).isEqualTo(true);
 			assertThat(responses.getContent().get(i).getGroupId()).isEqualTo(
 				problem.getStudyGroup().getId());
 		}
@@ -582,29 +695,50 @@ class SolutionServiceTest {
 		// given
 		Pageable pageable = PageRequest.of(0, 10);
 		List<Solution> expired = new ArrayList<>();
+		List<SolutionComment> comments = new ArrayList<>();
 		LocalDateTime fixedDateTime = LocalDateTime.now();
 
 		for (int i = 0; i < 5; i++) {
-			expired.add(Solution.builder()
+			Solution solution = Solution.builder()
 				.problem(problem2)
 				.user(user)
 				.codeLength(i)
 				.result("컴파일 에러")
 				.language("Java 11")
 				.solvedDateTime(fixedDateTime)
-				.build());
+				.build();
+			expired.add(solution);
+			for (int j = 0; j < 5; j++)
+				comments.add(SolutionComment.builder()
+					.solution(solution)
+					.user(user)
+					.content("content" + j)
+					.isRead(true)
+					.build());
+			for (int j = 5; j < 10; j++)
+				comments.add(SolutionComment.builder()
+					.solution(solution)
+					.user(user)
+					.content("content" + j)
+					.isRead(false)
+					.build());
 		}
 
 		Page<Solution> expiredPages = new PageImpl<>(expired, pageable, 10);
 
 		when(solutionRepository.findAllFilteredMySolutions(user, null, null, null,
 			ProgressCategory.EXPIRED, pageable)).thenReturn(expiredPages);
+		for (int i = 0; i < 5; i++) {
+			when(solutionCommentRepository.findAllBySolution(expiredPages.getContent().get(i))).thenReturn(
+				comments.subList(i * 10, i * 10 + 10));
+		}
 		// when
 		Page<GetSolutionWithGroupIdResponse> responses = solutionService.getMySolutionsExpired(user, null, null,
 			null, pageable);
 		// then
 		for (int i = 0; i < 5; i++) {
 			assertThat(responses.getContent().get(i).getNickname()).isEqualTo("nickname1");
+			assertThat(responses.getContent().get(i).getIsRead()).isEqualTo(false);
 			assertThat(responses.getContent().get(i).getGroupId()).isEqualTo(
 				problem2.getStudyGroup().getId());
 		}


### PR DESCRIPTION
## 📌 Related Issue
https://github.com/GAMZA-BAT/algohub-server/issues/321

## 🚀 Description
- 내 풀이 목록을 볼 때 만약 내 풀이 중 읽지 않은 댓글이 있는 풀이라면 reddot으로 표시하게 하기 위해 작업을 진행했습니다. 
- 모든 풀이 목록 조회 API들이 getGetSolutionResponse를 사용하여 이 dto에 isRead필드만 추가하여 진행했습니다.

## 📢 Review Point
-  getGetSolutionResponse만 수정해서 작업을 진행했기 때문에 테스트 코드들에 이에 대한 검증만 추가했습니다! 
