### PR TITLE
fix: make reset-password token url safe

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -348,7 +348,7 @@ public class UserService {
 		final int TOKEN_LENGTH = 32;
 		byte[] bytes = new byte[TOKEN_LENGTH];
 		new SecureRandom().nextBytes(bytes);
-		return Base64.getEncoder().withoutPadding().encodeToString(bytes);
+		return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
 	}
 
 }


### PR DESCRIPTION
## 📌 Related Issue
close #334 

## 🚀 Description
<!-- 작업 내용 -->
- 비밀번호 재설정 토큰이 URL-safe하지 않아 수정했습니다.
- 머지는 아무나 먼저 본 분이 하셔도 될듯 

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
- url safe란, 문자열을 url에 쓰기에 괜찮은지예요.
- / 나 +, =같은 문자열은 url에 들어가면 곤란합니다. 특히 "/"는 url에서 아주 중요한 역할이기에.. 들어가면 안 됩니다
- 그런데 base64에서는 저런 문자열이 들어갈 수 있어서, -나 _처럼 url-safe한 값으로 치환한 값을 써야합니다. 

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->
다음 코드로 테스트해보고 올렸습니다.
```java
List<String> tokens = IntStream.range(0, 10000000)
			.mapToObj(i -> generateSecureToken())
			.toList();

		boolean hasUnsafeToken = tokens.stream()
			.anyMatch(token -> token.contains("+") || token.contains("/") || token.contains("="));

		if (hasUnsafeToken) {
			System.out.println("UNSAFE DETECTED");
		} else {
			System.out.println("All tokens are URL safe.");
		}
```