### PR TITLE
refactor:회원가입시 백준ID 입력 제거 및 백준ID 연결 API 따로 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.assertj:assertj-core:3.23.0'
+    testImplementation 'org.mockito:mockito-inline:4.11.0'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
     implementation 'org.codehaus.janino:janino:3.1.9'
     implementation 'org.apache.commons:commons-text:1.13.0'

--- a/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
@@ -56,11 +56,11 @@ public class UserController {
 
 	@PatchMapping(value = "/users/baekjoon-nickname")
 	@Operation(summary = "백준 아이디 입력 API")
-	public ResponseEntity<Void> registerBjNickName(@Valid @RequestBody RegisterBjNickNameRequest request, Errors errors,
+	public ResponseEntity<Void> registerBjNickname(@Valid @RequestBody RegisterBjNickNameRequest request, Errors errors,
 		@AuthedUser User user) {
 		if (errors.hasErrors())
 			throw new RequestException("올바르지 않은 요청입니다.", errors);
-		userService.registerBjNickName(user, request);
+		userService.registerBjNickname(user, request);
 		return ResponseEntity.ok().build();
 	}
 

--- a/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
@@ -73,6 +73,13 @@ public class UserController {
 		return ResponseEntity.ok().body(response);
 	}
 
+	@GetMapping("/users/check-baekjoon-nickname")
+	@Operation(summary = "백준 닉네임 유효성 검증 API", description = "회원가입 진행 시, 백준 닉네임이 유효한지 검증하는 API")
+	public ResponseEntity<Void> checkBjNickname(@RequestParam String bjNickname) {
+		userService.checkBjNickname(bjNickname);
+		return ResponseEntity.ok().build();
+	}
+
 	@PostMapping(value = "/auth/reissue-token")
 	@Operation(summary = "토큰 재발급 API")
 	public ResponseEntity<TokenResponse> reissueToken(@Valid @RequestBody ReissueTokenRequest request,

--- a/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
@@ -56,8 +56,8 @@ public class UserController {
 
 	@PatchMapping(value = "/users/baekjoon-nickname")
 	@Operation(summary = "백준 아이디 입력 API")
-	public ResponseEntity<Void> registerBjNickName(@Valid @RequestBody RegisterBjNickNameRequest request,
-		@AuthedUser User user, Errors errors) {
+	public ResponseEntity<Void> registerBjNickName(@Valid @RequestBody RegisterBjNickNameRequest request, Errors errors,
+		@AuthedUser User user) {
 		if (errors.hasErrors())
 			throw new RequestException("올바르지 않은 요청입니다.", errors);
 		userService.registerBjNickName(user, request);

--- a/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
@@ -54,7 +54,7 @@ public class UserController {
 		return ResponseEntity.ok().build();
 	}
 
-	@PatchMapping(value = "/users/bjnickname")
+	@PatchMapping(value = "/users/baekjoon-nickname")
 	@Operation(summary = "백준 아이디 입력 API")
 	public ResponseEntity<Void> registerBjNickName(@Valid @RequestBody RegisterBjNickNameRequest request,
 		@AuthedUser User user, Errors errors) {

--- a/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
@@ -22,6 +22,7 @@ import com.gamzabat.algohub.feature.user.domain.User;
 import com.gamzabat.algohub.feature.user.dto.CheckEmailRequest;
 import com.gamzabat.algohub.feature.user.dto.DeleteUserRequest;
 import com.gamzabat.algohub.feature.user.dto.EditUserPasswordRequest;
+import com.gamzabat.algohub.feature.user.dto.RegisterBjNickNameRequest;
 import com.gamzabat.algohub.feature.user.dto.RegisterRequest;
 import com.gamzabat.algohub.feature.user.dto.ResetPasswordRequest;
 import com.gamzabat.algohub.feature.user.dto.SignInRequest;
@@ -50,6 +51,16 @@ public class UserController {
 		if (errors.hasErrors())
 			throw new RequestException("올바르지 않은 요청입니다.", errors);
 		userService.register(request, profileImage);
+		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping(value = "/users/bjnickname")
+	@Operation(summary = "백준 아이디 입력 API")
+	public ResponseEntity<Void> enterBjNickName(@Valid @RequestParam RegisterBjNickNameRequest request,
+		@AuthedUser User user, Errors errors) {
+		if (errors.hasErrors())
+			throw new RequestException("올바르지 않은 요청입니다.", errors);
+		userService.registerBjNickName(user, request);
 		return ResponseEntity.ok().build();
 	}
 
@@ -107,13 +118,6 @@ public class UserController {
 	@Operation(summary = "로그아웃 API")
 	public ResponseEntity<Void> logout(HttpServletRequest request) {
 		userService.logout(request);
-		return ResponseEntity.ok().build();
-	}
-
-	@GetMapping("/users/check-baekjoon-nickname")
-	@Operation(summary = "백준 닉네임 유효성 검증 API", description = "회원가입 진행 시, 백준 닉네임이 유효한지 검증하는 API")
-	public ResponseEntity<Void> checkBjNickname(@RequestParam String bjNickname) {
-		userService.checkBjNickname(bjNickname);
 		return ResponseEntity.ok().build();
 	}
 

--- a/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
@@ -54,9 +54,9 @@ public class UserController {
 		return ResponseEntity.ok().build();
 	}
 
-	@PostMapping(value = "/users/bjnickname")
+	@PatchMapping(value = "/users/bjnickname")
 	@Operation(summary = "백준 아이디 입력 API")
-	public ResponseEntity<Void> enterBjNickName(@Valid @RequestParam RegisterBjNickNameRequest request,
+	public ResponseEntity<Void> registerBjNickName(@Valid @RequestBody RegisterBjNickNameRequest request,
 		@AuthedUser User user, Errors errors) {
 		if (errors.hasErrors())
 			throw new RequestException("올바르지 않은 요청입니다.", errors);

--- a/src/main/java/com/gamzabat/algohub/feature/user/dto/RegisterBjNickNameRequest.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/dto/RegisterBjNickNameRequest.java
@@ -1,6 +1,6 @@
 package com.gamzabat.algohub.feature.user.dto;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 
-public record RegisterBjNickNameRequest(@NotNull(message = "백준 아이디는 필수 입력입니다") String bjNickName) {
+public record RegisterBjNickNameRequest(@NotBlank(message = "백준 아이디는 필수 입력입니다") String bjNickName) {
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/dto/RegisterBjNickNameRequest.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/dto/RegisterBjNickNameRequest.java
@@ -1,0 +1,6 @@
+package com.gamzabat.algohub.feature.user.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record RegisterBjNickNameRequest(@NotNull(message = "백준 아이디는 필수 입력입니다") String bjNickName) {
+}

--- a/src/main/java/com/gamzabat/algohub/feature/user/dto/RegisterRequest.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/dto/RegisterRequest.java
@@ -4,6 +4,5 @@ import jakarta.validation.constraints.NotBlank;
 
 public record RegisterRequest(@NotBlank(message = "이메일은 필수 입력입니다.") String email,
 							  @NotBlank(message = "비밀번호는 필수 입력입니다.") String password,
-							  @NotBlank(message = "닉네임은 필수 입력입니다.") String nickname,
-							  @NotBlank(message = "백준 닉네임은 필수 입력입니다.") String bjNickname) {
+							  @NotBlank(message = "닉네임은 필수 입력입니다.") String nickname) {
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -192,6 +192,9 @@ public class UserService {
 	public void registerBjNickname(User user, RegisterBjNickNameRequest request) {
 		String bjUserUrl = BOJ_USER_PROFILE_URL + request.bjNickName();
 
+		User editUser = userRepository.findById(user.getId())
+			.orElseThrow(() -> new UserValidationException("존재하지 않는 유저입니다."));
+
 		HttpHeaders headers = new HttpHeaders();
 		headers.set("User-Agent",
 			"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36");
@@ -209,7 +212,8 @@ public class UserService {
 			log.error("BOJ server error occurred : " + e.getMessage());
 			throw new BOJServerErrorException("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
 		}
-		user.editBjNickname(request.bjNickName());
+
+		editUser.editBjNickname(request.bjNickName());
 
 		log.info("success to register baekjoon-nickname user_id = {}", user.getId());
 	}

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -1,13 +1,16 @@
 package com.gamzabat.algohub.feature.user.service;
 
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
+import static com.gamzabat.algohub.constants.ApiConstants.*;
+
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.regex.Pattern;
 
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -16,6 +19,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -38,6 +43,8 @@ import com.gamzabat.algohub.feature.user.dto.SignInRequest;
 import com.gamzabat.algohub.feature.user.dto.TokenResponse;
 import com.gamzabat.algohub.feature.user.dto.UpdateUserRequest;
 import com.gamzabat.algohub.feature.user.dto.UserInfoResponse;
+import com.gamzabat.algohub.feature.user.exception.BOJServerErrorException;
+import com.gamzabat.algohub.feature.user.exception.CheckBjNicknameValidationException;
 import com.gamzabat.algohub.feature.user.exception.CheckEmailFormException;
 import com.gamzabat.algohub.feature.user.exception.CheckNicknameValidationException;
 import com.gamzabat.algohub.feature.user.exception.CheckPasswordFormException;
@@ -152,15 +159,6 @@ public class UserService {
 		}
 	}
 
-	private boolean isEqualToProfileImage(User user, MultipartFile profileImage) {
-		String prefix = imageService.createImagePrefix(user.getId(), user.getEmail());
-		String inputImageUrl = imageService.getImageName(ImageType.USER, prefix,
-			profileImage);
-		String userProfileImageUrl = URLDecoder.decode(imageService.parseImageName(user.getProfileImage()),
-			StandardCharsets.UTF_8);
-		return inputImageUrl.equals(userProfileImageUrl);
-	}
-
 	@Transactional
 	public void deleteUser(User user, DeleteUserRequest deleteUserRequest) {
 		if (!passwordEncoder.matches(deleteUserRequest.password(), user.getPassword())) {
@@ -187,6 +185,30 @@ public class UserService {
 		user.editPassword(encodedPassword);
 
 		userRepository.save(user);
+	}
+
+	@Transactional(readOnly = true)
+	public void checkBjNickname(String bjNickname) {
+		String bjUserUrl = BOJ_USER_PROFILE_URL + bjNickname;
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.set("User-Agent",
+			"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36");
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+
+		try {
+			restTemplate.exchange(bjUserUrl, HttpMethod.GET, entity, String.class);
+			// TODO : 백준 본인 인증 관련 사항 확정 후 로직 수정
+			// if (userRepository.existsByBjNickname(bjNickname))
+			// 	throw new CheckBjNicknameValidationException(HttpStatus.CONFLICT.value(), "이미 가입된 백준 닉네임 입니다.");
+		} catch (HttpClientErrorException e) {
+			if (e.getStatusCode() == HttpStatus.NOT_FOUND)
+				throw new CheckBjNicknameValidationException(HttpStatus.NOT_FOUND.value(), "백준 닉네임이 유효하지 않습니다.");
+		} catch (HttpServerErrorException e) {
+			log.error("BOJ server error occurred : " + e.getMessage());
+			throw new BOJServerErrorException("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+		}
+		log.info("success to check baekjoon nickname validity");
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -192,9 +192,6 @@ public class UserService {
 	public void registerBjNickname(User user, RegisterBjNickNameRequest request) {
 		String bjUserUrl = BOJ_USER_PROFILE_URL + request.bjNickName();
 
-		User editUser = userRepository.findById(user.getId())
-			.orElseThrow(() -> new UserValidationException("존재하지 않는 유저입니다."));
-
 		HttpHeaders headers = new HttpHeaders();
 		headers.set("User-Agent",
 			"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36");
@@ -213,8 +210,8 @@ public class UserService {
 			throw new BOJServerErrorException("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
 		}
 
-		editUser.editBjNickname(request.bjNickName());
-
+		user.editBjNickname(request.bjNickName());
+		userRepository.save(user);
 		log.info("success to register baekjoon-nickname user_id = {}", user.getId());
 	}
 

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -37,6 +37,7 @@ import com.gamzabat.algohub.feature.user.domain.ResetPassword;
 import com.gamzabat.algohub.feature.user.domain.User;
 import com.gamzabat.algohub.feature.user.dto.DeleteUserRequest;
 import com.gamzabat.algohub.feature.user.dto.EditUserPasswordRequest;
+import com.gamzabat.algohub.feature.user.dto.RegisterBjNickNameRequest;
 import com.gamzabat.algohub.feature.user.dto.RegisterRequest;
 import com.gamzabat.algohub.feature.user.dto.ResetPasswordRequest;
 import com.gamzabat.algohub.feature.user.dto.SignInRequest;
@@ -188,8 +189,8 @@ public class UserService {
 	}
 
 	@Transactional(readOnly = true)
-	public void checkBjNickname(String bjNickname) {
-		String bjUserUrl = BOJ_USER_PROFILE_URL + bjNickname;
+	public void registerBjNickName(User user, RegisterBjNickNameRequest request) {
+		String bjUserUrl = BOJ_USER_PROFILE_URL + request.bjNickName();
 
 		HttpHeaders headers = new HttpHeaders();
 		headers.set("User-Agent",
@@ -208,7 +209,8 @@ public class UserService {
 			log.error("BOJ server error occurred : " + e.getMessage());
 			throw new BOJServerErrorException("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
 		}
-		log.info("success to check baekjoon nickname validity");
+		user.editBjNickname(request.bjNickName());
+		log.info("success to register baekjoon nickname user_id = {}", user.getId());
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -189,7 +189,7 @@ public class UserService {
 	}
 
 	@Transactional
-	public void registerBjNickName(User user, RegisterBjNickNameRequest request) {
+	public void registerBjNickname(User user, RegisterBjNickNameRequest request) {
 		String bjUserUrl = BOJ_USER_PROFILE_URL + request.bjNickName();
 
 		HttpHeaders headers = new HttpHeaders();
@@ -210,9 +210,8 @@ public class UserService {
 			throw new BOJServerErrorException("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
 		}
 		user.editBjNickname(request.bjNickName());
-		userRepository.save(user);
 
-		log.info("success to register baekjoon nickname user_id = {}", user.getId());
+		log.info("success to register baekjoon-nickname user_id = {}", user.getId());
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -188,7 +188,7 @@ public class UserService {
 		userRepository.save(user);
 	}
 
-	@Transactional(readOnly = true)
+	@Transactional
 	public void registerBjNickName(User user, RegisterBjNickNameRequest request) {
 		String bjUserUrl = BOJ_USER_PROFILE_URL + request.bjNickName();
 
@@ -210,6 +210,8 @@ public class UserService {
 			throw new BOJServerErrorException("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
 		}
 		user.editBjNickname(request.bjNickName());
+		userRepository.save(user);
+
 		log.info("success to register baekjoon nickname user_id = {}", user.getId());
 	}
 

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -190,26 +190,7 @@ public class UserService {
 
 	@Transactional
 	public void registerBjNickname(User user, RegisterBjNickNameRequest request) {
-		String bjUserUrl = BOJ_USER_PROFILE_URL + request.bjNickName();
-
-		HttpHeaders headers = new HttpHeaders();
-		headers.set("User-Agent",
-			"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36");
-		HttpEntity<String> entity = new HttpEntity<>(headers);
-
-		try {
-			restTemplate.exchange(bjUserUrl, HttpMethod.GET, entity, String.class);
-			// TODO : 백준 본인 인증 관련 사항 확정 후 로직 수정
-			// if (userRepository.existsByBjNickname(bjNickname))
-			// 	throw new CheckBjNicknameValidationException(HttpStatus.CONFLICT.value(), "이미 가입된 백준 닉네임 입니다.");
-		} catch (HttpClientErrorException e) {
-			if (e.getStatusCode() == HttpStatus.NOT_FOUND)
-				throw new CheckBjNicknameValidationException(HttpStatus.NOT_FOUND.value(), "백준 닉네임이 유효하지 않습니다.");
-		} catch (HttpServerErrorException e) {
-			log.error("BOJ server error occurred : " + e.getMessage());
-			throw new BOJServerErrorException("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
-		}
-
+		validateBjNickname(request.bjNickName());
 		user.editBjNickname(request.bjNickName());
 		userRepository.save(user);
 		log.info("success to register baekjoon-nickname user_id = {}", user.getId());
@@ -217,25 +198,7 @@ public class UserService {
 
 	@Transactional(readOnly = true)
 	public void checkBjNickname(String bjNickname) {
-		String bjUserUrl = BOJ_USER_PROFILE_URL + bjNickname;
-
-		HttpHeaders headers = new HttpHeaders();
-		headers.set("User-Agent",
-			"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36");
-		HttpEntity<String> entity = new HttpEntity<>(headers);
-
-		try {
-			restTemplate.exchange(bjUserUrl, HttpMethod.GET, entity, String.class);
-			// TODO : 백준 본인 인증 관련 사항 확정 후 로직 수정
-			// if (userRepository.existsByBjNickname(bjNickname))
-			// 	throw new CheckBjNicknameValidationException(HttpStatus.CONFLICT.value(), "이미 가입된 백준 닉네임 입니다.");
-		} catch (HttpClientErrorException e) {
-			if (e.getStatusCode() == HttpStatus.NOT_FOUND)
-				throw new CheckBjNicknameValidationException(HttpStatus.NOT_FOUND.value(), "백준 닉네임이 유효하지 않습니다.");
-		} catch (HttpServerErrorException e) {
-			log.error("BOJ server error occurred : " + e.getMessage());
-			throw new BOJServerErrorException("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
-		}
+		validateBjNickname(bjNickname);
 		log.info("success to check baekjoon nickname validity nickname = {}", bjNickname);
 	}
 
@@ -364,6 +327,30 @@ public class UserService {
 		byte[] bytes = new byte[TOKEN_LENGTH];
 		new SecureRandom().nextBytes(bytes);
 		return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+	}
+
+	private void validateBjNickname(String bjNickname) {
+
+		String bjUserUrl = BOJ_USER_PROFILE_URL + bjNickname;
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.set("User-Agent",
+			"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36");
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+
+		try {
+			restTemplate.exchange(bjUserUrl, HttpMethod.GET, entity, String.class);
+			// TODO : 백준 본인 인증 관련 사항 확정 후 로직 수정
+			// if (userRepository.existsByBjNickname(bjNickname))
+			// 	throw new CheckBjNicknameValidationException(HttpStatus.CONFLICT.value(), "이미 가입된 백준 닉네임 입니다.");
+		} catch (HttpClientErrorException e) {
+			if (e.getStatusCode() == HttpStatus.NOT_FOUND)
+				throw new CheckBjNicknameValidationException(HttpStatus.NOT_FOUND.value(), "백준 닉네임이 유효하지 않습니다.");
+		} catch (HttpServerErrorException e) {
+			log.error("BOJ server error occurred : " + e.getMessage());
+			throw new BOJServerErrorException("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+		}
+
 	}
 
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -216,6 +216,30 @@ public class UserService {
 	}
 
 	@Transactional(readOnly = true)
+	public void checkBjNickname(String bjNickname) {
+		String bjUserUrl = BOJ_USER_PROFILE_URL + bjNickname;
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.set("User-Agent",
+			"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36");
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+
+		try {
+			restTemplate.exchange(bjUserUrl, HttpMethod.GET, entity, String.class);
+			// TODO : 백준 본인 인증 관련 사항 확정 후 로직 수정
+			// if (userRepository.existsByBjNickname(bjNickname))
+			// 	throw new CheckBjNicknameValidationException(HttpStatus.CONFLICT.value(), "이미 가입된 백준 닉네임 입니다.");
+		} catch (HttpClientErrorException e) {
+			if (e.getStatusCode() == HttpStatus.NOT_FOUND)
+				throw new CheckBjNicknameValidationException(HttpStatus.NOT_FOUND.value(), "백준 닉네임이 유효하지 않습니다.");
+		} catch (HttpServerErrorException e) {
+			log.error("BOJ server error occurred : " + e.getMessage());
+			throw new BOJServerErrorException("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+		}
+		log.info("success to check baekjoon nickname validity nickname = {}", bjNickname);
+	}
+
+	@Transactional(readOnly = true)
 	public void checkEmailDuplication(String email) {
 		if (userRepository.existsByEmail(email))
 			throw new UserValidationException("이미 사용 중인 이메일 입니다.");

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -1,7 +1,5 @@
 package com.gamzabat.algohub.feature.user.service;
 
-import static com.gamzabat.algohub.constants.ApiConstants.*;
-
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
@@ -10,9 +8,6 @@ import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.regex.Pattern;
 
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -21,8 +16,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -45,8 +38,6 @@ import com.gamzabat.algohub.feature.user.dto.SignInRequest;
 import com.gamzabat.algohub.feature.user.dto.TokenResponse;
 import com.gamzabat.algohub.feature.user.dto.UpdateUserRequest;
 import com.gamzabat.algohub.feature.user.dto.UserInfoResponse;
-import com.gamzabat.algohub.feature.user.exception.BOJServerErrorException;
-import com.gamzabat.algohub.feature.user.exception.CheckBjNicknameValidationException;
 import com.gamzabat.algohub.feature.user.exception.CheckEmailFormException;
 import com.gamzabat.algohub.feature.user.exception.CheckNicknameValidationException;
 import com.gamzabat.algohub.feature.user.exception.CheckPasswordFormException;
@@ -78,7 +69,6 @@ public class UserService {
 		checkEmailDuplication(request.email());
 		checkNickname(request.nickname());
 		checkEmailForm(request.email());
-		checkBjNickname(request.bjNickname());
 		checkPasswordForm(request.password());
 
 		String encodedPassword = passwordEncoder.encode(request.password());
@@ -87,7 +77,6 @@ public class UserService {
 			.email(request.email())
 			.password(encodedPassword)
 			.nickname(request.nickname())
-			.bjNickname(request.bjNickname())
 			.role(Role.USER)
 			.build());
 
@@ -198,30 +187,6 @@ public class UserService {
 		user.editPassword(encodedPassword);
 
 		userRepository.save(user);
-	}
-
-	@Transactional(readOnly = true)
-	public void checkBjNickname(String bjNickname) {
-		String bjUserUrl = BOJ_USER_PROFILE_URL + bjNickname;
-
-		HttpHeaders headers = new HttpHeaders();
-		headers.set("User-Agent",
-			"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36");
-		HttpEntity<String> entity = new HttpEntity<>(headers);
-
-		try {
-			restTemplate.exchange(bjUserUrl, HttpMethod.GET, entity, String.class);
-			// TODO : 백준 본인 인증 관련 사항 확정 후 로직 수정
-			// if (userRepository.existsByBjNickname(bjNickname))
-			// 	throw new CheckBjNicknameValidationException(HttpStatus.CONFLICT.value(), "이미 가입된 백준 닉네임 입니다.");
-		} catch (HttpClientErrorException e) {
-			if (e.getStatusCode() == HttpStatus.NOT_FOUND)
-				throw new CheckBjNicknameValidationException(HttpStatus.NOT_FOUND.value(), "백준 닉네임이 유효하지 않습니다.");
-		} catch (HttpServerErrorException e) {
-			log.error("BOJ server error occurred : " + e.getMessage());
-			throw new BOJServerErrorException("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
-		}
-		log.info("success to check baekjoon nickname validity");
 	}
 
 	@Transactional(readOnly = true)

--- a/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
@@ -37,6 +37,7 @@ import com.gamzabat.algohub.feature.image.service.ImageService;
 import com.gamzabat.algohub.feature.user.domain.User;
 import com.gamzabat.algohub.feature.user.dto.CheckEmailRequest;
 import com.gamzabat.algohub.feature.user.dto.DeleteUserRequest;
+import com.gamzabat.algohub.feature.user.dto.RegisterBjNickNameRequest;
 import com.gamzabat.algohub.feature.user.dto.RegisterRequest;
 import com.gamzabat.algohub.feature.user.dto.SignInRequest;
 import com.gamzabat.algohub.feature.user.dto.TokenResponse;
@@ -88,7 +89,7 @@ class UserControllerTest {
 	@DisplayName("회원 가입 성공")
 	void register() throws Exception {
 		// given
-		RegisterRequest request = new RegisterRequest("email", "password", "nickname", "bojNickname");
+		RegisterRequest request = new RegisterRequest("email", "password", "nickname");
 		String requestJson = objectMapper.writeValueAsString(request);
 		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
 			requestJson.getBytes());
@@ -110,7 +111,7 @@ class UserControllerTest {
 	@DisplayName("회원 가입 성공 : 프로필 사진 X")
 	void register_2() throws Exception {
 		// given
-		RegisterRequest request = new RegisterRequest("email", "password", "nickname", "bojNickname");
+		RegisterRequest request = new RegisterRequest("email", "password", "nickname");
 		String requestJson = objectMapper.writeValueAsString(request);
 		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
 			requestJson.getBytes());
@@ -127,16 +128,15 @@ class UserControllerTest {
 
 	@ParameterizedTest
 	@CsvSource(value = {
-		" ' ', password, nickname, bjNickname, email : 이메일은 필수 입력입니다.",
-		"email, ' ', nickname, bjNickname, password : 비밀번호는 필수 입력입니다.",
-		"email, password, ' ', bjNickname, nickname : 닉네임은 필수 입력입니다.",
-		"email, password, nickname, ' ', bjNickname : 백준 닉네임은 필수 입력입니다."
+		" ' ', password, nickname, email : 이메일은 필수 입력입니다.",
+		"email, ' ', nickname, password : 비밀번호는 필수 입력입니다.",
+		"email, password, ' ', nickname : 닉네임은 필수 입력입니다.",
 	}, nullValues = "null")
 	@DisplayName("회원 가입 실패 : 잘못된 요청")
-	void registerFailed_1(String email, String password, String nickname, String bjNickname,
+	void registerFailed_1(String email, String password, String nickname,
 		String exceptionMessage) throws Exception {
 		// given
-		RegisterRequest request = new RegisterRequest(email, password, nickname, bjNickname);
+		RegisterRequest request = new RegisterRequest(email, password, nickname);
 		String requestJson = objectMapper.writeValueAsString(request);
 		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
 			requestJson.getBytes());
@@ -157,7 +157,7 @@ class UserControllerTest {
 	@DisplayName("회원가입 실패 : 이미 가입 된 이메일")
 	void registerFailed_2() throws Exception {
 		// given
-		RegisterRequest request = new RegisterRequest("duplicatedEmail", "password", "nickname", "bjNickname");
+		RegisterRequest request = new RegisterRequest("duplicatedEmail", "password", "nickname");
 		String requestJson = objectMapper.writeValueAsString(request);
 		MockMultipartFile requestPart = new MockMultipartFile("request", "", "application/json",
 			requestJson.getBytes());
@@ -338,61 +338,52 @@ class UserControllerTest {
 	}
 
 	@Test
-	@DisplayName("백준 닉네임 검증 : 사용 가능한 백준 닉네임")
-	void checkBjNickname() throws Exception {
+	@DisplayName("백준 닉네임 연결 성공 : 사용 가능한 백준 닉네임")
+	void registerBjNickName() throws Exception {
 		// given
-		String bjNickname = "bjNickname";
-		doNothing().when(userService).checkBjNickname(bjNickname);
+		RegisterBjNickNameRequest request = new RegisterBjNickNameRequest("bjNickName");
+		doNothing().when(userService).registerBjNickName(user, request);
 		// when, then
-		mockMvc.perform(get("/api/users/check-baekjoon-nickname")
-				.param("bjNickname", bjNickname))
+		mockMvc.perform(patch("/api/users/bjnickname")
+				.header("Authorization", token)
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk());
-		verify(userService, times(1)).checkBjNickname(bjNickname);
+		verify(userService, times(1)).registerBjNickName(user, request);
 	}
 
 	@Test
-	@DisplayName("백준 닉네임 검증 : 유효하지 않은 백준 닉네임")
+	@DisplayName("백준 닉네임 연결 실패 : 유효하지 않은 백준 닉네임")
 	void checkBjNicknameFailed_1() throws Exception {
 		// given
-		String bjNickname = "bjNickname";
+		RegisterBjNickNameRequest request = new RegisterBjNickNameRequest("bjNickName");
 		doThrow(new CheckBjNicknameValidationException(HttpStatus.NOT_FOUND.value(), "백준 닉네임이 유효하지 않습니다.")).when(
-			userService).checkBjNickname(bjNickname);
+			userService).registerBjNickName(user, request);
 		// when, then
-		mockMvc.perform(get("/api/users/check-baekjoon-nickname")
-				.param("bjNickname", bjNickname))
+		mockMvc.perform(patch("/api/users/bjnickname")
+				.header("Authorization", token)
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.error").value("백준 닉네임이 유효하지 않습니다."));
-		verify(userService, times(1)).checkBjNickname(bjNickname);
+		verify(userService, times(1)).registerBjNickName(user, request);
 	}
 
 	@Test
-	@DisplayName("백준 닉네임 검증 : 이미 가입된 백준 닉네임")
-	void checkBjNicknameFailed_2() throws Exception {
-		// given
-		String bjNickname = "bjNickname";
-		doThrow(new CheckBjNicknameValidationException(HttpStatus.CONFLICT.value(), "이미 가입된 백준 닉네임 입니다.")).when(
-			userService).checkBjNickname(bjNickname);
-		// when, then
-		mockMvc.perform(get("/api/users/check-baekjoon-nickname")
-				.param("bjNickname", bjNickname))
-			.andExpect(status().isConflict())
-			.andExpect(jsonPath("$.error").value("이미 가입된 백준 닉네임 입니다."));
-		verify(userService, times(1)).checkBjNickname(bjNickname);
-	}
-
-	@Test
-	@DisplayName("백준 닉네임 검증 실패: 백준 서버 오류 발생")
+	@DisplayName("백준 닉네임 연결 실패: 백준 서버 오류 발생")
 	void checkBjNicknameFailed_3() throws Exception {
 		// given
-		String bjNickname = "bjNickname";
+		RegisterBjNickNameRequest request = new RegisterBjNickNameRequest("bjNickName");
 		doThrow(new BOJServerErrorException("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요."))
-			.when(userService).checkBjNickname(bjNickname);
+			.when(userService).registerBjNickName(user, request);
 		// when, then
-		mockMvc.perform(get("/api/users/check-baekjoon-nickname")
-				.param("bjNickname", bjNickname))
+		mockMvc.perform(patch("/api/users/bjnickname")
+				.header("Authorization", token)
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isServiceUnavailable())
 			.andExpect(jsonPath("$.error").value("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요."));
-		verify(userService, times(1)).checkBjNickname(bjNickname);
+		verify(userService, times(1)).registerBjNickName(user, request);
 	}
 
 	@Test

--- a/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
@@ -339,17 +339,17 @@ class UserControllerTest {
 
 	@Test
 	@DisplayName("백준 닉네임 연결 성공 : 사용 가능한 백준 닉네임")
-	void registerBjNickName() throws Exception {
+	void registerBjNickname() throws Exception {
 		// given
 		RegisterBjNickNameRequest request = new RegisterBjNickNameRequest("bjNickName");
-		doNothing().when(userService).registerBjNickName(user, request);
+		doNothing().when(userService).registerBjNickname(user, request);
 		// when, then
-		mockMvc.perform(patch("/api/users/bjnickname")
+		mockMvc.perform(patch("/api/users/baekjoon-nickname")
 				.header("Authorization", token)
 				.content(objectMapper.writeValueAsString(request))
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk());
-		verify(userService, times(1)).registerBjNickName(user, request);
+		verify(userService, times(1)).registerBjNickname(user, request);
 	}
 
 	@Test
@@ -358,15 +358,15 @@ class UserControllerTest {
 		// given
 		RegisterBjNickNameRequest request = new RegisterBjNickNameRequest("bjNickName");
 		doThrow(new CheckBjNicknameValidationException(HttpStatus.NOT_FOUND.value(), "백준 닉네임이 유효하지 않습니다.")).when(
-			userService).registerBjNickName(user, request);
+			userService).registerBjNickname(user, request);
 		// when, then
-		mockMvc.perform(patch("/api/users/bjnickname")
+		mockMvc.perform(patch("/api/users/baekjoon-nickname")
 				.header("Authorization", token)
 				.content(objectMapper.writeValueAsString(request))
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.error").value("백준 닉네임이 유효하지 않습니다."));
-		verify(userService, times(1)).registerBjNickName(user, request);
+		verify(userService, times(1)).registerBjNickname(user, request);
 	}
 
 	@Test
@@ -375,15 +375,15 @@ class UserControllerTest {
 		// given
 		RegisterBjNickNameRequest request = new RegisterBjNickNameRequest("bjNickName");
 		doThrow(new BOJServerErrorException("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요."))
-			.when(userService).registerBjNickName(user, request);
+			.when(userService).registerBjNickname(user, request);
 		// when, then
-		mockMvc.perform(patch("/api/users/bjnickname")
+		mockMvc.perform(patch("/api/users/baekjoon-nickname")
 				.header("Authorization", token)
 				.content(objectMapper.writeValueAsString(request))
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isServiceUnavailable())
 			.andExpect(jsonPath("$.error").value("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요."));
-		verify(userService, times(1)).registerBjNickName(user, request);
+		verify(userService, times(1)).registerBjNickname(user, request);
 	}
 
 	@Test

--- a/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
@@ -354,7 +354,7 @@ class UserControllerTest {
 
 	@Test
 	@DisplayName("백준 닉네임 연결 실패 : 유효하지 않은 백준 닉네임")
-	void checkBjNicknameFailed_1() throws Exception {
+	void registerBjNicknameFailed_1() throws Exception {
 		// given
 		RegisterBjNickNameRequest request = new RegisterBjNickNameRequest("bjNickName");
 		doThrow(new CheckBjNicknameValidationException(HttpStatus.NOT_FOUND.value(), "백준 닉네임이 유효하지 않습니다.")).when(
@@ -371,7 +371,7 @@ class UserControllerTest {
 
 	@Test
 	@DisplayName("백준 닉네임 연결 실패: 백준 서버 오류 발생")
-	void checkBjNicknameFailed_3() throws Exception {
+	void registerBjNicknameFailed_3() throws Exception {
 		// given
 		RegisterBjNickNameRequest request = new RegisterBjNickNameRequest("bjNickName");
 		doThrow(new BOJServerErrorException("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요."))
@@ -384,6 +384,54 @@ class UserControllerTest {
 			.andExpect(status().isServiceUnavailable())
 			.andExpect(jsonPath("$.error").value("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요."));
 		verify(userService, times(1)).registerBjNickname(user, request);
+	}
+
+	@Test
+	@DisplayName("백준 닉네임 검증 성공")
+	void checkBjNickname() throws Exception {
+		//given
+		String bjNickname = "string";
+		doNothing().when(userService).checkBjNickname(bjNickname);
+		//when,then
+		mockMvc.perform(get("/api/users/check-baekjoon-nickname")
+				.header("Authorization", token)
+				.param("bjNickname", bjNickname))
+			.andExpect(status().isOk());
+		verify(userService, times(1)).checkBjNickname(bjNickname);
+	}
+
+	@Test
+	@DisplayName("백준 닉네임 검증 실패 : 유효하지 않은 백준 닉네임")
+	void checkBjNicknameFailed_1() throws Exception {
+		String bjNickname = "bjNickName";
+		doThrow(new CheckBjNicknameValidationException(HttpStatus.NOT_FOUND.value(), "백준 닉네임이 유효하지 않습니다.")).when(
+				userService)
+			.checkBjNickname(bjNickname);
+		//when,then
+		mockMvc.perform(get("/api/users/check-baekjoon-nickname")
+				.header("Authorization", token)
+				.param("bjNickname", bjNickname))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.error").value("백준 닉네임이 유효하지 않습니다."));
+		verify(userService, times(1)).checkBjNickname(bjNickname);
+
+	}
+
+	@Test
+	@DisplayName("백준 닉네임 검증 실패 : 백준 서버 에러")
+	void checkBjNicknameFailed_2() throws Exception {
+		String bjNickname = "bjNickName";
+		doThrow(new BOJServerErrorException("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.")).when(
+				userService)
+			.checkBjNickname(bjNickname);
+		//when,then
+		mockMvc.perform(get("/api/users/check-baekjoon-nickname")
+				.header("Authorization", token)
+				.param("bjNickname", bjNickname))
+			.andExpect(status().isServiceUnavailable())
+			.andExpect(jsonPath("$.error").value("현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요."));
+		verify(userService, times(1)).checkBjNickname(bjNickname);
+
 	}
 
 	@Test

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -47,6 +47,7 @@ import com.gamzabat.algohub.feature.user.domain.ResetPassword;
 import com.gamzabat.algohub.feature.user.domain.User;
 import com.gamzabat.algohub.feature.user.dto.DeleteUserRequest;
 import com.gamzabat.algohub.feature.user.dto.EditUserPasswordRequest;
+import com.gamzabat.algohub.feature.user.dto.RegisterBjNickNameRequest;
 import com.gamzabat.algohub.feature.user.dto.RegisterRequest;
 import com.gamzabat.algohub.feature.user.dto.ResetPasswordRequest;
 import com.gamzabat.algohub.feature.user.dto.SignInRequest;
@@ -223,7 +224,6 @@ class UserServiceTest {
 		assertThat(response.getEmail()).isEqualTo(email);
 		assertThat(response.getNickname()).isEqualTo(nickname);
 		assertThat(response.getProfileImage()).isEqualTo(imageUrl);
-		assertThat(response.getBjNickname()).isEqualTo(bjNickname);
 		assertThat(response.getDescription()).isEqualTo("");
 	}
 
@@ -285,12 +285,13 @@ class UserServiceTest {
 	@DisplayName("백준 닉네임 유효성 검증 : 사용 가능한 백준 닉네임")
 	void checkBjNickname_1() {
 		// given
+		RegisterBjNickNameRequest request = new RegisterBjNickNameRequest("bjNickname");
 		String bjNickname = "bjNickname";
 		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
 			.thenReturn(new ResponseEntity<>(HttpStatus.OK));
 		// when(userRepository.existsByBjNickname(bjNickname)).thenReturn(false);
 		// when
-		userService.checkBjNickname(bjNickname);
+		userService.registerBjNickName(user, request);
 		// then
 		// verify(userRepository, times(1)).existsByBjNickname(bjNickname);
 	}
@@ -299,11 +300,11 @@ class UserServiceTest {
 	@DisplayName("백준 닉네임 유효성 검증 : 유효하지 않은 백준 닉네임")
 	void checkBjNickname_2() {
 		// given
-		String bjNickname = "bjNickname";
+		RegisterBjNickNameRequest request = new RegisterBjNickNameRequest("bjNickname");
 		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
 			.thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
 		// when, then
-		assertThatThrownBy(() -> userService.checkBjNickname(bjNickname))
+		assertThatThrownBy(() -> userService.registerBjNickName(user, request))
 			.isInstanceOf(CheckBjNicknameValidationException.class)
 			.hasFieldOrPropertyWithValue("code", HttpStatus.NOT_FOUND.value())
 			.hasFieldOrPropertyWithValue("error", "백준 닉네임이 유효하지 않습니다.");
@@ -313,11 +314,11 @@ class UserServiceTest {
 	@DisplayName("백준 닉네임 유효성 검증 실패 : 백준 서버 오류 발생")
 	void checkBjNickname_4() {
 		// given
-		String bjNickname = "bjNickname";
+		RegisterBjNickNameRequest request = new RegisterBjNickNameRequest("bjNickname");
 		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
 			.thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
 		// when, then
-		assertThatThrownBy(() -> userService.checkBjNickname(bjNickname))
+		assertThatThrownBy(() -> userService.registerBjNickName(user, request))
 			.isInstanceOf(BOJServerErrorException.class)
 			.hasFieldOrPropertyWithValue("error", "현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
 	}
@@ -504,7 +505,7 @@ class UserServiceTest {
 
 		//when, then
 		try (MockedStatic<LocalDateTime> mockedStatic = mockStatic(LocalDateTime.class)) {
-			mockedStatic.when(LocalDateTime::now).thenReturn(now.plusHours(3));
+			mockedStatic.when(LocalDateTime::now).thenReturn(now.plusHours(4));
 			assertThatThrownBy(() -> userService.resetPassword(request))
 				.isInstanceOf(ResetPasswordValidationError.class)
 				.satisfies(exception -> {

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -289,7 +289,6 @@ class UserServiceTest {
 		String bjNickname = "bjNickname";
 		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
 			.thenReturn(new ResponseEntity<>(HttpStatus.OK));
-		when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
 		// when(userRepository.existsByBjNickname(bjNickname)).thenReturn(false);
 		// when
 		userService.registerBjNickname(user, request);
@@ -305,7 +304,6 @@ class UserServiceTest {
 		RegisterBjNickNameRequest request = new RegisterBjNickNameRequest("bjNickname");
 		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
 			.thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
-		when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
 
 		// when, then
 		assertThatThrownBy(() -> userService.registerBjNickname(user, request))
@@ -321,7 +319,6 @@ class UserServiceTest {
 		RegisterBjNickNameRequest request = new RegisterBjNickNameRequest("bjNickname");
 		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
 			.thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
-		when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
 
 		// when, then
 		assertThatThrownBy(() -> userService.registerBjNickname(user, request))

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -282,8 +282,8 @@ class UserServiceTest {
 	}
 
 	@Test
-	@DisplayName("백준 닉네임 유효성 검증 : 사용 가능한 백준 닉네임")
-	void checkBjNickname_1() {
+	@DisplayName("백준 닉네임 등록 성공 : 사용 가능한 백준 닉네임")
+	void registerBjNickname_1() {
 		// given
 		RegisterBjNickNameRequest request = new RegisterBjNickNameRequest("bjNickname");
 		String bjNickname = "bjNickname";
@@ -291,20 +291,21 @@ class UserServiceTest {
 			.thenReturn(new ResponseEntity<>(HttpStatus.OK));
 		// when(userRepository.existsByBjNickname(bjNickname)).thenReturn(false);
 		// when
-		userService.registerBjNickName(user, request);
+		userService.registerBjNickname(user, request);
+		assertThat(user.getBjNickname()).isEqualTo(bjNickname);
 		// then
 		// verify(userRepository, times(1)).existsByBjNickname(bjNickname);
 	}
 
 	@Test
 	@DisplayName("백준 닉네임 유효성 검증 : 유효하지 않은 백준 닉네임")
-	void checkBjNickname_2() {
+	void registerBjNickname_2() {
 		// given
 		RegisterBjNickNameRequest request = new RegisterBjNickNameRequest("bjNickname");
 		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
 			.thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
 		// when, then
-		assertThatThrownBy(() -> userService.registerBjNickName(user, request))
+		assertThatThrownBy(() -> userService.registerBjNickname(user, request))
 			.isInstanceOf(CheckBjNicknameValidationException.class)
 			.hasFieldOrPropertyWithValue("code", HttpStatus.NOT_FOUND.value())
 			.hasFieldOrPropertyWithValue("error", "백준 닉네임이 유효하지 않습니다.");
@@ -318,7 +319,7 @@ class UserServiceTest {
 		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
 			.thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
 		// when, then
-		assertThatThrownBy(() -> userService.registerBjNickName(user, request))
+		assertThatThrownBy(() -> userService.registerBjNickname(user, request))
 			.isInstanceOf(BOJServerErrorException.class)
 			.hasFieldOrPropertyWithValue("error", "현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
 	}
@@ -505,7 +506,7 @@ class UserServiceTest {
 
 		//when, then
 		try (MockedStatic<LocalDateTime> mockedStatic = mockStatic(LocalDateTime.class)) {
-			mockedStatic.when(LocalDateTime::now).thenReturn(now.plusHours(4));
+			mockedStatic.when(LocalDateTime::now).thenReturn(now.plusHours(3));
 			assertThatThrownBy(() -> userService.resetPassword(request))
 				.isInstanceOf(ResetPasswordValidationError.class)
 				.satisfies(exception -> {

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -107,7 +107,6 @@ class UserServiceTest {
 			.email(email)
 			.password(encoded)
 			.nickname(nickname)
-			.bjNickname(bjNickname)
 			.profileImage(imageUrl)
 			.role(Role.USER)
 			.build();
@@ -130,7 +129,7 @@ class UserServiceTest {
 	void register() {
 		// given
 		String prefix = "1_test@email.com";
-		RegisterRequest request = new RegisterRequest(email, password, nickname, bjNickname);
+		RegisterRequest request = new RegisterRequest(email, password, nickname);
 		MockMultipartFile profileImage = new MockMultipartFile("image", "image.jpg", "image/jpeg", "test".getBytes());
 		when(userRepository.save(any(User.class))).thenReturn(user);
 		when(imageService.createImagePrefix(user.getId(), user.getEmail())).thenReturn(prefix);
@@ -153,7 +152,7 @@ class UserServiceTest {
 	@DisplayName("회원가입 실패 : 이미 가입 된 이메일")
 	void registerFailed_1() {
 		// given
-		RegisterRequest request = new RegisterRequest(email, password, nickname, bjNickname);
+		RegisterRequest request = new RegisterRequest(email, password, nickname);
 		MockMultipartFile profileImage = new MockMultipartFile("image", "image.jpg", "image/jpeg", "test".getBytes());
 		when(userRepository.existsByEmail(email)).thenReturn(true);
 		// when, then

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -298,7 +298,7 @@ class UserServiceTest {
 	}
 
 	@Test
-	@DisplayName("백준 닉네임 유효성 검증 : 유효하지 않은 백준 닉네임")
+	@DisplayName("백준 닉네임 등록 실패 : 유효하지 않은 백준 닉네임")
 	void registerBjNickname_2() {
 		// given
 		RegisterBjNickNameRequest request = new RegisterBjNickNameRequest("bjNickname");
@@ -313,7 +313,7 @@ class UserServiceTest {
 	}
 
 	@Test
-	@DisplayName("백준 닉네임 유효성 검증 실패 : 백준 서버 오류 발생")
+	@DisplayName("백준 닉네임 등록 실패 : 백준 서버 오류 발생")
 	void checkBjNickname_4() {
 		// given
 		RegisterBjNickNameRequest request = new RegisterBjNickNameRequest("bjNickname");

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -289,6 +289,7 @@ class UserServiceTest {
 		String bjNickname = "bjNickname";
 		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
 			.thenReturn(new ResponseEntity<>(HttpStatus.OK));
+		when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
 		// when(userRepository.existsByBjNickname(bjNickname)).thenReturn(false);
 		// when
 		userService.registerBjNickname(user, request);
@@ -304,6 +305,8 @@ class UserServiceTest {
 		RegisterBjNickNameRequest request = new RegisterBjNickNameRequest("bjNickname");
 		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
 			.thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+		when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+
 		// when, then
 		assertThatThrownBy(() -> userService.registerBjNickname(user, request))
 			.isInstanceOf(CheckBjNicknameValidationException.class)
@@ -318,6 +321,8 @@ class UserServiceTest {
 		RegisterBjNickNameRequest request = new RegisterBjNickNameRequest("bjNickname");
 		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
 			.thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
+		when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+
 		// when, then
 		assertThatThrownBy(() -> userService.registerBjNickname(user, request))
 			.isInstanceOf(BOJServerErrorException.class)

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -108,6 +108,7 @@ class UserServiceTest {
 			.email(email)
 			.password(encoded)
 			.nickname(nickname)
+			.bjNickname(bjNickname)
 			.profileImage(imageUrl)
 			.role(Role.USER)
 			.build();
@@ -285,8 +286,8 @@ class UserServiceTest {
 	@DisplayName("백준 닉네임 등록 성공 : 사용 가능한 백준 닉네임")
 	void registerBjNickname_1() {
 		// given
-		RegisterBjNickNameRequest request = new RegisterBjNickNameRequest("bjNickname");
-		String bjNickname = "bjNickname";
+		RegisterBjNickNameRequest request = new RegisterBjNickNameRequest("newBjNickname");
+		String bjNickname = "newBjNickname";
 		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
 			.thenReturn(new ResponseEntity<>(HttpStatus.OK));
 		// when(userRepository.existsByBjNickname(bjNickname)).thenReturn(false);
@@ -322,6 +323,46 @@ class UserServiceTest {
 
 		// when, then
 		assertThatThrownBy(() -> userService.registerBjNickname(user, request))
+			.isInstanceOf(BOJServerErrorException.class)
+			.hasFieldOrPropertyWithValue("error", "현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+	}
+
+	@Test
+	@DisplayName("백준 닉네임 유효성 검증 : 사용 가능한 백준 닉네임")
+	void checkBjNickname_1() {
+		// given
+		String bjNickname = "bjNickname";
+		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+			.thenReturn(new ResponseEntity<>(HttpStatus.OK));
+		// when
+		userService.checkBjNickname(bjNickname);
+		// then
+		assertThat(user.getBjNickname()).isEqualTo(bjNickname);
+	}
+
+	@Test
+	@DisplayName("백준 닉네임 유효성 검증 실패 : 사용 불가능한 백준 닉네임")
+	void checkBjNicknamefailed_1() {
+		//given
+		String bjNickName = "bjNickName";
+		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+			.thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+		//when,then
+		assertThatThrownBy(() -> userService.checkBjNickname(bjNickName))
+			.isInstanceOf(CheckBjNicknameValidationException.class)
+			.hasFieldOrPropertyWithValue("code", HttpStatus.NOT_FOUND.value())
+			.hasFieldOrPropertyWithValue("error", "백준 닉네임이 유효하지 않습니다.");
+	}
+
+	@Test
+	@DisplayName("백준 닉네임 유효성 검증 실패 : 백준 서버 에러")
+	void checkBjNicknamefailed_2() {
+		//given
+		String bjNickname = "bjNickname";
+		when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+			.thenThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
+		//when,then
+		assertThatThrownBy(() -> userService.checkBjNickname(bjNickname))
 			.isInstanceOf(BOJServerErrorException.class)
 			.hasFieldOrPropertyWithValue("error", "현재 백준 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
 	}


### PR DESCRIPTION
## 📌 Related Issue
close #346 

## 🚀 Description
- 회원가입시 백준ID 입력 제거
- 백준ID 연결 API 따로 분리

## 📢 Review Point
- 사실 은수님이 다 만들어 놓으신 코드에 몇줄만 추가했습니다
- ControllerTest도 일부 수정이 필요해서 해봤는데 기존에 있던 Controller 보고 흐름만 살짝 이해하고 바꾸어 봤는데 피드백 부탁드립니다 .

+) 비밀번호 재설정 토큰 만료시 실패하는 test가 plusHour(3) 일 때 테스트가 실패하더라구요 그래서 제 맘대로 4로 바꿨읍니다 .. 이것도 괜찮을지 확인 부탁드립니다.