### PR TITLE
feat: 소셜 로그인 회원 탈퇴

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/controller/UserController.java
@@ -141,7 +141,7 @@ public class UserController {
 	}
 
 	@DeleteMapping(value = "/users/me")
-	@Operation(summary = "회원 정보 삭제 API")
+	@Operation(summary = "회원 탈퇴 API")
 	public ResponseEntity<Void> deleteUser(@AuthedUser User user, @Valid @RequestBody DeleteUserRequest request,
 		Errors errors) {
 		if (errors.hasErrors()) {

--- a/src/main/java/com/gamzabat/algohub/feature/user/dto/DeleteUserRequest.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/dto/DeleteUserRequest.java
@@ -1,6 +1,7 @@
 package com.gamzabat.algohub.feature.user.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
-public record DeleteUserRequest(@NotBlank(message = "비밀번호는 필수 입력입니다.") String password) {
+public record DeleteUserRequest(@NotNull(message = "소셜 로그인 여부는 필수 입력입니다.") Boolean isOAuthAccount,
+								String password) {
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/dto/UserInfoResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/dto/UserInfoResponse.java
@@ -12,5 +12,6 @@ public class UserInfoResponse {
 	private String nickname;
 	private String profileImage;
 	private String bjNickname;
+	private String githubName;
 	private String description;
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -119,7 +119,12 @@ public class UserService {
 
 	@Transactional(readOnly = true)
 	public UserInfoResponse userInfo(User user) {
-		return new UserInfoResponse(user.getEmail(), user.getNickname(), user.getProfileImage(), user.getBjNickname(),
+		return new UserInfoResponse(
+			user.getEmail(),
+			user.getNickname(),
+			user.getProfileImage(),
+			user.getBjNickname(),
+			user.getGithubName(),
 			user.getDescription());
 	}
 
@@ -248,6 +253,7 @@ public class UserService {
 
 		return new UserInfoResponse(targetUser.getEmail(), targetUser.getNickname(), targetUser.getProfileImage(),
 			targetUser.getBjNickname(),
+			targetUser.getGithubName(),
 			targetUser.getDescription());
 	}
 

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -166,6 +166,10 @@ public class UserService {
 
 	@Transactional
 	public void deleteUser(User user, DeleteUserRequest deleteUserRequest) {
+		if (deleteUserRequest.isOAuthAccount()) {
+			userRepository.delete(user);
+			return;
+		}
 		if (!passwordEncoder.matches(deleteUserRequest.password(), user.getPassword())) {
 			throw new UncorrectedPasswordException("비밀번호가 틀렸습니다.");
 		}

--- a/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
@@ -280,7 +280,7 @@ class UserControllerTest {
 	@DisplayName("회원 정보 조회 성공")
 	void getUserInfo() throws Exception {
 		// given
-		UserInfoResponse response = new UserInfoResponse("email", "nickname", "profileImage", "bjNickname", "");
+		UserInfoResponse response = new UserInfoResponse("email", "nickname", "profileImage", "bjNickname", "", "");
 		when(userService.userInfo(user)).thenReturn(response);
 		// when, then
 		mockMvc.perform(get("/api/users/me")

--- a/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
@@ -299,7 +299,7 @@ class UserControllerTest {
 	@DisplayName("회원 탈퇴 성공")
 	void deleteUser() throws Exception {
 		// given
-		DeleteUserRequest request = new DeleteUserRequest("password");
+		DeleteUserRequest request = new DeleteUserRequest(false, "password");
 		// when, then
 		mockMvc.perform(delete("/api/users/me")
 				.header("Authorization", token)
@@ -314,7 +314,7 @@ class UserControllerTest {
 	@DisplayName("회원 탈퇴 실패 : 잘못된 요청")
 	void deleteUserFailed_1() throws Exception {
 		// given
-		DeleteUserRequest request = new DeleteUserRequest("");
+		DeleteUserRequest request = new DeleteUserRequest(null, "");
 		// when, then
 		mockMvc.perform(delete("/api/users/me")
 				.header("Authorization", token)
@@ -322,14 +322,14 @@ class UserControllerTest {
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.error").value("올바르지 않은 요청입니다."))
-			.andExpect(jsonPath("$.messages", hasItem("password : 비밀번호는 필수 입력입니다.")));
+			.andExpect(jsonPath("$.messages", hasItem("isOAuthAccount : 소셜 로그인 여부는 필수 입력입니다.")));
 	}
 
 	@Test
 	@DisplayName("회원 탈퇴 실패 : 틀린 비밀번호")
 	void deleteUserFailed_2() throws Exception {
 		// given
-		DeleteUserRequest request = new DeleteUserRequest("invalidPassword");
+		DeleteUserRequest request = new DeleteUserRequest(false, "invalidPassword");
 		doThrow(new UncorrectedPasswordException("비밀번호가 틀렸습니다.")).when(userService).deleteUser(user, request);
 		// when, then
 		mockMvc.perform(delete("/api/users/me")

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -260,8 +260,19 @@ class UserServiceTest {
 	@DisplayName("회원 탈퇴 성공")
 	void deleteUser() {
 		// given
-		DeleteUserRequest request = new DeleteUserRequest(password);
+		DeleteUserRequest request = new DeleteUserRequest(false, password);
 		when(passwordEncoder.matches(password, user.getPassword())).thenReturn(true);
+		// when
+		userService.deleteUser(user, request);
+		// then
+		verify(userRepository, times(1)).delete(user);
+	}
+
+	@Test
+	@DisplayName("소셜 로그인 회원 탈퇴 성공")
+	void deleteOAuthUser() {
+		// given
+		DeleteUserRequest request = new DeleteUserRequest(true, null);
 		// when
 		userService.deleteUser(user, request);
 		// then
@@ -272,7 +283,7 @@ class UserServiceTest {
 	@DisplayName("회원 탈퇴 실패 : 틀린 비밀번호")
 	void deleteUserFailed() {
 		// given
-		DeleteUserRequest request = new DeleteUserRequest(password);
+		DeleteUserRequest request = new DeleteUserRequest(false, password);
 		when(passwordEncoder.matches(password, user.getPassword())).thenReturn(false);
 		// when, then
 		assertThatThrownBy(() -> userService.deleteUser(user, request))


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://github.com/GAMZA-BAT/algohub-server/issues/362
close be-6

## 🚀 Description
<!-- 작업 내용 -->
- 소셜 로그인으로 회원가입한 유저의 경우, 비밀번호를 설정하지 않아 기존 회원 탈퇴 API를 사용하면 정상적인 탈퇴가 불가능 합니다.
- request에 `isOAuthAccount`를 받아 해당 유저가 소셜 로그인 유저면 비밀번호 검증 없이 즉시 회원 탈퇴가 진행됩니다. 
- 소셜 로그인 유저가 아닐 경우 비밀번호 검증 이후에 회원 탈퇴를 진행합니다.

- 기존 회원 정보 조회 response에도 `githubName`를 추가해 소셜 로그인한 유저인지 구분하도록 만들었습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
- 소셜 로그인의 회원 탈퇴를 다른 곳들에서는 어떻게 하나 찾아봤는데, 별다른 검증 없이 탈퇴시켜주더라구요.
- 뭐 다른 방법이 있는진 모르겠습니다. 아는 분 있으면 알려주세요
- 소셜 로그인 유저일 경우 비밀번호가 null일 것을 대비해서 request의 password에 `@NotBlank` 어노테이션을 제거했는데, 만약 `isOAuthAccount`가 false인 채로 password를 null로 전송하면 비밀번호 매칭 메서드에서 NPE가 발생합니다..
- 사용자측에선 일어날 일 없는거고 아마 API를 사용하는 측의 실수로 발생할 수 있는 케이스인 것 같은데, 이런 API 오사용에 대한 검증도 꼼꼼하게 추가를 해야할지 고민입니다

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->