### PR TITLE
[Feat] 문제 수정 API 시, 시작 날짜 검증로직 삭제

### DIFF
--- a/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
@@ -115,7 +115,7 @@ public class ProblemService {
 		checkProblemValidation(problem);
 
 		if (request.startDate() != null) {
-			checkProblemStartDate(request, problem);
+			// checkProblemStartDate(request, problem);
 			problem.editProblemStartDate(request.startDate());
 		}
 		if (request.endDate() != null) {
@@ -142,22 +142,23 @@ public class ProblemService {
 				"문제 마감 날짜는 오늘 이전의 날짜로 수정할 수 없습니다.");
 	}
 
-	private void checkProblemStartDate(EditProblemRequest request, Problem problem) {
-		if (request.startDate().isBefore(LocalDate.now()))
-			throw new ProblemValidationException(HttpStatus.BAD_REQUEST.value(),
-				"문제 시작 날짜는 오늘 이전의 날짜로 수정할 수 없습니다.");
-		if (request.startDate().isAfter(problem.getEndDate()))
-			throw new ProblemValidationException(HttpStatus.BAD_REQUEST.value(),
-				"문제 시작 날짜는 마감 날짜 이후로 수정할 수 없습니다.");
-	}
+	// private void checkProblemStartDate(EditProblemRequest request, Problem problem) {
+	// 	if (request.startDate().isBefore(LocalDate.now()))
+	// 		throw new ProblemValidationException(HttpStatus.BAD_REQUEST.value(),
+	// 			"문제 시작 날짜는 오늘 이전의 날짜로 수정할 수 없습니다.");
+	// 	if (request.startDate().isAfter(problem.getEndDate()))
+	// 		throw new ProblemValidationException(HttpStatus.BAD_REQUEST.value(),
+	// 			"문제 시작 날짜는 마감 날짜 이후로 수정할 수 없습니다.");
+	// }
 
 	@Transactional(readOnly = true)
-	public Page<GetProblemResponse> getProblems(User user, Long groupId, ProblemListStatus status, Boolean unsolvedOnly, Pageable pageable) {
+	public Page<GetProblemResponse> getProblems(User user, Long groupId, ProblemListStatus status, Boolean unsolvedOnly,
+		Pageable pageable) {
 		Page<GetProblemResponse> response;
 		if (status == ProblemListStatus.IN_PROGRESS) {
-				if (unsolvedOnly == null) {
-					unsolvedOnly = false;
-				}
+			if (unsolvedOnly == null) {
+				unsolvedOnly = false;
+			}
 			response = getInProgressProblems(user, groupId, unsolvedOnly, pageable);
 		} else if (status == ProblemListStatus.EXPIRED) {
 			response = getExpiredProblems(user, groupId, pageable);

--- a/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
@@ -4,6 +4,7 @@ import static com.gamzabat.algohub.constants.ApiConstants.*;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -75,6 +76,10 @@ public class ProblemService {
 		int level = getProblemLevel(apiResult);
 		String title = getProblemTitle(apiResult);
 
+		if (Objects.nonNull(request.startDate())) {
+			checkProblemStartDate(request);
+		}
+
 		Problem problem = problemRepository.save(Problem.builder()
 			.studyGroup(group)
 			.link(request.link())
@@ -142,14 +147,14 @@ public class ProblemService {
 				"문제 마감 날짜는 오늘 이전의 날짜로 수정할 수 없습니다.");
 	}
 
-	// private void checkProblemStartDate(EditProblemRequest request, Problem problem) {
-	// 	if (request.startDate().isBefore(LocalDate.now()))
-	// 		throw new ProblemValidationException(HttpStatus.BAD_REQUEST.value(),
-	// 			"문제 시작 날짜는 오늘 이전의 날짜로 수정할 수 없습니다.");
-	// 	if (request.startDate().isAfter(problem.getEndDate()))
-	// 		throw new ProblemValidationException(HttpStatus.BAD_REQUEST.value(),
-	// 			"문제 시작 날짜는 마감 날짜 이후로 수정할 수 없습니다.");
-	// }
+	private void checkProblemStartDate(CreateProblemRequest request) {
+		if (request.startDate().isBefore(LocalDate.now()))
+			throw new ProblemValidationException(HttpStatus.BAD_REQUEST.value(),
+				"문제 시작 날짜는 오늘 이전의 날짜로 수정할 수 없습니다.");
+		if (request.startDate().isAfter(request.endDate()))
+			throw new ProblemValidationException(HttpStatus.BAD_REQUEST.value(),
+				"문제 시작 날짜는 마감 날짜 이후로 수정할 수 없습니다.");
+	}
 
 	@Transactional(readOnly = true)
 	public Page<GetProblemResponse> getProblems(User user, Long groupId, ProblemListStatus status, Boolean unsolvedOnly,

--- a/src/test/java/com/gamzabat/algohub/service/ProblemServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/ProblemServiceTest.java
@@ -176,7 +176,8 @@ class ProblemServiceTest {
 		assertThat(result.getLevel()).isEqualTo(1);
 		assertThat(result.getStartDate()).isEqualTo(LocalDate.now());
 		assertThat(result.getEndDate()).isEqualTo(LocalDate.now().plusDays(10));
-		verify(notificationService, times(1)).sendNotificationToMembers(any(), any(), any(), any(), any(), any(), any());
+		verify(notificationService, times(1)).sendNotificationToMembers(any(), any(), any(), any(), any(), any(),
+			any());
 	}
 
 	@Test
@@ -380,30 +381,6 @@ class ProblemServiceTest {
 			.isInstanceOf(StudyGroupValidationException.class)
 			.hasFieldOrPropertyWithValue("code", HttpStatus.FORBIDDEN.value())
 			.hasFieldOrPropertyWithValue("error", "문제 수정 권한이 없습니다. 방장, 부방장일 경우에만 수정이 가능합니다.");
-	}
-
-	@Test
-	@DisplayName("문제 정보 수정 실패 : 문제 시작 날짜를 오늘 이전의 날짜로 요청한 경우")
-	void editProblemFailed_6() {
-		// given
-		Problem problem = Problem.builder()
-			.studyGroup(group)
-			.link("link")
-			.startDate(LocalDate.now().plusDays(1))
-			.endDate(LocalDate.now().plusDays(10))
-			.build();
-		EditProblemRequest request = EditProblemRequest.builder()
-			.startDate(LocalDate.now().minusDays(3))
-			.endDate(LocalDate.now().plusDays(7))
-			.build();
-		when(problemRepository.findById(20L)).thenReturn(Optional.ofNullable(problem));
-		when(groupRepository.findById(10L)).thenReturn(Optional.ofNullable(group));
-		when(groupMemberRepository.findByUserAndStudyGroup(user, group)).thenReturn(Optional.ofNullable(groupMember1));
-		// when, then
-		assertThatThrownBy(() -> problemService.editProblem(user, 20L, request))
-			.isInstanceOf(ProblemValidationException.class)
-			.hasFieldOrPropertyWithValue("code", HttpStatus.BAD_REQUEST.value())
-			.hasFieldOrPropertyWithValue("error", "문제 시작 날짜는 오늘 이전의 날짜로 수정할 수 없습니다.");
 	}
 
 	@Test
@@ -824,7 +801,8 @@ class ProblemServiceTest {
 		// when
 		problemService.dailyProblemScheduler();
 		// then
-		verify(notificationService, times(20)).sendNotificationToMembers(any(), any(), any(), any(), any(), any(), any());
+		verify(notificationService, times(20)).sendNotificationToMembers(any(), any(), any(), any(), any(), any(),
+			any());
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
[BE-52](https://linear.app/algo-hub/issue/BE-52/문제-수정-api-시작날짜-검증-로직-삭제)

## 🚀 Description
<!-- 작업 내용 -->
문제를 수정할 때, 클라 측에서 시작날짜는 수정하지 못하고, 끝나는 날짜만 수정할 수 있게끔 기획되어 있으므로, 문제 수정 시, 시작날짜 검증이 필요없어졌습니다.

해당 로직을 삭제하도록 하겠습니다 🙂 

<img width="670" height="535" alt="image" src="https://github.com/user-attachments/assets/57fddc3e-b864-4a15-b468-c9fe9a8166d4" />


## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->
### 테스트 코드 결과