### PR TITLE
devops: Assign reviewer automatically

### DIFF
--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -1,0 +1,14 @@
+name: Review Assign
+
+on:
+  pull_request:
+    types: [ opened, ready_for_review ]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hkusu/review-assign-action@v1
+        with:
+          assignees: ${{ github.actor }} # assign pull request author
+          reviewers: s-hwan , rladmstn, sh0723, hwangjokim, junggyo1020  # if draft, assigned when draft is released


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
BE-39

## 🚀 Description
<!-- 작업 내용 -->
- 이제 리뷰어를 직접 지정하지 않아도 됩니다. 
- Assigness도 자동으로 들어가요 