### PR TITLE
fix: Increase column length for fields that may exceed 255 characters

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/comment/domain/Comment.java
+++ b/src/main/java/com/gamzabat/algohub/feature/comment/domain/Comment.java
@@ -6,6 +6,7 @@ import org.hibernate.annotations.DynamicUpdate;
 
 import com.gamzabat.algohub.feature.user.domain.User;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -29,6 +30,7 @@ public abstract class Comment {
 	@JoinColumn(name = "user_id")
 	private User user;
 
+	@Column(columnDefinition = "TEXT")
 	private String content;
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;

--- a/src/main/java/com/gamzabat/algohub/feature/problem/domain/Problem.java
+++ b/src/main/java/com/gamzabat/algohub/feature/problem/domain/Problem.java
@@ -7,6 +7,7 @@ import org.hibernate.annotations.SQLDelete;
 
 import com.gamzabat.algohub.feature.group.studygroup.domain.StudyGroup;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -26,6 +27,7 @@ public class Problem {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+	@Column(length = 512)
 	private String link;
 	private LocalDate startDate;
 	private LocalDate endDate;

--- a/src/main/java/com/gamzabat/algohub/feature/user/domain/User.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/domain/User.java
@@ -35,6 +35,7 @@ public class User {
 	private String password;
 	private String nickname;
 	private String bjNickname;
+	@Column(length = 512)
 	private String profileImage;
 	@Column(nullable = false)
 	@NotNull


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close #336 
작업해놓고 pr을 안올림.. 그래놓고 리뷰 독려하러 들어왔네요; 

## 🚀 Description
<!-- 작업 내용 -->
- Hibernate에서 String은 기본적으로 varcahr(255)로 자료형을 잡아줍니다.
- 그런데 일부 필드는 그 길이로 부족할 수 있어서, 어느정도 넉넉하게 늘려줍니다. 

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
- S3 링크에 한글이 들어가면 인코딩이 들어가는데, 이러면 길이가 어어어어어엄청 길어지는 경향이 있어용 

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->
- DB에서 varchar와 char의 차이를 알아보면 좋겠습니다.