### PR TITLE
refactor : 백준 API 호출 시 timeout 에러 처리 추가

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -374,6 +375,10 @@ public class ProblemService {
 				throw new SolvedAcApiErrorException(HttpStatus.BAD_REQUEST.value(), "백준에 유효하지 않은 문제입니다.");
 
 			return root.get(0);
+		} catch (ResourceAccessException e) {
+			log.error("Timeout or connection failed solved.ac API error : " + e.getMessage());
+			throw new SolvedAcApiErrorException(HttpStatus.GATEWAY_TIMEOUT.value(),
+				"solved.ac API 응답이 지연되거나 연결에 실패했습니다. 잠시 후 다시 시도해주세요.");
 		} catch (JsonProcessingException e) {
 			log.error("Json processing error : " + e.getMessage());
 			throw new SolvedAcApiErrorException(HttpStatus.INTERNAL_SERVER_ERROR.value(),

--- a/src/test/java/com/gamzabat/algohub/service/ProblemServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/ProblemServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
 import com.gamzabat.algohub.common.DateFormatUtil;
@@ -270,6 +271,29 @@ class ProblemServiceTest {
 			.isInstanceOf(SolvedAcApiErrorException.class)
 			.hasFieldOrPropertyWithValue("code", HttpStatus.SERVICE_UNAVAILABLE.value())
 			.hasFieldOrPropertyWithValue("error", "solved.ac API로부터 예상치 못한 응답을 받았습니다.");
+	}
+
+	@Test
+	@DisplayName("문제 생성 실패 : solved.ac API 타임아웃 발생")
+	void createProblemFailed_solvedAcApiTimeout() {
+		// given
+		CreateProblemRequest request = CreateProblemRequest.builder()
+			.link("https://www.acmicpc.net/problem/00")
+			.startDate(LocalDate.now().minusDays(7))
+			.endDate(LocalDate.now())
+			.build();
+
+		when(groupRepository.findById(10L)).thenReturn(Optional.of(group));
+		when(groupMemberRepository.findByUserAndStudyGroup(user, group)).thenReturn(Optional.of(groupMember1));
+
+		when(restTemplate.getForEntity(anyString(), eq(String.class)))
+			.thenThrow(new ResourceAccessException("I/O error: Read timed out"));
+
+		// when, then
+		assertThatThrownBy(() -> problemService.createProblem(user, 10L, request))
+			.isInstanceOf(SolvedAcApiErrorException.class)
+			.hasFieldOrPropertyWithValue("code", HttpStatus.GATEWAY_TIMEOUT.value())
+			.hasFieldOrPropertyWithValue("error", "solved.ac API 응답이 지연되거나 연결에 실패했습니다. 잠시 후 다시 시도해주세요.");
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 Related Issue
[BE-31](https://linear.app/algo-hub/issue/BE-31/%EB%B0%B1%EC%A4%80-api-%ED%98%B8%EC%B6%9C-%EC%8B%9C-timeout-%EC%97%90%EB%9F%AC-%EC%B2%98%EB%A6%AC-%EC%B6%94%EA%B0%80)
## 🚀 Description
<!-- 작업 내용 -->
### SocketTimeoutException에 대한 예외처리
- Spring `RestTemplate`은 `SocketTimeoutException`(checkedException)에 대한 처리를 `ResourceAccessException`이라는 런타임 예외(unchecked exception)로 throw 하기때문에 해당 부분에 대한 예외처리를 추가했습니다!
- 테스트 코드는 기존에 존재하는 형식을 따라 작성했습니다.

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
- 더 추가해야할 예외처리가 있다면 말씀주시면 추가해두겠습니다 :)
## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->