### PR TITLE
refactor: 댓글 및 공지 생성 일시 응답 타입 수정

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/comment/dto/GetCommentResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/comment/dto/GetCommentResponse.java
@@ -1,6 +1,7 @@
 package com.gamzabat.algohub.feature.comment.dto;
 
-import com.gamzabat.algohub.common.DateFormatUtil;
+import java.time.LocalDateTime;
+
 import com.gamzabat.algohub.feature.comment.domain.Comment;
 
 import lombok.Builder;
@@ -10,7 +11,7 @@ public record GetCommentResponse(Long commentId,
 								 String writerNickname,
 								 String writerProfileImage,
 								 String content,
-								 String createdAt) {
+								 LocalDateTime createdAt) {
 
 	public static GetCommentResponse toDTO(Comment comment) {
 		return GetCommentResponse.builder()
@@ -18,7 +19,7 @@ public record GetCommentResponse(Long commentId,
 			.writerNickname(comment.getUser().getNickname())
 			.writerProfileImage(comment.getUser().getProfileImage())
 			.content(comment.getContent())
-			.createdAt(DateFormatUtil.formatDateTime(comment.getCreatedAt()))
+			.createdAt(comment.getCreatedAt())
 			.build();
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/notification/dto/GetNotificationResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/notification/dto/GetNotificationResponse.java
@@ -1,6 +1,7 @@
 package com.gamzabat.algohub.feature.notification.dto;
 
-import com.gamzabat.algohub.common.DateFormatUtil;
+import java.time.LocalDateTime;
+
 import com.gamzabat.algohub.feature.notification.domain.Notification;
 
 import jakarta.annotation.Nullable;
@@ -13,7 +14,7 @@ public record GetNotificationResponse(Long id,
 									  String groupImage,
 									  String message,
 									  String subContent,
-									  String createdAt,
+									  LocalDateTime createdAt,
 									  boolean isRead) {
 	public static GetNotificationResponse toDTO(Notification notification) {
 		return new GetNotificationResponse(
@@ -25,7 +26,7 @@ public record GetNotificationResponse(Long id,
 			notification.getStudyGroup().getGroupImage(),
 			notification.getMessage(),
 			notification.getSubContent(),
-			DateFormatUtil.formatDate(notification.getCreatedAt().toLocalDate()),
+			notification.getCreatedAt(),
 			notification.isRead()
 		);
 	}

--- a/src/test/java/com/gamzabat/algohub/feature/notice/service/NoticeCommentServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/feature/notice/service/NoticeCommentServiceTest.java
@@ -189,7 +189,7 @@ class NoticeCommentServiceTest {
 		// then
 		assertThat(result.size()).isEqualTo(30);
 		for (int i = 0; i < 30; i++)
-			assertThat(result.get(i).content()).isEqualTo("content" + i);
+			assertThat(result.get(i).content()).isEqualTo("content" + (30 - i - 1));
 	}
 
 	@Test

--- a/src/test/java/com/gamzabat/algohub/service/SolutionCommentServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/SolutionCommentServiceTest.java
@@ -241,12 +241,11 @@ class SolutionCommentServiceTest {
 		// then
 		assertThat(result.size()).isEqualTo(30);
 		for (int i = 0; i < 30; i++)
-			assertThat(result.get(i).content()).isEqualTo("content" + i);
+			assertThat(result.get(i).content()).isEqualTo("content" + (30 - i - 1));
 
 		for (SolutionComment comment : list) {
 			assertThat(comment.isRead()).isTrue();
 		}
-		
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
close https://linear.app/algo-hub/issue/BE-19/생성-날짜-관련-response-type-수정

## 🚀 Description
<!-- 작업 내용 -->
- 공지, 공지 댓글, 풀이 댓글의 `createdAt` response 타입을 `LocalDateTime`으로 변경했습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
- 또 변경되어야 할 response가 뭐가 있을지 모르겠네요..!
- 혹시 놓친 부분 있는 것 같으면 알려주세요

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->