### PR TITLE
fix : OAuth 회원 탈퇴 로직 수정

### DIFF
--- a/src/main/java/com/gamzabat/algohub/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/gamzabat/algohub/exception/CustomExceptionHandler.java
@@ -30,6 +30,7 @@ import com.gamzabat.algohub.feature.user.exception.CheckBjNicknameValidationExce
 import com.gamzabat.algohub.feature.user.exception.CheckEmailFormException;
 import com.gamzabat.algohub.feature.user.exception.CheckNicknameValidationException;
 import com.gamzabat.algohub.feature.user.exception.CheckPasswordFormException;
+import com.gamzabat.algohub.feature.user.exception.InvalidDeleteUserRequestException;
 import com.gamzabat.algohub.feature.user.exception.InvalidEmailException;
 import com.gamzabat.algohub.feature.user.exception.InvalidVerificationCodeException;
 import com.gamzabat.algohub.feature.user.exception.ResetPasswordValidationError;
@@ -221,5 +222,13 @@ public class CustomExceptionHandler {
 		return ResponseEntity
 			.status(HttpStatus.NOT_FOUND)
 			.body(new ErrorResponse(HttpStatus.NOT_FOUND.value(), e.getErrors(), null));
+	}
+
+	@ExceptionHandler(InvalidDeleteUserRequestException.class)
+	protected ResponseEntity<ErrorResponse> handleCannotFoundVerificationCodeException(
+		InvalidDeleteUserRequestException e) {
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(new ErrorResponse(HttpStatus.BAD_REQUEST.value(), e.getMessage(), null));
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/dto/DeleteUserRequest.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/dto/DeleteUserRequest.java
@@ -1,7 +1,4 @@
 package com.gamzabat.algohub.feature.user.dto;
 
-import jakarta.validation.constraints.NotNull;
-
-public record DeleteUserRequest(@NotNull(message = "소셜 로그인 여부는 필수 입력입니다.") Boolean isOAuthAccount,
-								String password) {
+public record DeleteUserRequest(String password) {
 }

--- a/src/main/java/com/gamzabat/algohub/feature/user/exception/InvalidDeleteUserRequestException.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/exception/InvalidDeleteUserRequestException.java
@@ -1,0 +1,7 @@
+package com.gamzabat.algohub.feature.user.exception;
+
+public class InvalidDeleteUserRequestException extends RuntimeException {
+	public InvalidDeleteUserRequestException(final String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -173,19 +173,26 @@ public class UserService {
 	@Transactional
 	public void deleteUser(User user, DeleteUserRequest deleteUserRequest) {
 		if (user.getGithubName() != null) {
-			if (deleteUserRequest.password() != null) {
-				throw new InvalidDeleteUserRequestException("소셜 로그인 회원의 비밀번호는 존재하지 않습니다.");
-			}
-			userRepository.delete(user);
-			return;
+			validateOAuthUserRequest(deleteUserRequest);
+		} else {
+			validateNormalUserRequest(user, deleteUserRequest);
 		}
+		userRepository.delete(user);
+	}
+
+	private static void validateOAuthUserRequest(DeleteUserRequest deleteUserRequest) {
+		if (deleteUserRequest.password() != null) {
+			throw new InvalidDeleteUserRequestException("소셜 로그인 회원의 비밀번호는 존재하지 않습니다.");
+		}
+	}
+
+	private void validateNormalUserRequest(User user, DeleteUserRequest deleteUserRequest) {
 		if (deleteUserRequest.password() == null) {
 			throw new InvalidDeleteUserRequestException("일반 회원 탈퇴 시 비밀번호 입력이 필요합니다.");
 		}
 		if (!passwordEncoder.matches(deleteUserRequest.password(), user.getPassword())) {
 			throw new UncorrectedPasswordException("비밀번호가 틀렸습니다.");
 		}
-		userRepository.delete(user);
 	}
 
 	@Transactional

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -50,6 +50,7 @@ import com.gamzabat.algohub.feature.user.exception.CheckBjNicknameValidationExce
 import com.gamzabat.algohub.feature.user.exception.CheckEmailFormException;
 import com.gamzabat.algohub.feature.user.exception.CheckNicknameValidationException;
 import com.gamzabat.algohub.feature.user.exception.CheckPasswordFormException;
+import com.gamzabat.algohub.feature.user.exception.InvalidDeleteUserRequestException;
 import com.gamzabat.algohub.feature.user.exception.InvalidEmailException;
 import com.gamzabat.algohub.feature.user.exception.ResetPasswordValidationError;
 import com.gamzabat.algohub.feature.user.exception.UncorrectedPasswordException;
@@ -171,9 +172,15 @@ public class UserService {
 
 	@Transactional
 	public void deleteUser(User user, DeleteUserRequest deleteUserRequest) {
-		if (deleteUserRequest.isOAuthAccount()) {
+		if (user.getGithubName() != null) {
+			if (deleteUserRequest.password() != null) {
+				throw new InvalidDeleteUserRequestException("소셜 로그인 회원의 비밀번호는 존재하지 않습니다.");
+			}
 			userRepository.delete(user);
 			return;
+		}
+		if (deleteUserRequest.password() == null) {
+			throw new InvalidDeleteUserRequestException("일반 회원 탈퇴 시 비밀번호 입력이 필요합니다.");
 		}
 		if (!passwordEncoder.matches(deleteUserRequest.password(), user.getPassword())) {
 			throw new UncorrectedPasswordException("비밀번호가 틀렸습니다.");

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -178,6 +178,7 @@ public class UserService {
 			validateNormalUserRequest(user, deleteUserRequest);
 		}
 		userRepository.delete(user);
+		log.info("success to delete user user_id={}", user.getId());
 	}
 
 	private static void validateOAuthUserRequest(DeleteUserRequest deleteUserRequest) {
@@ -193,8 +194,6 @@ public class UserService {
 		if (!passwordEncoder.matches(deleteUserRequest.password(), user.getPassword())) {
 			throw new UncorrectedPasswordException("비밀번호가 틀렸습니다.");
 		}
-		userRepository.delete(user);
-		log.info("success to delete user user_id={}", user.getId());
 	}
 
 	@Transactional

--- a/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/service/UserService.java
@@ -181,7 +181,7 @@ public class UserService {
 		log.info("success to delete user user_id={}", user.getId());
 	}
 
-	private static void validateOAuthUserRequest(DeleteUserRequest deleteUserRequest) {
+	private void validateOAuthUserRequest(DeleteUserRequest deleteUserRequest) {
 		if (deleteUserRequest.password() != null) {
 			throw new InvalidDeleteUserRequestException("소셜 로그인 회원의 비밀번호는 존재하지 않습니다.");
 		}

--- a/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
@@ -299,7 +299,7 @@ class UserControllerTest {
 	@DisplayName("회원 탈퇴 성공")
 	void deleteUser() throws Exception {
 		// given
-		DeleteUserRequest request = new DeleteUserRequest(false, "password");
+		DeleteUserRequest request = new DeleteUserRequest("password");
 		// when, then
 		mockMvc.perform(delete("/api/users/me")
 				.header("Authorization", token)
@@ -314,7 +314,7 @@ class UserControllerTest {
 	@DisplayName("회원 탈퇴 실패 : 잘못된 요청")
 	void deleteUserFailed_1() throws Exception {
 		// given
-		DeleteUserRequest request = new DeleteUserRequest(null, "");
+		DeleteUserRequest request = new DeleteUserRequest("");
 		// when, then
 		mockMvc.perform(delete("/api/users/me")
 				.header("Authorization", token)
@@ -329,7 +329,7 @@ class UserControllerTest {
 	@DisplayName("회원 탈퇴 실패 : 틀린 비밀번호")
 	void deleteUserFailed_2() throws Exception {
 		// given
-		DeleteUserRequest request = new DeleteUserRequest(false, "invalidPassword");
+		DeleteUserRequest request = new DeleteUserRequest("invalidPassword");
 		doThrow(new UncorrectedPasswordException("비밀번호가 틀렸습니다.")).when(userService).deleteUser(user, request);
 		// when, then
 		mockMvc.perform(delete("/api/users/me")

--- a/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/controller/UserControllerTest.java
@@ -311,21 +311,6 @@ class UserControllerTest {
 	}
 
 	@Test
-	@DisplayName("회원 탈퇴 실패 : 잘못된 요청")
-	void deleteUserFailed_1() throws Exception {
-		// given
-		DeleteUserRequest request = new DeleteUserRequest("");
-		// when, then
-		mockMvc.perform(delete("/api/users/me")
-				.header("Authorization", token)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.error").value("올바르지 않은 요청입니다."))
-			.andExpect(jsonPath("$.messages", hasItem("isOAuthAccount : 소셜 로그인 여부는 필수 입력입니다.")));
-	}
-
-	@Test
 	@DisplayName("회원 탈퇴 실패 : 틀린 비밀번호")
 	void deleteUserFailed_2() throws Exception {
 		// given

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -260,7 +260,7 @@ class UserServiceTest {
 	@DisplayName("회원 탈퇴 성공")
 	void deleteUser() {
 		// given
-		DeleteUserRequest request = new DeleteUserRequest(false, password);
+		DeleteUserRequest request = new DeleteUserRequest(password);
 		when(passwordEncoder.matches(password, user.getPassword())).thenReturn(true);
 		// when
 		userService.deleteUser(user, request);
@@ -272,7 +272,9 @@ class UserServiceTest {
 	@DisplayName("소셜 로그인 회원 탈퇴 성공")
 	void deleteOAuthUser() {
 		// given
-		DeleteUserRequest request = new DeleteUserRequest(true, null);
+		User user = User.builder().email("githubEmail").role(Role.USER).bjNickname("bjNickname").build();
+		user.editGithubName("githubName");
+		DeleteUserRequest request = new DeleteUserRequest(null);
 		// when
 		userService.deleteUser(user, request);
 		// then
@@ -283,7 +285,7 @@ class UserServiceTest {
 	@DisplayName("회원 탈퇴 실패 : 틀린 비밀번호")
 	void deleteUserFailed() {
 		// given
-		DeleteUserRequest request = new DeleteUserRequest(false, password);
+		DeleteUserRequest request = new DeleteUserRequest(password);
 		when(passwordEncoder.matches(password, user.getPassword())).thenReturn(false);
 		// when, then
 		assertThatThrownBy(() -> userService.deleteUser(user, request))

--- a/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/user/service/UserServiceTest.java
@@ -59,6 +59,7 @@ import com.gamzabat.algohub.feature.user.exception.BOJServerErrorException;
 import com.gamzabat.algohub.feature.user.exception.CheckBjNicknameValidationException;
 import com.gamzabat.algohub.feature.user.exception.CheckNicknameValidationException;
 import com.gamzabat.algohub.feature.user.exception.CheckPasswordFormException;
+import com.gamzabat.algohub.feature.user.exception.InvalidDeleteUserRequestException;
 import com.gamzabat.algohub.feature.user.exception.InvalidEmailException;
 import com.gamzabat.algohub.feature.user.exception.ResetPasswordValidationError;
 import com.gamzabat.algohub.feature.user.exception.UncorrectedPasswordException;
@@ -283,7 +284,7 @@ class UserServiceTest {
 
 	@Test
 	@DisplayName("회원 탈퇴 실패 : 틀린 비밀번호")
-	void deleteUserFailed() {
+	void deleteUserFailed_1() {
 		// given
 		DeleteUserRequest request = new DeleteUserRequest(password);
 		when(passwordEncoder.matches(password, user.getPassword())).thenReturn(false);
@@ -291,6 +292,30 @@ class UserServiceTest {
 		assertThatThrownBy(() -> userService.deleteUser(user, request))
 			.isInstanceOf(UncorrectedPasswordException.class)
 			.hasFieldOrPropertyWithValue("errors", "비밀번호가 틀렸습니다.");
+	}
+
+	@Test
+	@DisplayName("회원 탈퇴 실패 : 소셜 로그인 회원의 잘못된 요청")
+	void deleteUserFailed_2() {
+		// given
+		User user = User.builder().email("githubEmail").role(Role.USER).bjNickname("bjNickname").build();
+		user.editGithubName("githubName");
+		DeleteUserRequest request = new DeleteUserRequest(password);
+		// when, then
+		assertThatThrownBy(() -> userService.deleteUser(user, request))
+			.isInstanceOf(InvalidDeleteUserRequestException.class)
+			.hasFieldOrPropertyWithValue("message", "소셜 로그인 회원의 비밀번호는 존재하지 않습니다.");
+	}
+
+	@Test
+	@DisplayName("회원 탈퇴 실패 : 일반 회원의 잘못된 요청")
+	void deleteUserFailed_3() {
+		// given
+		DeleteUserRequest request = new DeleteUserRequest(null);
+		// when, then
+		assertThatThrownBy(() -> userService.deleteUser(user, request))
+			.isInstanceOf(InvalidDeleteUserRequestException.class)
+			.hasFieldOrPropertyWithValue("message", "일반 회원 탈퇴 시 비밀번호 입력이 필요합니다.");
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://linear.app/algo-hub/issue/BE-13/회원-탈퇴-api에서-isoauthaccount-제거

## 🚀 Description
<!-- 작업 내용 -->
- 회원 탈퇴 시 request에서 소셜 로그인 유저를 구분하는 `isOAuthAccount`를 제거했습니다. (왜 넣었는지 모르겠음)
- 각각 회원에 대한 request 검증을 쪼갰습니다. ( 일반 회원은 password 검증 필요, 소셜 로그인 회원은 request null 필요 )
- 내 정보 조회 API에서 `isOAuthAccount` 필드를 넣어달란 요청이 있었는데 이건 프론트 답변 듣고 추후에 추가해야할 것 같습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->