### PR TITLE
fix: 알림 대상에서 자신 제외

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/group/ranking/service/RankingService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/ranking/service/RankingService.java
@@ -32,7 +32,7 @@ public class RankingService {
 	private final StudyGroupRepository groupRepository;
 	private final GroupMemberRepository groupMemberRepository;
 
-	public static final double SCORE_SCALING_FACTOR = 1e-4;
+	public static final double SCORE_SCALING_FACTOR = 1e-6;
 
 	@Transactional(readOnly = true)
 	public Page<GetRankingResponse> getAllRank(User user, Long groupId, Pageable pageable) {

--- a/src/main/java/com/gamzabat/algohub/feature/group/ranking/service/RankingService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/ranking/service/RankingService.java
@@ -2,7 +2,6 @@ package com.gamzabat.algohub.feature.group.ranking.service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -61,6 +60,6 @@ public class RankingService {
 	}
 
 	private double calculateNewScore(LocalDateTime solvedDateTime) {
-		return solvedDateTime.toEpochSecond(ZoneOffset.of("Asia/Seoul")) * SCORE_SCALING_FACTOR;
+		return solvedDateTime.atZone(java.time.ZoneId.of("Asia/Seoul")).toEpochSecond() * SCORE_SCALING_FACTOR;
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/notification/service/NotificationService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notification/service/NotificationService.java
@@ -193,7 +193,7 @@ public class NotificationService {
 		for (GroupMember member : receiver) {
 			NotificationSetting setting = notificationSettingRepository.findByMember(member)
 				.orElseThrow(() -> {
-					log.error("cannot find notification setting for member. user_id = {}, group_id =g {}",
+					log.error("cannot find notification setting for member. user_id = {}, group_id = {}",
 						member.getUser().getId(), group.getId());
 					return new CannotFoundNotificationSettingException("해당 그룹에 가입 되지 않은 유저입니다.");
 				});

--- a/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionCommentService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionCommentService.java
@@ -56,7 +56,9 @@ public class SolutionCommentService implements CommentService<CreateSolutionComm
 			.isRead(false)
 			.build());
 
-		sendCommentNotification(user, solution);
+		if (!solution.getUser().getId().equals(user.getId())) {
+			sendCommentNotification(user, solution);
+		}
 		log.info("success to create solution comment. comment_id = {}, solution_id = {}", comment.getId(),
 			solution.getId());
 	}

--- a/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/solution/service/SolutionService.java
@@ -245,9 +245,13 @@ public class SolutionService {
 	}
 
 	private void sendNewSolutionNotification(StudyGroup group, GroupMember solver, Problem problem) {
+		List<GroupMember> groupMembers = groupMemberRepository.findAllByStudyGroup(group).stream()
+			.filter(member -> !member.getId().equals(solver.getId()))
+			.toList();
+
 		notificationService.sendNotificationToMembers(
 			group,
-			groupMemberRepository.findAllByStudyGroup(group),
+			groupMembers,
 			problem,
 			null,
 			NotificationCategory.NEW_SOLUTION_POSTED,

--- a/src/test/java/com/gamzabat/algohub/feature/group/ranking/service/RankingServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/group/ranking/service/RankingServiceTest.java
@@ -5,10 +5,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Field;
-import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -208,9 +206,7 @@ class RankingServiceTest {
 		LocalDate problemEndDate = LocalDate.now().plusDays(10);
 		LocalDateTime solvedDateTime = LocalDateTime.now();
 
-		LocalDateTime endDateTime = problemEndDate.atTime(LocalTime.MAX);
-		Duration duration = Duration.between(solvedDateTime, endDateTime);
-		double score = duration.getSeconds() * SCORE_SCALING_FACTOR;
+		double score = solvedDateTime.atZone(java.time.ZoneId.of("Asia/Seoul")).toEpochSecond() * SCORE_SCALING_FACTOR;
 
 		when(rankingRepository.findByMember(groupMember2)).thenReturn(Optional.ofNullable(ranking2));
 

--- a/src/test/java/com/gamzabat/algohub/feature/solution/controller/SolutionControllerTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/solution/controller/SolutionControllerTest.java
@@ -1,8 +1,8 @@
 package com.gamzabat.algohub.feature.solution.controller;
 
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.eq;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 

--- a/src/test/java/com/gamzabat/algohub/service/SolutionCommentServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/SolutionCommentServiceTest.java
@@ -114,7 +114,7 @@ class SolutionCommentServiceTest {
 	}
 
 	@Test
-	@DisplayName("댓글 작성 성공")
+	@DisplayName("타 유저 풀이에 댓글 작성 성공")
 	void createComment_1() {
 		// given
 		CreateSolutionCommentRequest request = CreateSolutionCommentRequest.builder()
@@ -141,6 +141,30 @@ class SolutionCommentServiceTest {
 		assertThat(result.getUser()).isEqualTo(user2);
 		assertThat(result.getSolution()).isEqualTo(solution);
 		verify(notificationService, times(1)).sendNotificationToMembers(any(), any(), any(), any(), any(), any());
+	}
+
+	@Test
+	@DisplayName("내 풀이에 댓글 작성 성공")
+	void createComment_2() {
+		// given
+		CreateSolutionCommentRequest request = CreateSolutionCommentRequest.builder()
+			.content("content")
+			.build();
+
+		when(solutionRepository.findById(10L)).thenReturn(Optional.ofNullable(solution));
+		when(problemRepository.findById(20L)).thenReturn(Optional.ofNullable(problem));
+		when(studyGroupRepository.findById(30L)).thenReturn(Optional.ofNullable(studyGroup));
+		when(groupMemberRepository.existsByUserAndStudyGroup(user, studyGroup)).thenReturn(true);
+		when(commentRepository.save(any(SolutionComment.class))).thenReturn(comment);
+		// when
+		commentService.createComment(user, 10L, request);
+		// then
+		verify(commentRepository, times(1)).save(commentCaptor.capture());
+		SolutionComment result = commentCaptor.getValue();
+		assertThat(result.getContent()).isEqualTo("content");
+		assertThat(result.getUser()).isEqualTo(user);
+		assertThat(result.getSolution()).isEqualTo(solution);
+		verify(notificationService, times(0)).sendNotificationToMembers(any(), any(), any(), any(), any(), any());
 	}
 
 	@Test
@@ -246,7 +270,7 @@ class SolutionCommentServiceTest {
 		for (SolutionComment comment : list) {
 			assertThat(comment.isRead()).isTrue();
 		}
-		
+
 	}
 
 	@Test

--- a/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
@@ -487,7 +487,7 @@ class SolutionServiceTest {
 
 	@Test
 	@DisplayName("풀이 추가 성공")
-	void createSolution() {
+	void createSolution() throws NoSuchFieldException, IllegalAccessException {
 		// given
 		CreateSolutionRequest request = new CreateSolutionRequest(
 			"bjNickname",
@@ -508,6 +508,11 @@ class SolutionServiceTest {
 			.studyGroup(group)
 			.user(user2)
 			.build();
+
+		Field memberField = GroupMember.class.getDeclaredField("id");
+		memberField.setAccessible(true);
+		memberField.set(member1, 10L);
+		memberField.set(member2, 20L);
 
 		Problem problem = Problem.builder()
 			.number(300)

--- a/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/SolutionServiceTest.java
@@ -520,6 +520,7 @@ class SolutionServiceTest {
 		memberField.setAccessible(true);
 		memberField.set(member1, 10L);
 		memberField.set(member2, 20L);
+		memberField.set(member3, 30L);
 
 		Problem problem = Problem.builder()
 			.number(300)


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://linear.app/algo-hub/issue/BE-18/회원-본인-활동에-관한-알림이-뜨는-이슈

## 🚀 Description
<!-- 작업 내용 -->
- 기존 알림 전송 로직에서, 아래 두 케이스가 유저 경험 입장에선 매우 어색한 케이스들이었습니다.
1. 내 풀이에 내가 댓글을 작성할 경우, 나에게 알림이 전송된다.
2. 내 풀이가 새로 추가된 경우, 나에게 알림이 전송된다.

- 그래서 두 케이스에서 자신은 알림 전송 대상에서 제외하는 로직을 추가했습니다.
1. 내 풀이에 내가 댓글을 작성하면, 나에게 알림이 오지 않습니다.
2. 내 풀이가 새로 추가된 경우, 나를 제외한 그룹 멤버들에게 알림이 전송됩니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
- 뭔가 고민하다보니, 특정 유저가 타 유저의 풀이에 댓글을 달고서 해당 풀이 댓글을 구독?하고 있어야 하나라는 생각이 듭니다.
- 알고리즘 스터디 특성 상, 풀이에 대한 댓글 작성이 일방적인 소통이 되진 않을 것 같습니다.
- 내가 누군가 풀이에 질문하는 댓글을 달았을 경우, 풀이 주인이 댓글을 달면 이에 대한 알림이 나에게 와야하지 않나 싶습니다. ( like 디코 스레드 )
- 근데 복잡해질 것 같다는 생각이 들기도 하고

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->