### PR TITLE
Refactor : 반례리스트 조회

### DIFF
--- a/src/main/java/com/gamzabat/algohub/common/annotation/AuthedUser.java
+++ b/src/main/java/com/gamzabat/algohub/common/annotation/AuthedUser.java
@@ -11,4 +11,5 @@ import io.swagger.v3.oas.annotations.Hidden;
 @Retention(RetentionPolicy.RUNTIME)
 @Hidden
 public @interface AuthedUser {
+	boolean required() default true;
 }

--- a/src/main/java/com/gamzabat/algohub/common/annotation/AuthedUserResolver.java
+++ b/src/main/java/com/gamzabat/algohub/common/annotation/AuthedUserResolver.java
@@ -29,11 +29,19 @@ public class AuthedUserResolver implements HandlerMethodArgumentResolver {
 	@Override
 	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
 		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+		AuthedUser authedUser = parameter.getParameterAnnotation(AuthedUser.class);
+		boolean required = (authedUser == null) || authedUser.required();
+
 		String jwt = webRequest.getHeader("Authorization");
-		if (jwt != null)
-			return userRepository.findByEmail(tokenProvider.getUserEmail(jwt))
-				.orElseThrow(() -> new UserValidationException("없는 사용자 입니다."));
-		else
-			throw new UserValidationException("로그인 되지 않았습니다.");
+
+		if (jwt == null || jwt.isBlank()) {
+			if (required) {
+				throw new UserValidationException("로그인되지 않았습니다.");
+			} else {
+				return null;
+			}
+		}
+		return userRepository.findByEmail(tokenProvider.getUserEmail(jwt))
+			.orElseThrow(() -> new UserValidationException("없는 사용자입니다."));
 	}
 }

--- a/src/main/java/com/gamzabat/algohub/common/annotation/AuthedUserResolver.java
+++ b/src/main/java/com/gamzabat/algohub/common/annotation/AuthedUserResolver.java
@@ -30,7 +30,7 @@ public class AuthedUserResolver implements HandlerMethodArgumentResolver {
 	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
 		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
 		AuthedUser authedUser = parameter.getParameterAnnotation(AuthedUser.class);
-		boolean required = (authedUser == null) || authedUser.required();
+		boolean required = authedUser.required();
 
 		String jwt = webRequest.getHeader("Authorization");
 

--- a/src/main/java/com/gamzabat/algohub/feature/edgecase/controller/EdgeCaseController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/edgecase/controller/EdgeCaseController.java
@@ -49,11 +49,11 @@ public class EdgeCaseController {
 	@GetMapping("/list")
 	@Operation(summary = "반례리스트 조회")
 	public ResponseEntity<GetEdgeCaseListResponse> getEdgeCaseList(
-		@AuthedUser() User user,
+		@AuthedUser(required = false) User user,
 		@RequestParam(required = false) Integer problemNumber,
 		@RequestParam(required = false, defaultValue = "RECENT") EdgeCaseSortType sort
 	) {
-		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(problemNumber, sort);
+		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(user, problemNumber, sort);
 
 		return ResponseEntity.ok().body(response);
 	}

--- a/src/main/java/com/gamzabat/algohub/feature/edgecase/controller/EdgeCaseController.java
+++ b/src/main/java/com/gamzabat/algohub/feature/edgecase/controller/EdgeCaseController.java
@@ -49,6 +49,7 @@ public class EdgeCaseController {
 	@GetMapping("/list")
 	@Operation(summary = "반례리스트 조회")
 	public ResponseEntity<GetEdgeCaseListResponse> getEdgeCaseList(
+		@AuthedUser() User user,
 		@RequestParam(required = false) Integer problemNumber,
 		@RequestParam(required = false, defaultValue = "RECENT") EdgeCaseSortType sort
 	) {

--- a/src/main/java/com/gamzabat/algohub/feature/edgecase/dto/GetEdgeCaseResponse.java
+++ b/src/main/java/com/gamzabat/algohub/feature/edgecase/dto/GetEdgeCaseResponse.java
@@ -10,5 +10,6 @@ public record GetEdgeCaseResponse(
 	String title,
 	String input,
 	String output,
-	Integer like) {
+	Integer like,
+	Boolean isLiked) {
 }

--- a/src/main/java/com/gamzabat/algohub/feature/edgecase/repository/EdgeCaseLikeRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/edgecase/repository/EdgeCaseLikeRepository.java
@@ -12,4 +12,5 @@ import com.gamzabat.algohub.feature.user.domain.User;
 public interface EdgeCaseLikeRepository extends JpaRepository<EdgeCaseLike, Long> {
 	Optional<EdgeCaseLike> findByEdgeCaseAndUser(EdgeCase edgeCase, User user);
 	List<EdgeCaseLike> findAllByEdgeCase(EdgeCase edgeCase);
+	List<EdgeCaseLike> findByUserAndEdgeCaseIn(User user, List<EdgeCase> edgeCases);
 }

--- a/src/main/java/com/gamzabat/algohub/feature/edgecase/service/EdgeCaseService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/edgecase/service/EdgeCaseService.java
@@ -2,7 +2,9 @@ package com.gamzabat.algohub.feature.edgecase.service;
 
 import static com.gamzabat.algohub.constants.ApiConstants.*;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.http.HttpStatus;
@@ -55,8 +57,10 @@ public class EdgeCaseService {
 		edgeCaseRepository.save(edgeCase);
 	}
 
-	public GetEdgeCaseListResponse getEdgeCaseList(Integer problemNumber, EdgeCaseSortType sort) {
+	public GetEdgeCaseListResponse getEdgeCaseList(User user, Integer problemNumber, EdgeCaseSortType sort) {
 		List<EdgeCase> edgeCaseList;
+		Set<Long> likedEdgeCaseIds = Collections.emptySet();
+
 		if (problemNumber == null) {
 			switch (sort) {
 				case LIKE:
@@ -85,6 +89,17 @@ public class EdgeCaseService {
 			}
 		}
 
+		if (user != null && !edgeCaseList.isEmpty()) {
+			List<EdgeCaseLike> myLikes =
+				edgeCaseLikeRepository.findByUserAndEdgeCaseIn(user, edgeCaseList);
+
+			likedEdgeCaseIds = myLikes.stream()
+				.map(like -> like.getEdgeCase().getId())
+				.collect(Collectors.toSet());
+		}
+
+		final Set<Long> likedIds = likedEdgeCaseIds;
+
 		List<GetEdgeCaseResponse> responseList = edgeCaseList.stream()
 			.map(edgeCase -> new GetEdgeCaseResponse(
 				edgeCase.getId().intValue(),
@@ -93,7 +108,8 @@ public class EdgeCaseService {
 				edgeCase.getTitle(),
 				edgeCase.getInput(),
 				edgeCase.getOutput(),
-				edgeCase.getLikeCount()
+				edgeCase.getLikeCount(),
+				likedIds.contains(edgeCase.getId())
 			))
 			.collect(Collectors.toList());
 

--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/repository/JoinRequestRepository.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/repository/JoinRequestRepository.java
@@ -3,6 +3,8 @@ package com.gamzabat.algohub.feature.group.studygroup.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.gamzabat.algohub.feature.group.studygroup.domain.JoinRequest;
 
@@ -10,5 +12,13 @@ public interface JoinRequestRepository extends JpaRepository<JoinRequest, Long> 
 
 	boolean existsByGroup_IdAndRequester_Id(Long groupId, Long userId);
 
-	List<JoinRequest> findAllByGroup_Id(Long groupId);
+	@Query("""
+		select jr
+		from JoinRequest jr
+		join fetch jr.requester u
+		join fetch jr.group g
+		where g.id = :groupId
+		""")
+	List<JoinRequest> findAllByGroupIdWithFetch(@Param("groupId") Long groupId);
+
 }

--- a/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/JoinRequestService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/group/studygroup/service/JoinRequestService.java
@@ -2,7 +2,6 @@ package com.gamzabat.algohub.feature.group.studygroup.service;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -59,12 +58,15 @@ public class JoinRequestService {
 	@Transactional(readOnly = true)
 	public List<JoinRequest> getAllJoinRequests(User user, Long groupId) {
 		StudyGroup studyGroup = studyGroupRepository.findById(groupId)
-			.orElseThrow(() -> new StudyGroupValidationException(HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다."));
-		Optional<GroupMember> groupMember = groupMemberRepository.findByUserAndStudyGroup(user, studyGroup);
-		if (groupMember.isPresent() && RoleOfGroupMember.isParticipant(groupMember.get()) || groupMember.isEmpty()) {
+			.orElseThrow(() -> new StudyGroupValidationException(
+				HttpStatus.NOT_FOUND.value(), "존재하지 않는 그룹 입니다."));
+		final boolean noAuthority = groupMemberRepository.findByUserAndStudyGroup(user, studyGroup)
+			.map(RoleOfGroupMember::isParticipant)
+			.orElse(true);
+		if (noAuthority) {
 			throw new JoinRequestException("요청 목록을 조회할 권한이 없습니다.");
 		}
-		return joinRequestRepository.findAllByGroup_Id(groupId);
+		return joinRequestRepository.findAllByGroupIdWithFetch(groupId);
 	}
 
 	@Transactional

--- a/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
+++ b/src/main/java/com/gamzabat/algohub/feature/problem/service/ProblemService.java
@@ -4,6 +4,7 @@ import static com.gamzabat.algohub.constants.ApiConstants.*;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -75,6 +76,10 @@ public class ProblemService {
 		int level = getProblemLevel(apiResult);
 		String title = getProblemTitle(apiResult);
 
+		if (Objects.nonNull(request.startDate())) {
+			checkProblemStartDate(request);
+		}
+
 		Problem problem = problemRepository.save(Problem.builder()
 			.studyGroup(group)
 			.link(request.link())
@@ -115,7 +120,7 @@ public class ProblemService {
 		checkProblemValidation(problem);
 
 		if (request.startDate() != null) {
-			checkProblemStartDate(request, problem);
+			// checkProblemStartDate(request, problem);
 			problem.editProblemStartDate(request.startDate());
 		}
 		if (request.endDate() != null) {
@@ -142,22 +147,23 @@ public class ProblemService {
 				"문제 마감 날짜는 오늘 이전의 날짜로 수정할 수 없습니다.");
 	}
 
-	private void checkProblemStartDate(EditProblemRequest request, Problem problem) {
+	private void checkProblemStartDate(CreateProblemRequest request) {
 		if (request.startDate().isBefore(LocalDate.now()))
 			throw new ProblemValidationException(HttpStatus.BAD_REQUEST.value(),
 				"문제 시작 날짜는 오늘 이전의 날짜로 수정할 수 없습니다.");
-		if (request.startDate().isAfter(problem.getEndDate()))
+		if (request.startDate().isAfter(request.endDate()))
 			throw new ProblemValidationException(HttpStatus.BAD_REQUEST.value(),
 				"문제 시작 날짜는 마감 날짜 이후로 수정할 수 없습니다.");
 	}
 
 	@Transactional(readOnly = true)
-	public Page<GetProblemResponse> getProblems(User user, Long groupId, ProblemListStatus status, Boolean unsolvedOnly, Pageable pageable) {
+	public Page<GetProblemResponse> getProblems(User user, Long groupId, ProblemListStatus status, Boolean unsolvedOnly,
+		Pageable pageable) {
 		Page<GetProblemResponse> response;
 		if (status == ProblemListStatus.IN_PROGRESS) {
-				if (unsolvedOnly == null) {
-					unsolvedOnly = false;
-				}
+			if (unsolvedOnly == null) {
+				unsolvedOnly = false;
+			}
 			response = getInProgressProblems(user, groupId, unsolvedOnly, pageable);
 		} else if (status == ProblemListStatus.EXPIRED) {
 			response = getExpiredProblems(user, groupId, pageable);

--- a/src/test/java/com/gamzabat/algohub/service/EdgeCaseServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/EdgeCaseServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.*;
 import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -175,7 +176,7 @@ class EdgeCaseServiceTest {
 			.thenReturn(edgeCaseList);
 
 		//when
-		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(problemNumber, EdgeCaseSortType.RECENT);
+		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(null,problemNumber, EdgeCaseSortType.RECENT);
 
 		//then
 		assertEquals(2, response.edgeCaseList().size());
@@ -205,7 +206,7 @@ class EdgeCaseServiceTest {
 			.thenReturn(edgeCaseList);
 
 		// when
-		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(problemNumber, EdgeCaseSortType.RECENT);
+		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(null, problemNumber, EdgeCaseSortType.RECENT);
 
 		// then
 		assertEquals(3, response.edgeCaseList().size());
@@ -242,7 +243,7 @@ class EdgeCaseServiceTest {
 			.thenReturn(edgeCaseList);
 
 		//when
-		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(problemNumber, EdgeCaseSortType.LIKE);
+		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(null, problemNumber, EdgeCaseSortType.LIKE);
 
 		//then
 		assertThat(response.edgeCaseList()).hasSize(2);
@@ -265,7 +266,7 @@ class EdgeCaseServiceTest {
 			.thenReturn(edgeCaseList);
 
 		// when
-		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(problemNumber, EdgeCaseSortType.LIKE);
+		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(null,problemNumber, EdgeCaseSortType.LIKE);
 
 		// then
 		assertThat(response.edgeCaseList()).hasSize(3);
@@ -289,7 +290,7 @@ class EdgeCaseServiceTest {
 			.thenReturn(edgeCaseList);
 
 		//when
-		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(problemNumber, EdgeCaseSortType.OLD);
+		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(null, problemNumber, EdgeCaseSortType.OLD);
 
 		//then
 		assertThat(response.edgeCaseList()).hasSize(2);
@@ -312,7 +313,7 @@ class EdgeCaseServiceTest {
 			.thenReturn(edgeCaseList);
 
 		// when
-		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(problemNumber, EdgeCaseSortType.OLD);
+		GetEdgeCaseListResponse response = edgeCaseService.getEdgeCaseList(null, problemNumber, EdgeCaseSortType.OLD);
 
 		// then
 		assertThat(response.edgeCaseList()).hasSize(3);
@@ -323,6 +324,39 @@ class EdgeCaseServiceTest {
 			() -> assertThat(response.edgeCaseList().get(1).edgeCaseId()).isEqualTo(edgeCase2.getId().intValue()),
 			() -> assertThat(response.edgeCaseList().get(2).edgeCaseId()).isEqualTo(edgeCase3.getId().intValue())
 		);
+	}
+
+	@Test
+	@DisplayName("반례 리스트 조회 성공 // user가 있고 edgeCaseList가 비어있지 않은 경우")
+	void getEdgeCaseListSuccess_whenUserExistsAndListNotEmpty() {
+		// given
+		List<EdgeCase> edgeCaseList = List.of(edgeCase1, edgeCase2);
+		when(edgeCaseRepository.findAllByOrderByCreatedAtDesc())
+			.thenReturn(edgeCaseList);
+		when(edgeCaseLikeRepository.findByUserAndEdgeCaseIn(user, edgeCaseList))
+			.thenReturn(Collections.emptyList());
+
+		// when
+		edgeCaseService.getEdgeCaseList(user, null, EdgeCaseSortType.RECENT);
+
+		// then
+		verify(edgeCaseLikeRepository, times(1))
+			.findByUserAndEdgeCaseIn(user, edgeCaseList);
+	}
+
+	@Test
+	@DisplayName("반례 리스트 조회 성공 // user가 있고 edgeCaseList가 비어있는 경우")
+	void getEdgeCaseListSuccess_whenUserExistsAndListEmpty() {
+		// given
+		when(edgeCaseRepository.findAllByOrderByCreatedAtDesc())
+			.thenReturn(Collections.emptyList());
+
+		// when
+		edgeCaseService.getEdgeCaseList(user, null, EdgeCaseSortType.RECENT);
+
+		// then
+		verify(edgeCaseLikeRepository, never())
+			.findByUserAndEdgeCaseIn(any(), any());
 	}
 
 	@Test

--- a/src/test/java/com/gamzabat/algohub/service/JoinRequestServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/JoinRequestServiceTest.java
@@ -53,7 +53,7 @@ class JoinRequestServiceTest {
 	private NotificationSettingRepository notificationSettingRepository;
 	@Mock
 	private RankingRepository rankingRepository;
-	
+
 	private User user, owner, user2, user3, requester;
 	private StudyGroup group;
 	private Problem problem1, problem2;
@@ -200,7 +200,7 @@ class JoinRequestServiceTest {
 		// given
 		when(studyGroupRepository.findById(10L)).thenReturn(Optional.of(group));
 		when(groupMemberRepository.findByUserAndStudyGroup(owner, group)).thenReturn(Optional.of(ownerGroupmember));
-		when(joinRequestRepository.findAllByGroup_Id(10L)).thenReturn(List.of(joinRequest));
+		when(joinRequestRepository.findAllByGroupIdWithFetch(10L)).thenReturn(List.of(joinRequest));
 
 		// when
 		List<JoinRequest> requests = joinRequestService.getAllJoinRequests(owner, 10L);

--- a/src/test/java/com/gamzabat/algohub/service/ProblemServiceTest.java
+++ b/src/test/java/com/gamzabat/algohub/service/ProblemServiceTest.java
@@ -176,7 +176,8 @@ class ProblemServiceTest {
 		assertThat(result.getLevel()).isEqualTo(1);
 		assertThat(result.getStartDate()).isEqualTo(LocalDate.now());
 		assertThat(result.getEndDate()).isEqualTo(LocalDate.now().plusDays(10));
-		verify(notificationService, times(1)).sendNotificationToMembers(any(), any(), any(), any(), any(), any(), any());
+		verify(notificationService, times(1)).sendNotificationToMembers(any(), any(), any(), any(), any(), any(),
+			any());
 	}
 
 	@Test
@@ -380,30 +381,6 @@ class ProblemServiceTest {
 			.isInstanceOf(StudyGroupValidationException.class)
 			.hasFieldOrPropertyWithValue("code", HttpStatus.FORBIDDEN.value())
 			.hasFieldOrPropertyWithValue("error", "문제 수정 권한이 없습니다. 방장, 부방장일 경우에만 수정이 가능합니다.");
-	}
-
-	@Test
-	@DisplayName("문제 정보 수정 실패 : 문제 시작 날짜를 오늘 이전의 날짜로 요청한 경우")
-	void editProblemFailed_6() {
-		// given
-		Problem problem = Problem.builder()
-			.studyGroup(group)
-			.link("link")
-			.startDate(LocalDate.now().plusDays(1))
-			.endDate(LocalDate.now().plusDays(10))
-			.build();
-		EditProblemRequest request = EditProblemRequest.builder()
-			.startDate(LocalDate.now().minusDays(3))
-			.endDate(LocalDate.now().plusDays(7))
-			.build();
-		when(problemRepository.findById(20L)).thenReturn(Optional.ofNullable(problem));
-		when(groupRepository.findById(10L)).thenReturn(Optional.ofNullable(group));
-		when(groupMemberRepository.findByUserAndStudyGroup(user, group)).thenReturn(Optional.ofNullable(groupMember1));
-		// when, then
-		assertThatThrownBy(() -> problemService.editProblem(user, 20L, request))
-			.isInstanceOf(ProblemValidationException.class)
-			.hasFieldOrPropertyWithValue("code", HttpStatus.BAD_REQUEST.value())
-			.hasFieldOrPropertyWithValue("error", "문제 시작 날짜는 오늘 이전의 날짜로 수정할 수 없습니다.");
 	}
 
 	@Test
@@ -824,7 +801,8 @@ class ProblemServiceTest {
 		// when
 		problemService.dailyProblemScheduler();
 		// then
-		verify(notificationService, times(20)).sendNotificationToMembers(any(), any(), any(), any(), any(), any(), any());
+		verify(notificationService, times(20)).sendNotificationToMembers(any(), any(), any(), any(), any(), any(),
+			any());
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 Related Issue
<!-- issue 링크 -->
be-48
## 🚀 Description
<!-- 작업 내용 -->
- 반례리스트 조회할 때 자기 자신이 좋아요를 눌렀는지에 대한 여부(isLiked 필드) 추가했습니다.
- 비회원의 경우 isLiked 필드는 항상 false여야하고, 회원인 경우 자신이 좋아요를 누른 부분에 대해서만 isLiked 가 true이도록 했습니다. 
- 비회원인 경우와 회원인 경우를 모두 처리해야해서, AuthUser 어노테이션 부분을 수정했습니다. 

## 📢 Review Point
<!-- 코드리뷰 할 때 더 집중해서? 봐주면 좋을 포인트들 -->
- 자신이 좋아요를 누른 반례게시물의 ID를 모아와 집합으로 만들고 이를 edgeCaseList안의 반례게시물들의 ID와 비교하며 자신이 좋아요를 누른 부분을 찾도록 했는데, 괜찮을까요.?.?
- 다른 부분도 이상한 거 있으면 알려주세요...!
## 📚Etc (선택)
<!-- 작업 도중 생긴 특이사항, 또는 고려할 것들(?) -->