### PR TITLE
fix: 회원 이메일 존재 오류 수정

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/user/repository/UserRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/user/repository/UserRepository.java
@@ -3,21 +3,24 @@ package com.gamzabat.algohub.feature.user.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.gamzabat.algohub.feature.user.domain.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+	@Query("SELECT EXISTS ("
+		+ "SELECT 1 FROM User u "
+		+ "WHERE u.email = :email "
+		+ "AND u.deletedAt IS NULL"
+		+ ")")
 	boolean existsByEmail(String email);
 
+	@Query("SELECT u FROM User u "
+		+ "WHERE u.email = :email "
+		+ "AND u.deletedAt IS NULL")
 	Optional<User> findByEmail(String email);
 
-	void deleteByEmail(String email);
-
 	Optional<User> findByBjNickname(String bjNickname);
-
-	Optional<User> findById(Long Id);
-
-	boolean existsByBjNickname(String bjNickname);
 
 	boolean existsByNickname(String nickname);
 


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://linear.app/algo-hub/issue/BE-9/회원탈퇴한-계정인데-사용중인-메일이라고-뜨는-이슈

## 🚀 Description
<!-- 작업 내용 -->
- user를 soft delete 하고 있어서 `WHERE deletedAt IS NULL` 조건을 추가했어야 했는데 안되어있었습니다. 그래서 추가함!

## 📢 Review Point

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->