### PR TITLE
refactor : 공지 단건 조회시 image같이 전달

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/notice/service/NoticeService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notice/service/NoticeService.java
@@ -77,6 +77,7 @@ public class NoticeService {
 		log.info("success to get notice");
 		return GetNoticeResponse.builder()
 			.author(notice.getAuthor().getNickname())
+			.authorImage(notice.getAuthor().getProfileImage())
 			.noticeId(notice.getId())
 			.title(notice.getTitle())
 			.content(notice.getContent())


### PR DESCRIPTION
## 📌 Related Issue
close be-12

## 🚀 Description
- 공지 단건 조회시 작성자의 프로필 이미지를 전송하지 않았었던걸 수정했습니다

## 📢 Review Point

## 📚Etc (선택)
