### PR TITLE
feat : 반례게시판 이슈 해결 및 정렬을 위한 분기 param 추가

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/edgecase/controller/EdgeCaseController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/edgecase/controller/EdgeCaseController.java
@@ -36,12 +36,12 @@ public class EdgeCaseController {
 	@PostMapping
 	@Operation(summary = "반례 등록")
 	public ResponseEntity<Void> createEdgeCase(@AuthedUser User user,
-		@RequestBody @Valid CreateEdgeCaseRequest creatEdgeCaseRequest,
+		@RequestBody @Valid CreateEdgeCaseRequest createEdgeCaseRequest,
 		Errors errors) {
 		if (errors.hasErrors())
 			throw new RequestException("올바르지 않은 요청입니다.", errors);
 
-		edgeCaseService.createEdgeCase(user, creatEdgeCaseRequest);
+		edgeCaseService.createEdgeCase(user, createEdgeCaseRequest);
 
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/com/gamzabat/algohub/feature/edgecase/controller/EdgeCaseController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/edgecase/controller/EdgeCaseController.java
@@ -1,7 +1,7 @@
 package com.gamzabat.algohub.feature.edgecase.controller;
 
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -14,14 +14,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.gamzabat.algohub.common.annotation.AuthedUser;
 import com.gamzabat.algohub.exception.RequestException;
-import com.gamzabat.algohub.feature.edgecase.domain.EdgeCaseLike;
+import com.gamzabat.algohub.feature.edgecase.domain.EdgeCaseSortType;
 import com.gamzabat.algohub.feature.edgecase.dto.CreateEdgeCaseRequest;
 import com.gamzabat.algohub.feature.edgecase.dto.GetEdgeCaseListResponse;
 import com.gamzabat.algohub.feature.edgecase.dto.TogleEdgeCaseResponse;
 import com.gamzabat.algohub.feature.edgecase.service.EdgeCaseService;
 import com.gamzabat.algohub.feature.user.domain.User;
 
-import org.springframework.validation.Errors;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -36,7 +35,8 @@ public class EdgeCaseController {
 
 	@PostMapping
 	@Operation(summary = "반례 등록")
-	public ResponseEntity<Void> createEdgeCase(@AuthedUser User user, @RequestBody @Valid CreateEdgeCaseRequest creatEdgeCaseRequest,
+	public ResponseEntity<Void> createEdgeCase(@AuthedUser User user,
+		@RequestBody @Valid CreateEdgeCaseRequest creatEdgeCaseRequest,
 		Errors errors) {
 		if (errors.hasErrors())
 			throw new RequestException("올바르지 않은 요청입니다.", errors);
@@ -48,8 +48,12 @@ public class EdgeCaseController {
 
 	@GetMapping("/list")
 	@Operation(summary = "반례리스트 조회")
-	public ResponseEntity<GetEdgeCaseListResponse> getEdgeCaseList(@AuthedUser User user, @RequestParam(required = false) Integer problemNumber) {
-		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(problemNumber);
+	public ResponseEntity<GetEdgeCaseListResponse> getEdgeCaseList(
+		@AuthedUser User user,
+		@RequestParam(required = false) Integer problemNumber,
+		@RequestParam(required = false, defaultValue = "RECENT") EdgeCaseSortType sort
+	) {
+		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(problemNumber, sort);
 
 		return ResponseEntity.ok().body(response);
 	}

--- a/src/main/java/com/gamzabat/algohub/feature/edgecase/controller/EdgeCaseController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/edgecase/controller/EdgeCaseController.java
@@ -49,7 +49,6 @@ public class EdgeCaseController {
 	@GetMapping("/list")
 	@Operation(summary = "반례리스트 조회")
 	public ResponseEntity<GetEdgeCaseListResponse> getEdgeCaseList(
-		@AuthedUser User user,
 		@RequestParam(required = false) Integer problemNumber,
 		@RequestParam(required = false, defaultValue = "RECENT") EdgeCaseSortType sort
 	) {

--- a/src/main/java/com/gamzabat/algohub/feature/edgecase/domain/EdgeCase.java
+++ b/src/main/java/com/gamzabat/algohub/feature/edgecase/domain/EdgeCase.java
@@ -1,8 +1,6 @@
 package com.gamzabat.algohub.feature.edgecase.domain;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.hibernate.annotations.SQLDelete;
 
@@ -16,8 +14,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -40,7 +36,6 @@ public class EdgeCase {
 	@Column(columnDefinition = "TEXT")
 	private String output;
 
-
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User author;
@@ -52,7 +47,8 @@ public class EdgeCase {
 	private int likeCount = 0;
 
 	@Builder
-	public EdgeCase(Integer level, String link, Integer problemNumber, String title, String input, String output, User author) {
+	public EdgeCase(Integer level, String link, Integer problemNumber, String title, String input, String output,
+		User author) {
 		this.level = level;
 		this.link = link;
 		this.problemNumber = problemNumber;
@@ -60,6 +56,16 @@ public class EdgeCase {
 		this.input = input;
 		this.output = output;
 		this.author = author;
+		this.createdAt = LocalDateTime.now();
 	}
 
+	public void increaseLikeCount() {
+		this.likeCount++;
+	}
+
+	public void decreaseLikeCount() {
+		if (this.likeCount > 0) {
+			this.likeCount--;
+		}
+	}
 }

--- a/src/main/java/com/gamzabat/algohub/feature/edgecase/domain/EdgeCaseSortType.java
+++ b/src/main/java/com/gamzabat/algohub/feature/edgecase/domain/EdgeCaseSortType.java
@@ -1,0 +1,7 @@
+package com.gamzabat.algohub.feature.edgecase.domain;
+
+public enum EdgeCaseSortType {
+	RECENT, // 최신순 (기본값)
+	LIKE,   // 좋아요순
+	OLD     // 오래된순
+}

--- a/src/main/java/com/gamzabat/algohub/feature/edgecase/repository/EdgeCaseLikeRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/edgecase/repository/EdgeCaseLikeRepository.java
@@ -1,5 +1,6 @@
 package com.gamzabat.algohub.feature.edgecase.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,5 @@ import com.gamzabat.algohub.feature.user.domain.User;
 
 public interface EdgeCaseLikeRepository extends JpaRepository<EdgeCaseLike, Long> {
 	Optional<EdgeCaseLike> findByEdgeCaseAndUser(EdgeCase edgeCase, User user);
+	List<EdgeCaseLike> findAllByEdgeCase(EdgeCase edgeCase);
 }

--- a/src/main/java/com/gamzabat/algohub/feature/edgecase/repository/EdgeCaseRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/edgecase/repository/EdgeCaseRepository.java
@@ -7,6 +7,18 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.gamzabat.algohub.feature.edgecase.domain.EdgeCase;
 
 public interface EdgeCaseRepository extends JpaRepository<EdgeCase, Long> {
+	// RECENT
 	List<EdgeCase> findAllByProblemNumberOrderByCreatedAtDesc(Integer problemNumber);
+
 	List<EdgeCase> findAllByOrderByCreatedAtDesc();
+
+	// LIKE
+	List<EdgeCase> findAllByProblemNumberOrderByLikeCountDesc(Integer problemNumber);
+
+	List<EdgeCase> findAllByOrderByLikeCountDesc();
+
+	// OLD
+	List<EdgeCase> findAllByProblemNumberOrderByCreatedAtAsc(Integer problemNumber);
+
+	List<EdgeCase> findAllByOrderByCreatedAtAsc();
 }

--- a/src/main/java/com/gamzabat/algohub/feature/edgecase/service/EdgeCaseService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/edgecase/service/EdgeCaseService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.gamzabat.algohub.feature.edgecase.domain.EdgeCase;
 import com.gamzabat.algohub.feature.edgecase.domain.EdgeCaseLike;
+import com.gamzabat.algohub.feature.edgecase.domain.EdgeCaseSortType;
 import com.gamzabat.algohub.feature.edgecase.dto.CreateEdgeCaseRequest;
 import com.gamzabat.algohub.feature.edgecase.dto.GetEdgeCaseListResponse;
 import com.gamzabat.algohub.feature.edgecase.dto.GetEdgeCaseResponse;
@@ -44,7 +45,7 @@ public class EdgeCaseService {
 		int level = problemService.getProblemLevel(apiResult);
 		String title = problemService.getProblemTitle(apiResult);
 
-		saveEdgeCase(author,request,level,title,Integer.parseInt(number));
+		saveEdgeCase(author, request, level, title, Integer.parseInt(number));
 	}
 
 	private void saveEdgeCase(User author, CreateEdgeCaseRequest request, int level, String title, int number) {
@@ -54,12 +55,35 @@ public class EdgeCaseService {
 		edgeCaseRepository.save(edgeCase);
 	}
 
-	public GetEdgeCaseListResponse getEdgeCaseList(Integer problemNumber) {
+	public GetEdgeCaseListResponse getEdgeCaseList(Integer problemNumber, EdgeCaseSortType sort) {
 		List<EdgeCase> edgeCaseList;
-		if (problemNumber == null)
-			edgeCaseList = edgeCaseRepository.findAllByOrderByCreatedAtDesc();
-		else
-			edgeCaseList = edgeCaseRepository.findAllByProblemNumberOrderByCreatedAtDesc(problemNumber);
+		if (problemNumber == null) {
+			switch (sort) {
+				case LIKE:
+					edgeCaseList = edgeCaseRepository.findAllByOrderByLikeCountDesc();
+					break;
+				case OLD:
+					edgeCaseList = edgeCaseRepository.findAllByOrderByCreatedAtAsc();
+					break;
+				case RECENT:
+				default:
+					edgeCaseList = edgeCaseRepository.findAllByOrderByCreatedAtDesc();
+					break;
+			}
+		} else {
+			switch (sort) {
+				case LIKE:
+					edgeCaseList = edgeCaseRepository.findAllByProblemNumberOrderByLikeCountDesc(problemNumber);
+					break;
+				case OLD:
+					edgeCaseList = edgeCaseRepository.findAllByProblemNumberOrderByCreatedAtAsc(problemNumber);
+					break;
+				case RECENT:
+				default:
+					edgeCaseList = edgeCaseRepository.findAllByProblemNumberOrderByCreatedAtDesc(problemNumber);
+					break;
+			}
+		}
 
 		List<GetEdgeCaseResponse> responseList = edgeCaseList.stream()
 			.map(edgeCase -> new GetEdgeCaseResponse(
@@ -94,20 +118,20 @@ public class EdgeCaseService {
 		EdgeCase edgeCase = edgeCaseRepository.findById(edgeCaseId)
 			.orElseThrow(() -> new CannotFoundEdgeCaseException("존재하지 않는 반례입니다.", HttpStatus.NOT_FOUND));
 
-		EdgeCaseLike edgeCaseLike = edgeCaseLikeRepository.findByEdgeCaseAndUser(edgeCase,user).orElse(null);
+		EdgeCaseLike edgeCaseLike = edgeCaseLikeRepository.findByEdgeCaseAndUser(edgeCase, user).orElse(null);
 		Boolean isLike = false;
 		if (edgeCaseLike == null) {
 			edgeCaseLike = EdgeCaseLike.builder().user(user).edgeCase(edgeCase).build();
 			edgeCaseLikeRepository.save(edgeCaseLike);
-
+			edgeCase.increaseLikeCount();
 			isLike = true;
 		} else {
 			edgeCaseLikeRepository.delete(edgeCaseLike);
+			edgeCase.decreaseLikeCount();
 		}
 
 		return new TogleEdgeCaseResponse(isLike);
 	}
-
 
 	private String getProblemId(String url) {
 		String[] parts = url.split("/");

--- a/src/main/java/com/gamzabat/algohub/feature/edgecase/service/EdgeCaseService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/edgecase/service/EdgeCaseService.java
@@ -109,7 +109,8 @@ public class EdgeCaseService {
 
 		if (!user.getId().equals(author.getId()))
 			throw new NotAuthorizedUserException("반례를 삭제할 권한이 없습니다.", HttpStatus.FORBIDDEN);
-
+		List<EdgeCaseLike> likes = edgeCaseLikeRepository.findAllByEdgeCase(edgeCase);
+		edgeCaseLikeRepository.deleteAll(likes);
 		edgeCaseRepository.delete(edgeCase);
 	}
 

--- a/src/test/java/com/gamzabat/algohub/service/EdgeCaseServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/EdgeCaseServiceTest.java
@@ -5,10 +5,12 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.lang.reflect.Field;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gamzabat.algohub.enums.Role;
 import com.gamzabat.algohub.feature.edgecase.domain.EdgeCase;
 import com.gamzabat.algohub.feature.edgecase.domain.EdgeCaseLike;
+import com.gamzabat.algohub.feature.edgecase.domain.EdgeCaseSortType;
 import com.gamzabat.algohub.feature.edgecase.dto.CreateEdgeCaseRequest;
 import com.gamzabat.algohub.feature.edgecase.dto.GetEdgeCaseListResponse;
 import com.gamzabat.algohub.feature.edgecase.dto.GetEdgeCaseResponse;
@@ -105,14 +108,23 @@ class EdgeCaseServiceTest {
 		userId.set(user, 1L);
 		userId.set(user2, 2L);
 
-
 		Field edgeCaseId = EdgeCase.class.getDeclaredField("id");
-		Field edgeCaseLikeCount = EdgeCase.class.getDeclaredField("likeCount");
 		edgeCaseId.setAccessible(true);
 		edgeCaseId.set(edgeCase1, 1L);
 		edgeCaseId.set(edgeCase2, 2L);
 		edgeCaseId.set(edgeCase3, 3L);
 
+		Field edgeCaseLikeCount = EdgeCase.class.getDeclaredField("likeCount");
+		edgeCaseLikeCount.setAccessible(true);
+		edgeCaseLikeCount.set(edgeCase1, 10);
+		edgeCaseLikeCount.set(edgeCase2, 5);
+		edgeCaseLikeCount.set(edgeCase3, 20);
+
+		Field edgeCaseCreatedAt = EdgeCase.class.getDeclaredField("createdAt");
+		edgeCaseCreatedAt.setAccessible(true);
+		edgeCaseCreatedAt.set(edgeCase1, LocalDateTime.now().minusDays(3));
+		edgeCaseCreatedAt.set(edgeCase2, LocalDateTime.now().minusDays(2));
+		edgeCaseCreatedAt.set(edgeCase3, LocalDateTime.now().minusDays(1));
 	}
 
 	@Test
@@ -139,15 +151,18 @@ class EdgeCaseServiceTest {
 		verify(edgeCaseRepository, times(1)).save(edgeCaseCaptor.capture());
 
 		EdgeCase result = edgeCaseCaptor.getValue();
-		assertThat(result.getLink()).isEqualTo("https://www.acmicpc.net/problem/1000");
-		assertThat(result.getProblemNumber()).isEqualTo(1000);
-		assertThat(result.getTitle()).isEqualTo("A+B");
-		assertThat(result.getLevel()).isEqualTo(1);
-		assertThat(result.getInput()).isEqualTo("1 2");
-		assertThat(result.getOutput()).isEqualTo("3");
-		assertThat(result.getLikeCount()).isEqualTo(0);
-		assertThat(result.getAuthor()).isEqualTo(user);
 
+		Assertions.assertAll(
+			() -> assertThat(result.getLink()).isEqualTo("https://www.acmicpc.net/problem/1000"),
+			() -> assertThat(result.getProblemNumber()).isEqualTo(1000),
+			() -> assertThat(result.getTitle()).isEqualTo("A+B"),
+			() -> assertThat(result.getLevel()).isEqualTo(1),
+			() -> assertThat(result.getInput()).isEqualTo("1 2"),
+			() -> assertThat(result.getOutput()).isEqualTo("3"),
+			() -> assertThat(result.getLikeCount()).isEqualTo(0),
+			() -> assertThat(result.getAuthor()).isEqualTo(user),
+			() -> assertThat(result.getCreatedAt()).isNotNull()
+		);
 	}
 
 	@Test
@@ -160,7 +175,7 @@ class EdgeCaseServiceTest {
 			.thenReturn(edgeCaseList);
 
 		//when
-		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(problemNumber);
+		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(problemNumber, EdgeCaseSortType.RECENT);
 
 		//then
 		assertEquals(2, response.edgeCaseList().size());
@@ -188,8 +203,9 @@ class EdgeCaseServiceTest {
 		List<EdgeCase> edgeCaseList = Arrays.asList(edgeCase1, edgeCase2, edgeCase3);
 		when(edgeCaseRepository.findAllByOrderByCreatedAtDesc())
 			.thenReturn(edgeCaseList);
+
 		// when
-		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(problemNumber);
+		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(problemNumber, EdgeCaseSortType.RECENT);
 
 		// then
 		assertEquals(3, response.edgeCaseList().size());
@@ -214,6 +230,99 @@ class EdgeCaseServiceTest {
 		assertEquals("Turret", thirdResponse.title());
 		assertEquals("0 0 13 40 0 37", thirdResponse.input());
 		assertEquals("2", thirdResponse.output());
+	}
+
+	@Test
+	@DisplayName("반례 리스트 조회 성공 (LIKE) // 문제 번호O")
+	void getEdgeCaseListSuccess_Like_WithProblemNumber() {
+		//given
+		Integer problemNumber = 1001;
+		List<EdgeCase> edgeCaseList = Arrays.asList(edgeCase1, edgeCase2);
+		when(edgeCaseRepository.findAllByProblemNumberOrderByLikeCountDesc(problemNumber))
+			.thenReturn(edgeCaseList);
+
+		//when
+		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(problemNumber, EdgeCaseSortType.LIKE);
+
+		//then
+		assertThat(response.edgeCaseList()).hasSize(2);
+
+		// 정렬 순서 검증 (ID 1 -> ID 2)
+		Assertions.assertAll(
+			() -> assertThat(response.edgeCaseList().get(0).edgeCaseId()).isEqualTo(edgeCase1.getId().intValue()),
+			() -> assertThat(response.edgeCaseList().get(1).edgeCaseId()).isEqualTo(edgeCase2.getId().intValue())
+		);
+	}
+
+	@Test
+	@DisplayName("반례 리스트 조회 성공 (LIKE) // 모든 리스트")
+	void getEdgeCaseListSuccess_Like_NoProblemNumber() {
+		// given
+		Integer problemNumber = null;
+		// setUp 순서 (전체): 3(20개) -> 1(10개) -> 2(5개)
+		List<EdgeCase> edgeCaseList = Arrays.asList(edgeCase3, edgeCase1, edgeCase2);
+		when(edgeCaseRepository.findAllByOrderByLikeCountDesc())
+			.thenReturn(edgeCaseList);
+
+		// when
+		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(problemNumber, EdgeCaseSortType.LIKE);
+
+		// then
+		assertThat(response.edgeCaseList()).hasSize(3);
+
+		// 정렬 순서 검증 (ID 3 -> ID 1 -> ID 2)
+		Assertions.assertAll(
+			() -> assertThat(response.edgeCaseList().get(0).edgeCaseId()).isEqualTo(edgeCase3.getId().intValue()),
+			() -> assertThat(response.edgeCaseList().get(1).edgeCaseId()).isEqualTo(edgeCase1.getId().intValue()),
+			() -> assertThat(response.edgeCaseList().get(2).edgeCaseId()).isEqualTo(edgeCase2.getId().intValue())
+		);
+	}
+
+	@Test
+	@DisplayName("반례 리스트 조회 성공 (OLD) // 문제 번호O")
+	void getEdgeCaseListSuccess_Old_WithProblemNumber() {
+		//given
+		Integer problemNumber = 1001;
+		// setUp 순서 (문제 1001번): 1(오래됨) -> 2(최신)
+		List<EdgeCase> edgeCaseList = Arrays.asList(edgeCase1, edgeCase2);
+		when(edgeCaseRepository.findAllByProblemNumberOrderByCreatedAtAsc(problemNumber))
+			.thenReturn(edgeCaseList);
+
+		//when
+		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(problemNumber, EdgeCaseSortType.OLD);
+
+		//then
+		assertThat(response.edgeCaseList()).hasSize(2);
+
+		// 정렬 순서 검증 (ID 1 -> ID 2)
+		Assertions.assertAll(
+			() -> assertThat(response.edgeCaseList().get(0).edgeCaseId()).isEqualTo(edgeCase1.getId().intValue()),
+			() -> assertThat(response.edgeCaseList().get(1).edgeCaseId()).isEqualTo(edgeCase2.getId().intValue())
+		);
+	}
+
+	@Test
+	@DisplayName("반례 리스트 조회 성공 (OLD) // 모든 리스트")
+	void getEdgeCaseListSuccess_Old_NoProblemNumber() {
+		// given
+		Integer problemNumber = null;
+		// setUp 순서 (전체): 1(오래됨) -> 2 -> 3(최신)
+		List<EdgeCase> edgeCaseList = Arrays.asList(edgeCase1, edgeCase2, edgeCase3);
+		when(edgeCaseRepository.findAllByOrderByCreatedAtAsc())
+			.thenReturn(edgeCaseList);
+
+		// when
+		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(problemNumber, EdgeCaseSortType.OLD);
+
+		// then
+		assertThat(response.edgeCaseList()).hasSize(3);
+
+		// 정렬 순서 검증 (ID 1 -> ID 2 -> ID 3)
+		Assertions.assertAll(
+			() -> assertThat(response.edgeCaseList().get(0).edgeCaseId()).isEqualTo(edgeCase1.getId().intValue()),
+			() -> assertThat(response.edgeCaseList().get(1).edgeCaseId()).isEqualTo(edgeCase2.getId().intValue()),
+			() -> assertThat(response.edgeCaseList().get(2).edgeCaseId()).isEqualTo(edgeCase3.getId().intValue())
+		);
 	}
 
 	@Test
@@ -261,7 +370,7 @@ class EdgeCaseServiceTest {
 	void addEdgeCase_success_1() {
 		//given
 		when(edgeCaseRepository.findById(2L)).thenReturn(Optional.of(edgeCase2));
-		when(edgeCaseLikeRepository.findByEdgeCaseAndUser(edgeCase2,user2)).thenReturn(Optional.of(edgeCaseLike2));
+		when(edgeCaseLikeRepository.findByEdgeCaseAndUser(edgeCase2, user2)).thenReturn(Optional.of(edgeCaseLike2));
 
 		//when
 		edgeCaseService.togleEdgeCaseLike(user2, 2L);
@@ -275,7 +384,7 @@ class EdgeCaseServiceTest {
 	void addEdgeCase_success_2() {
 		//given
 		when(edgeCaseRepository.findById(2L)).thenReturn(Optional.of(edgeCase2));
-		when(edgeCaseLikeRepository.findByEdgeCaseAndUser(edgeCase2,user2)).thenReturn(Optional.empty());
+		when(edgeCaseLikeRepository.findByEdgeCaseAndUser(edgeCase2, user2)).thenReturn(Optional.empty());
 
 		//when
 		edgeCaseService.togleEdgeCaseLike(user2, 2L);


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
[BE-50](https://linear.app/algo-hub/issue/BE-50/%EB%B0%98%EB%A1%80%EA%B2%8C%EC%8B%9C%ED%8C%90-%EA%B4%80%EB%A0%A8-%EC%9D%B4%EC%8A%88-%ED%95%B4%EA%B2%B0)

## 🚀 Description
<!-- 작업 내용 -->
- 반례 게시판의 주요 이슈를 해결하고, 사용자 편의를 위해 정렬 기능을 추가했습니다.

<img width="441" height="99" alt="image" src="https://github.com/user-attachments/assets/d75263df-2ebd-4f52-b07e-5b4379355588" />

</br>
</br>

- 최신순 정렬 버그 수정: EdgeCase 엔티티 생성 시 createdAt이 누락되어 최신순 정렬이 동작하지 않던 문제를 해결했습니다. (생성자에 LocalDateTime.now() 할당)

<img width="454" height="523" alt="image" src="https://github.com/user-attachments/assets/ceafc4a8-4e4d-4543-9101-ab30f2ac23dd" />

</br>
</br>

- 좋아요 카운트 버그 수정: 반례 좋아요 토글 시(togleEdgeCaseLike) EdgeCase 엔티티의 likeCount가 갱신되지 않던 버그를 수정했습니다.

<img width="453" height="370" alt="image" src="https://github.com/user-attachments/assets/6a7a2d88-71c4-48a8-9bd9-221889d4e7bf" />

</br>
</br>

- 정렬 기능 파라미터 추가: 반례 리스트 조회 API(GET /api/edge-case/list)에 sort 파라미터를 추가했습니다.

- `RECENT` (최신순, 기본값), `LIKE` (좋아요순), `OLD` (오래된순) 3가지 옵션으로 분기하도록 Enum 클래스를 추가했습니다!

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
- 이슈가 발생한 부분이 있어 클라측에서 요청한 급한 안건을 먼저 해결하게 되었습니다..! (원래 상혁님 테스크인데 본의 아니게 제가 처리하게 된 점 죄송합니다 ㅠㅠ)

- likeCount 관리를 위해 EdgeCase 엔티티에 컬럼을 두고, 토글 시마다 UPDATE 쿼리가 발생하도록 했습니다. 이 방식이 괜찮은지, 아니면 COUNT 쿼리를 사용하는 방식이 나을지 의견 주시면 감사하겠습니다.

## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->
### 테스트 코드 결과
<img width="764" height="515" alt="image" src="https://github.com/user-attachments/assets/912658a7-3238-4893-86f9-11814b53b424" />
