### PR TITLE
feat: 공지 조회 시 생성 일시 response 타입 수정

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/notice/dto/GetNoticeResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notice/dto/GetNoticeResponse.java
@@ -1,6 +1,7 @@
 package com.gamzabat.algohub.feature.notice.dto;
 
-import com.gamzabat.algohub.common.DateFormatUtil;
+import java.time.LocalDateTime;
+
 import com.gamzabat.algohub.feature.notice.domain.Notice;
 
 import lombok.Builder;
@@ -12,7 +13,7 @@ public record GetNoticeResponse(String author,
 								String content,
 								String title,
 								String category,
-								String createdAt,
+								LocalDateTime createdAt,
 								boolean isRead) {
 
 	public static GetNoticeResponse toDTO(Notice notice, boolean isRead) {
@@ -23,7 +24,7 @@ public record GetNoticeResponse(String author,
 			.title(notice.getTitle())
 			.content(notice.getContent())
 			.category(notice.getCategory())
-			.createdAt(DateFormatUtil.formatDateTimeForNotice(notice.getCreatedAt()))
+			.createdAt(notice.getCreatedAt())
 			.isRead(isRead)
 			.build();
 	}

--- a/src/main/java/com/gamzabat/algohub/feature/notice/service/NoticeService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notice/service/NoticeService.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.gamzabat.algohub.common.DateFormatUtil;
 import com.gamzabat.algohub.common.annotation.AuthedUser;
 import com.gamzabat.algohub.exception.StudyGroupValidationException;
 import com.gamzabat.algohub.exception.UserValidationException;
@@ -75,16 +74,7 @@ public class NoticeService {
 			throw new StudyGroupValidationException(HttpStatus.FORBIDDEN.value(), "참여하지 않은 스터디 그룹 입니다.");
 
 		log.info("success to get notice");
-		return GetNoticeResponse.builder()
-			.author(notice.getAuthor().getNickname())
-			.authorImage(notice.getAuthor().getProfileImage())
-			.noticeId(notice.getId())
-			.title(notice.getTitle())
-			.content(notice.getContent())
-			.category(notice.getCategory())
-			.createdAt(DateFormatUtil.formatDateTimeForNotice(notice.getCreatedAt()))
-			.isRead(true)
-			.build();
+		return GetNoticeResponse.toDTO(notice, true);
 	}
 
 	@Transactional

--- a/src/test/java/com/gamzabat/algohub/service/NoticeServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/NoticeServiceTest.java
@@ -26,7 +26,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 
-import com.gamzabat.algohub.common.DateFormatUtil;
 import com.gamzabat.algohub.enums.Role;
 import com.gamzabat.algohub.exception.StudyGroupValidationException;
 import com.gamzabat.algohub.exception.UserValidationException;
@@ -193,7 +192,7 @@ public class NoticeServiceTest {
 		assertThat(response.content()).isEqualTo("content");
 		assertThat(response.title()).isEqualTo("title");
 		assertThat(response.category()).isEqualTo("category");
-		assertThat(response.createdAt()).isEqualTo(DateFormatUtil.formatDateTimeForNotice(notice.getCreatedAt()));
+		assertThat(response.createdAt()).isEqualTo(notice.getCreatedAt());
 		assertThat(response.noticeId()).isEqualTo(1000L);
 	}
 


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://linear.app/algo-hub/issue/BE-15/공지-createdat-에서-시간-정보-누락된-이슈

## 🚀 Description
<!-- 작업 내용 -->
- 공지 생성 일시를 `LocalDateTime`으로 뱉습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
작은거라 걍 먼저 본 사람이 머지해도 될 듯

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->